### PR TITLE
Compile fixes

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,9 +1,9 @@
 cd loader
-g++ loader.cpp -o loader
+g++ loader.cpp md5.c -Imd5 -o loader
 MOVE loader.exe ../build
 
 set SOURCES=dllMain.c main.c hook.c globals.c Win95\Window.c Main\Main.c Main\swrMain.c Primitives\rdVector.c General\stdMath.c Primitives\rdMatrix.c
-set FLAGS=-s -shared
+set FLAGS=-s -shared -fpermissive
 set INCLUDES=-I. -IGeneral -IMain -IPrimitives -ISwr -IUnknown -IWin95
 set LIBS=-lgdi32 -lcomctl32
 

--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -5,6 +5,30 @@
 
 // g++ loader.cpp -o loader
 
+std::string GetLastErrorAsString()
+{
+    //Get the error message ID, if any.
+    DWORD errorMessageID = ::GetLastError();
+    if(errorMessageID == 0) {
+        return std::string(); //No error message has been recorded
+    }
+
+    LPSTR messageBuffer = nullptr;
+
+    //Ask Win32 to give us the string version of that message ID.
+    //The parameters we pass in, tell Win32 to create the buffer that holds the message for us (because we don't yet know how long the message string will be).
+    size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                                 NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+    //Copy the error message into a std::string.
+    std::string message(messageBuffer, size);
+
+    //Free the Win32's string's buffer.
+    LocalFree(messageBuffer);
+
+    return message;
+}
+
 int main(int argc, char** argv)
 {
     LPCSTR lpcstrDll = "swr_reimpl.dll";
@@ -17,23 +41,39 @@ int main(int argc, char** argv)
     memset(&startupInfo, 0, sizeof(startupInfo));
     startupInfo.cb = sizeof(STARTUPINFO);
 
-    int matching = true;
+    int matching_gog = true;
+    int matching_steam = true;
     // Check md5 in order to work only on supported versions
     FILE* f = fopen(targetPath, "rb");
     uint8_t GOG_VERSION[16] = { 0xe1, 0xfc, 0xf5, 0x0c, 0x8d, 0xe2, 0xdb, 0xef, 0x70, 0xe6, 0xad, 0x8e, 0x09, 0x37, 0x13, 0x22 };
     uint8_t result[16];
     md5File(f, result);
+    // check md5 sum of the
     for (size_t i = 0; i < 16; i++)
     {
         if (result[i] != GOG_VERSION[i])
         {
-            matching = false;
+            matching_gog = false;
             break;
         }
     }
-    if (!matching)
+    if (!matching_gog)
     {
-        printf("Your version not supported yet for this loader. Only GOG Version is supported at the moment.\n");
+        // try the steam version
+        uint8_t STEAM_VERSION[16] = { 0xad, 0xbe, 0xf6, 0xbc, 0x97, 0x47, 0xc0, 0x87, 0x48, 0x5f, 0xce, 0x8a, 0x48, 0xf5, 0xec, 0xa4 };
+        for (size_t i = 0; i < 16; i++)
+        {
+            if (result[i] != STEAM_VERSION[i])
+            {
+                matching_steam = false;
+                break;
+            }
+        }
+    }
+    // check md5 sum of the
+    if (!(matching_gog || matching_steam))
+    {
+        printf("Your version not supported yet for this loader. Only GOG and Steams Versions are supported at the moment.\n");
         printf("If you want your version to be supported in the future, please file an issue with your version and the attached md5 sum provided here:\n");
         printf("md5: ");
         for (size_t i = 0; i < 16; i++)
@@ -44,7 +84,14 @@ int main(int argc, char** argv)
 
         return 1;
     }
-    printf("Versions md5 are matching\n");
+    if (matching_gog)
+    {
+        printf("GOG version detected, md5 are matching\n");
+    }
+    if (matching_steam)
+    {
+        printf("Steam version detected, md5 are matching\n");
+    }
 
     // https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation
     char cmdArgs[8191] = { 0 };
@@ -59,12 +106,16 @@ int main(int argc, char** argv)
     if (!CreateProcessA(targetPath, cmdArgs, NULL, NULL, FALSE, CREATE_SUSPENDED, NULL, NULL, &startupInfo, &processInformation))
     {
         std::cerr << "Target process has failed to start\n";
+        auto error = GetLastErrorAsString();
+        std::cerr << error << std::endl;
         return FALSE;
     }
     lpLoadLibraryA = (LPVOID)GetProcAddress(GetModuleHandleA("kernel32.dll"), "LoadLibraryA");
     if (!lpLoadLibraryA)
     {
         std::cerr << "GetProcAddress failed\n";
+        auto error = GetLastErrorAsString();
+        std::cerr << error << std::endl;
 
         CloseHandle(processInformation.hProcess);
         return FALSE;
@@ -75,12 +126,16 @@ int main(int argc, char** argv)
     if (!lpRemoteString)
     {
         std::cerr << "VirtualAllocEx failed\n";
+        auto error = GetLastErrorAsString();
+        std::cerr << error << std::endl;
         CloseHandle(processInformation.hProcess);
         return FALSE;
     }
     if (!WriteProcessMemory(processInformation.hProcess, lpRemoteString, lpcstrDll, nLength, NULL))
     {
         std::cerr << "WriteProcessMemory failed\n";
+        auto error = GetLastErrorAsString();
+        std::cerr << error << std::endl;
 
         VirtualFreeEx(processInformation.hProcess, lpRemoteString, 0, MEM_RELEASE);
         CloseHandle(processInformation.hProcess);
@@ -90,6 +145,8 @@ int main(int argc, char** argv)
     if (!hThread_injection)
     {
         std::cerr << "CreateRemoteThread failed\n";
+        auto error = GetLastErrorAsString();
+        std::cerr << error << std::endl;
     }
     else
     {

--- a/src/Primitives/rdMatrix.c
+++ b/src/Primitives/rdMatrix.c
@@ -239,7 +239,7 @@ void rdMatrix_ExtractTransform(rdMatrix44* mat, swrTranslationRotation* tr_rot)
         {
             fVar4 = 0.0;
         }
-        tr_rot->yaw = fVar4;
+        tr_rot->yaw_roll_pitch.x = fVar4;
     }
     else
     {
@@ -248,8 +248,8 @@ void rdMatrix_ExtractTransform(rdMatrix44* mat, swrTranslationRotation* tr_rot)
         {
             fVar4 = -fVar4;
         }
-        tr_rot->pitch = fVar4;
-        tr_rot->yaw = 0.0;
+        tr_rot->yaw_roll_pitch.z = fVar4;
+        tr_rot->yaw_roll_pitch.x = 0.0;
     }
     if (0.001 <= fVar3)
     {
@@ -257,20 +257,20 @@ void rdMatrix_ExtractTransform(rdMatrix44* mat, swrTranslationRotation* tr_rot)
         if (fVar5 < 1.0)
         {
             fVar5 = stdMath_ArcCos(fVar5);
-            tr_rot->roll = fVar5;
+            tr_rot->yaw_roll_pitch.y = fVar5;
         }
         else
         {
-            tr_rot->roll = 0.0;
+            tr_rot->yaw_roll_pitch.y = 0.0;
         }
     }
     else
     {
-        tr_rot->roll = 90.0;
+        tr_rot->yaw_roll_pitch.y = 90.0;
     }
     if (fVar2 < 0.0)
     {
-        tr_rot->roll = -tr_rot->roll;
+        tr_rot->yaw_roll_pitch.y = -tr_rot->yaw_roll_pitch.y;
     }
     local_c.x = -local_24.y;
     local_c.y = local_24.x;
@@ -284,20 +284,20 @@ void rdMatrix_ExtractTransform(rdMatrix44* mat, swrTranslationRotation* tr_rot)
             if (-1.0 < fVar5)
             {
                 fVar5 = stdMath_ArcCos(fVar5);
-                tr_rot->pitch = fVar5;
+                tr_rot->yaw_roll_pitch.z = fVar5;
             }
             else
             {
-                tr_rot->pitch = 180.0;
+                tr_rot->yaw_roll_pitch.z = 180.0;
             }
         }
         else
         {
-            tr_rot->pitch = 0.0;
+            tr_rot->yaw_roll_pitch.z = 0.0;
         }
         if (local_10 < 0.0)
         {
-            tr_rot->pitch = -tr_rot->pitch;
+            tr_rot->yaw_roll_pitch.z = -tr_rot->yaw_roll_pitch.z;
             return;
         }
     }
@@ -389,7 +389,8 @@ void rdMatrix_SetTransform44(rdMatrix44* mat, swrTranslationRotation* v)
     (mat->vB).w = 0.0;
     (mat->vC).w = 0.0;
     (mat->vD).w = 1.0;
-    rdMatrix_BuildRotation44(mat, v->yaw, v->roll, v->pitch);
+    rdMatrix_BuildRotation44(mat, v->yaw_roll_pitch.x, v->yaw_roll_pitch.y,
+            v->yaw_roll_pitch.z);
     return;
 }
 
@@ -701,7 +702,7 @@ void rdMatrix_BuildRotate34(rdMatrix34* out, rdVector3* rot)
 // 0x00492930
 void rdMatrix_BuildTranslate34(rdMatrix34* out, rdVector3* tV)
 {
-    _memcpy(out, &rdMatrix34_identity, sizeof(rdMatrix34));
+    memcpy(out, &rdMatrix34_identity, sizeof(rdMatrix34));
     rdVector_Copy3(&out->scale, tV);
 }
 
@@ -725,7 +726,7 @@ void rdMatrix_ExtractAngles34(rdMatrix34* in, rdVector3* out)
     fVar1 = (in->rvec).z;
     fVar3 = (in->lvec).z;
     fVar8 = fVar2 * fVar2 + fVar9 * fVar9;
-    fVar6 = SQRT(fVar8);
+    fVar6 = stdMath_Sqrt(fVar8);
     if (0.001 <= fVar6)
     {
         fVar7 = stdMath_ArcSin3(fVar2 / fVar6);
@@ -771,7 +772,7 @@ void rdMatrix_ExtractAngles34(rdMatrix34* in, rdVector3* out)
     fVar2 = -fVar2;
     if (0.001 <= fVar6)
     {
-        fVar9 = (fVar2 * fVar4 + fVar5 * fVar9) / SQRT(fVar2 * fVar2 + fVar9 * fVar9);
+        fVar9 = (fVar2 * fVar4 + fVar5 * fVar9) / stdMath_Sqrt(fVar2 * fVar2 + fVar9 * fVar9);
         if (fVar9 < 1.0)
         {
             if (-1.0 < fVar9)
@@ -816,7 +817,7 @@ void rdMatrix_Multiply34(rdMatrix34* out, rdMatrix34* mat1, rdMatrix34* mat2)
 void rdMatrix_PreMultiply34(rdMatrix34* mat1, rdMatrix34* mat2)
 {
     rdMatrix34 tmp;
-    _memcpy(&tmp, mat1, sizeof(tmp));
+    memcpy(&tmp, mat1, sizeof(tmp));
     (mat1->rvec).x = tmp.rvec.x * (mat2->rvec).x + (mat2->rvec).z * tmp.uvec.x + (mat2->rvec).y * tmp.lvec.x;
     (mat1->rvec).y = tmp.rvec.y * (mat2->rvec).x + (mat2->rvec).z * tmp.uvec.y + (mat2->rvec).y * tmp.lvec.y;
     (mat1->rvec).z = tmp.rvec.z * (mat2->rvec).x + (mat2->rvec).z * tmp.uvec.z + (mat2->rvec).y * tmp.lvec.z;
@@ -835,7 +836,7 @@ void rdMatrix_PreMultiply34(rdMatrix34* mat1, rdMatrix34* mat2)
 void rdMatrix_PostMultiply34(rdMatrix34* mat1, rdMatrix34* mat2)
 {
     rdMatrix34 tmp;
-    _memcpy(&tmp, mat1, sizeof(tmp));
+    memcpy(&tmp, mat1, sizeof(tmp));
     (mat1->rvec).x = tmp.rvec.x * (mat2->rvec).x + (mat2->lvec).x * tmp.rvec.y + (mat2->uvec).x * tmp.rvec.z;
     (mat1->rvec).y = (mat2->lvec).y * tmp.rvec.y + (mat2->uvec).y * tmp.rvec.z + (mat2->rvec).y * tmp.rvec.x;
     (mat1->rvec).z = (mat2->rvec).z * tmp.rvec.x + (mat2->uvec).z * tmp.rvec.z + (mat2->lvec).z * tmp.rvec.y;
@@ -854,7 +855,7 @@ void rdMatrix_PostMultiply34(rdMatrix34* mat1, rdMatrix34* mat2)
 void rdMatrix_PreRotate34(rdMatrix34* out, rdVector3* rot)
 {
     rdMatrix34 tmp;
-    rdMatrix_BuildRotate34(out, &tmp);
+    //rdMatrix_BuildRotate34(out, &tmp);
     rdMatrix_PreMultiply34(out, &tmp);
 }
 

--- a/src/Win95/Window.c
+++ b/src/Win95/Window.c
@@ -54,6 +54,8 @@ GUID* Window_GetGUID(void)
     return &Window_GUID;
 }
 
+static int Window_border_width = 0;
+static int Window_border_height = 0;
 // 0x0049cd40
 int Window_Main(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine, int nCmdShow, const char* window_name)
 {
@@ -68,7 +70,14 @@ int Window_Main(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine, int
     Window_CreateMainWindow(hInstance, nCmdShow, window_name, 0, NULL);
     Window_SetHWND(g_hWnd);
     Window_SetHINSTANCE(hInstance);
-    Window_SetGUID(Window_UUID);
+    GUID win_guid = {
+        Window_UUID[0],
+        Window_UUID[1],
+        Window_UUID[2],
+        Window_UUID[3],
+    };
+
+    Window_SetGUID(&win_guid);
     InitCommonControls();
     iVar1 = GetSystemMetrics(0x20);
     Window_border_width = iVar1 << 1;

--- a/src/globals.c
+++ b/src/globals.c
@@ -105,7 +105,7 @@ float  swrSprite_unk_x  = 16.0;
 // Line 48: swrSprite_unk_y 0x004b91c0 float = 155.0
 float  swrSprite_unk_y  = 155.0;
 
-// Line 50: eventManagerMain 0x004bfec0 extern swrEventManager[][9]; 
+// Line 50: eventManagerMain 0x004bfec0 extern swrEventManager[][9];
 extern swrEventManager eventManagerMain[][9];  ;
 
 // Line 51: swrObjHang_unused_state 0x004bfec8 swrObjHang_STATE = -1
@@ -118,7 +118,7 @@ int  swrObjHang_unused_unk  = -1;
 swrObjHang_STATE  swrObjHang_state2  = -1;
 
 // Line 56: time_ms_unk 0x004c00a8 float;
-float; time_ms_unk ;
+float time_ms_unk ;
 
 // Line 58: rdVector_negZ 0x004c2598 rdVector3 = {0.0, 0.0, -1.0}
 rdVector3  rdVector_negZ  = {0.0, 0.0, -1.0};
@@ -237,7 +237,7 @@ int directDraw_BltFillColor ;
 // Line 109: d3d_FogEnabled 0x004c98b0 int = 1
 int  d3d_FogEnabled  = 1;
 
-// Line 110: d3d_CurrentScene 0x004c98b4 int = 1 
+// Line 110: d3d_CurrentScene 0x004c98b4 int = 1
 int  d3d_CurrentScene  = 1 ;
 
 // Line 112: stdMath_SinTable 0x004c98e8 float[4096]
@@ -372,7 +372,7 @@ int Main_settings_RegDevMode ;
 // Line 185: Main_settings_RegUseFett 0x0050b56c int
 int Main_settings_RegUseFett ;
 
-// Line 187: Main_hWnd 0x0050b59c HWND 
+// Line 187: Main_hWnd 0x0050b59c HWND
 HWND  Main_hWnd ;
 
 // Line 189: Main_settings_menu_only 0x0050b5b0 int
@@ -408,10 +408,10 @@ char swrSprite_unk2_a ;
 // Line 201: swrRace_DebugLevel 0x0050c040 int
 int swrRace_DebugLevel ;
 
-// Line 202: swrRace_DebugMenu 0x0050c044 int 
+// Line 202: swrRace_DebugMenu 0x0050c044 int
 int  swrRace_DebugMenu ;
 
-// Line 203: swrRace_DebugFlag 0x0050c048 char 
+// Line 203: swrRace_DebugFlag 0x0050c048 char
 char  swrRace_DebugFlag ;
 
 // Line 205: swrLoader_sprite_file 0x0050c08c FILE*
@@ -480,10 +480,10 @@ swrUI_Unk3* swrUI_unk3 ;
 // Line 238: rdVector_unk5 0x0050c6e8 rdVector3
 rdVector3 rdVector_unk5 ;
 
-// Line 240: swrTextEntries1Count 0x0050c750 int 
+// Line 240: swrTextEntries1Count 0x0050c750 int
 int  swrTextEntries1Count ;
 
-// Line 242: swrTextEntries2Count 0x0050c758 int 
+// Line 242: swrTextEntries2Count 0x0050c758 int
 int  swrTextEntries2Count ;
 
 // Line 244: rdMatrixStack34_size 0x0050c6f4 int
@@ -537,13 +537,13 @@ int DirectInput_initialized ;
 // Line 273: iDirectInputA_ptr 0x0050feb8 LPDIRECTINPUTA
 LPDIRECTINPUTA iDirectInputA_ptr ;
 
-// Line 274: DirectInputNbKeyboard 0x00febc int 
+// Line 274: DirectInputNbKeyboard 0x00febc int
 int  DirectInputNbKeyboard ;
 
-// Line 276: DirectInputNbMouses 0x0050fec0 int 
+// Line 276: DirectInputNbMouses 0x0050fec0 int
 int  DirectInputNbMouses ;
 
-// Line 278: DirectInputNbJoysticks 0x0050fec8 int 
+// Line 278: DirectInputNbJoysticks 0x0050fec8 int
 int  DirectInputNbJoysticks ;
 
 // Line 279: DirectInputTimeMs 0x0050fecc int
@@ -637,7 +637,7 @@ D3DDEVICEDESC d3dDeviceDesc ;
 int swrNb3DDevices ;
 
 // Line 326: swr3DTextureFormats 0x0052d570 swr3DTextureFormat[8]
-swr3DTextureFormat swr3DTextureFormats[8] ;
+//swr3DTextureFormat swr3DTextureFormats[8] ;
 
 // Line 328: swr3DDevices 0x0052d870 swr3DDevice[4]
 swr3DDevice swr3DDevices[4] ;
@@ -675,7 +675,7 @@ LPDIRECT3DDEVICE3 iDirect3DDevice3_ptr ;
 // Line 342: iDirect3DViewport_ptr 0x0052e648 IDirect3DViewport3*
 IDirect3DViewport3* iDirect3DViewport_ptr ;
 
-// Line 343: direct3DInterfaceInitialized 0x0052e64c int 
+// Line 343: direct3DInterfaceInitialized 0x0052e64c int
 int  direct3DInterfaceInitialized ;
 
 // Line 345: stdFilePrintf_buffer 0x0052e658 char[0x800]
@@ -705,13 +705,13 @@ swrRenderUnk swrRenders[1024] ;
 // Line 358: swr_RenderState 0x006830c8 unsigned int
 unsigned int swr_RenderState ;
 
-// Line 360: swrNbRenders 0x00af30d8 int 
+// Line 360: swrNbRenders 0x00af30d8 int
 int  swrNbRenders ;
 
-// Line 362: d3d_IndexBuffer 0x00af30e8 WORD[2] 
+// Line 362: d3d_IndexBuffer 0x00af30e8 WORD[2]
 WORD d3d_IndexBuffer[2]  ;
 
-// Line 364: d3d_VertexBuffer 0x00b6b0e8 void* 
+// Line 364: d3d_VertexBuffer 0x00b6b0e8 void*
 void*  d3d_VertexBuffer ;
 
 // Line 366: rdCamera_camRotation 0x00df7f20 rdVector3
@@ -990,13 +990,13 @@ rdMatrix44 rdMatrix44_00e37580 ;
 // Line 487: rdMatrixStack34 0x00e375c0 rdMatrix34[33]
 rdMatrix34 rdMatrixStack34[33] ;
 
-// Line 489: texture_buffer 0x00e93860 void*[1700] 
+// Line 489: texture_buffer 0x00e93860 void*[1700]
 void* texture_buffer[1700]  ;
 
 // Line 491: assetBufferEnd 0x00e981e4 char*
 char* assetBufferEnd ;
 
-// Line 493: assetBuffer 0x00e98200 char* 
+// Line 493: assetBuffer 0x00e98200 char*
 char*  assetBuffer ;
 
 // Line 495: texture_count 0x00e9823c unsigned int
@@ -1017,10 +1017,10 @@ rdMatrix44 rdMatrix44_unk2 ;
 // Line 505: sound_3d_gain_adjust 0x00e9e048 float
 float sound_3d_gain_adjust ;
 
-// Line 507: unk_statuses 0x00e9ed60 int[24] 
+// Line 507: unk_statuses 0x00e9ed60 int[24]
 int unk_statuses[24]  ;
 
-// Line 508: array_classes_unk 0x00e9edc0 void*[300] 
+// Line 508: array_classes_unk 0x00e9edc0 void*[300]
 void* array_classes_unk[300]  ;
 
 // Line 510: stdPlatform_hostServices 0x00e9f280 HostServices
@@ -1219,7 +1219,7 @@ LPDIRECTDRAWSURFACE4 iDirectDrawSurface4_ptr ;
 DDSURFACEDESC2 _ddSurfaceDesc2_2 ;
 
 // Line 595: directDrawVidMemTotal 0x00ec8d80 int;
-int; directDrawVidMemTotal ;
+int directDrawVidMemTotal ;
 
 // Line 597: stdVBuffer_main 0x00ec8da0 stdVBuffer
 stdVBuffer stdVBuffer_main ;
@@ -1230,7 +1230,7 @@ int swrConfig_nbTokens ;
 // Line 604: swrConfig_TokenBuffer 0x00ec8e84 char*[0x400]
 char* swrConfig_TokenBuffer[0x400] ;
 
-// Line 606: swrConfig_buffer2 0x00ec9e84 char* 
+// Line 606: swrConfig_buffer2 0x00ec9e84 char*
 char*  swrConfig_buffer2 ;
 
 // Line 608: DirectInputJoysticks 0x00ec9ea0 void*
@@ -1264,8 +1264,8 @@ float rdCamera_screen_width ;
 rdMatrix34 rdCamera_camMatrix ;
 
 // Line 625: nbVertexBuffer1 0x00ecc480
- 
- nbVertexBuffer1 ;
+
+int nbVertexBuffer1 ;
 
 // Line 627: VertexBuffer1 0x00ecc48c rdVector3*
 rdVector3* VertexBuffer1 ;

--- a/src/globals.h
+++ b/src/globals.h
@@ -11,1274 +11,1274 @@
 extern "C"
 {
 #endif
-    
+
     // Line 0: diDataFormat 0x0049e720 DIDATAFORMAT
     extern DIDATAFORMAT diDataFormat;
-    
+
     // Line 2: A3dApi_GUID 0x004ae0e8 GUID
     extern GUID A3dApi_GUID;
-    
+
     // Line 3: IID_Ia3d4_GUID 0x004ae128 GUID
     extern GUID IID_Ia3d4_GUID;
-    
+
     // Line 4: IID_IA3dListener_GUID 0x004ae158 GUID
     extern GUID IID_IA3dListener_GUID;
-    
+
     // Line 6: stdMath_Primes 0x004aeeb0 int[32] = { 0x17, 0x35, 0x4f, 0x65, 0x97, 0xd3, 0xfb, 0x133, 0x161, 0x191, 0x1c9, 0x1f7, 0x22d, 0x259, 0x28d, 0x2bd, 0x2ef, 0x329, 0x355, 0x38b, 0x3b9, 0x3f1, 0x44f, 0x4b1, 0x515, 0x581, 0x5e7, 0x641, 0x6ad, 0x709, 0x76d, 0x7cf }
     extern int stdMath_Primes[32] ;
-    
+
     // Line 8: iDirectDraw4_GUID 0x004af1c8 GUID
     extern GUID iDirectDraw4_GUID;
-    
+
     // Line 9: iDirect3D3_GUID 0x004af278 GUID
     extern GUID iDirect3D3_GUID;
-    
+
     // Line 11: IID_IDirectPlay4_GUID 0x004af4a8 GUID
     extern GUID IID_IDirectPlay4_GUID;
-    
+
     // Line 12: DirectPlay_GUID 0x004af4c8 GUID
     extern GUID DirectPlay_GUID;
-    
+
     // Line 14: Window_UUID 0x004af9b0 uint32_t[4] = { 0xC95FB584, 0x11D2FA31, 0xAA009D90, 0xAD22A300 }
     extern uint32_t Window_UUID[4] ;
-    
+
     // Line 16: rdMatrix34_identity 0x004af880 rdMatrix34 = {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}
     extern rdMatrix34  rdMatrix34_identity;
-    
+
     // Line 18: swrConfig_joystick_enabled 0x004b2944 int = 1
     extern int  swrConfig_joystick_enabled;
-    
+
     // Line 19: swrConfig_keyboard_enabled 0x004b2948 int = 1
     extern int  swrConfig_keyboard_enabled;
-    
+
     // Line 20: joystick_detected 0x004b294c int = 1
     extern int  joystick_detected;
-    
+
     // Line 22: direct3d_LensFlareCompatible 0x004b431c int
     extern int direct3d_LensFlareCompatible;
-    
+
     // Line 24: swrConfig_defaultVideoConfig 0x004b4330 int[9] = { 0, 0, 0, 0, 0, 0, 1, 3, 2 }
     extern int swrConfig_defaultVideoConfig[9] ;
-    
+
     // Line 26: iDirectDraw4_error 0x004b4758 int
     extern int iDirectDraw4_error;
-    
+
     // Line 28: Main_force_feedback 0x004b4938 int = 1
     extern int  Main_force_feedback;
-    
+
     // Line 30: swrConfig_defaultForceConfig 0x004b4ae8 int[8] = { 3, 3, 2, 2, 2, 2, 1, 1 }
     extern int swrConfig_defaultForceConfig[8] ;
-    
+
     // Line 32: swrUI_unk_ptr 0x004b5d74 swrUI_unk*
     extern swrUI_unk* swrUI_unk_ptr;
-    
+
     // Line 34: Main_nut_delay_ms 0x004b6718 int = 32
     extern int  Main_nut_delay_ms;
-    
+
     // Line 35: Main_hiRes_sound 0x004b6d14 int = 1
     extern int  Main_hiRes_sound;
-    
+
     // Line 36: Main_doppler_sound 0x004b6d18 int = 0
     extern int  Main_doppler_sound;
-    
+
     // Line 37: Main_sound 0x004b6d20 int = 1
     extern int  Main_sound;
-    
+
     // Line 38: Main_sound_gain_adjust 0x004b6d24 float
     extern float Main_sound_gain_adjust;
-    
+
     // Line 39: swrRace_voices_enabled 0x004b6d28 int = 1
     extern int  swrRace_voices_enabled;
-    
+
     // Line 40: Main_sound_unk 0x004b6d2c int = 1
     extern int  Main_sound_unk;
-    
+
     // Line 41: Main_fullscreen_unk 0x004b79f8 int = 1
     extern int  Main_fullscreen_unk;
-    
+
     // Line 42: Main_display_intro_scene 0x004b7a00 int = 1
     extern int  Main_display_intro_scene;
-    
+
     // Line 44: swrSound_criticalSection 0x004b7e7e CRITICAL_SECTION
     extern CRITICAL_SECTION swrSound_criticalSection;
-    
+
     // Line 46: swrSprite_SpriteCount 0x004b91b8 int
     extern int swrSprite_SpriteCount;
-    
+
     // Line 47: swrSprite_unk_x 0x004b91bc float = 16.0
     extern float  swrSprite_unk_x;
-    
+
     // Line 48: swrSprite_unk_y 0x004b91c0 float = 155.0
     extern float  swrSprite_unk_y;
-    
-    // Line 50: eventManagerMain 0x004bfec0 extern swrEventManager[][9]; 
-    extern extern swrEventManager eventManagerMain[][9]; ;
-    
+
+    // Line 50: eventManagerMain 0x004bfec0 extern swrEventManager[][9];
+    extern swrEventManager eventManagerMain[][9]; ;
+
     // Line 51: swrObjHang_unused_state 0x004bfec8 swrObjHang_STATE = -1
     extern swrObjHang_STATE  swrObjHang_unused_state;
-    
+
     // Line 52: swrObjHang_unused_unk 0x004bfecc int = -1
     extern int  swrObjHang_unused_unk;
-    
+
     // Line 54: swrObjHang_state2 0x004bfedc swrObjHang_STATE = -1
     extern swrObjHang_STATE  swrObjHang_state2;
-    
+
     // Line 56: time_ms_unk 0x004c00a8 float;
-    extern float; time_ms_unk;
-    
+    extern float time_ms_unk;
+
     // Line 58: rdVector_negZ 0x004c2598 rdVector3 = {0.0, 0.0, -1.0}
     extern rdVector3  rdVector_negZ;
-    
+
     // Line 60: ai_antiskid 0x004c3114 float
     extern float ai_antiskid;
-    
+
     // Line 61: ai_turn_response 0x004c3118 float
     extern float ai_turn_response;
-    
+
     // Line 62: ai_max_turn_rate 0x004c311c float
     extern float ai_max_turn_rate;
-    
+
     // Line 63: ai_acceleration 0x004c3120 float
     extern float ai_acceleration;
-    
+
     // Line 64: ai_max_speed 0x004c3124 float
     extern float ai_max_speed;
-    
+
     // Line 65: ai_air_brake_interval 0x004c3128 float
     extern float ai_air_brake_interval;
-    
+
     // Line 66: ai_deceleration_interval 0x004c312c float
     extern float ai_deceleration_interval;
-    
+
     // Line 67: ai_boost_thrust 0x004c3130 float
     extern float ai_boost_thrust;
-    
+
     // Line 68: ai_heat_rate 0x004c3134 float
     extern float ai_heat_rate;
-    
+
     // Line 69: ai_cool_rate 0x004c3138 float
     extern float ai_cool_rate;
-    
+
     // Line 70: ai_hover_height 0x004c313c float
     extern float ai_hover_height;
-    
+
     // Line 71: ai_repair_rate 0x004c3140 float
     extern float ai_repair_rate;
-    
+
     // Line 72: ai_bump_mass 0x004c3144 float
     extern float ai_bump_mass;
-    
+
     // Line 73: ai_damage_immunity 0x004c3148 float
     extern float ai_damage_immunity;
-    
+
     // Line 74: ai_intersect_radius 0x004c314c float
     extern float ai_intersect_radius;
-    
+
     // Line 77: rdMatrixStack34_modified 0x004c3c0c int
     extern int rdMatrixStack34_modified;
-    
+
     // Line 79: rdMatrix_unk5 0x004c3c38 rdMatrix44 = {{-1.0 / 6.0, 0.5, -0.5, 1.0 / 6.0}, {0.5, -1.0, 0.5, 0.0}, {-0.5, 0.0, 0.5, 0.0}, {1.0 /6.0, 2.0 / 3.0, 1.0 / 6.0, 0.0}}
     extern rdMatrix44  rdMatrix_unk5;
-    
+
     // Line 80: rdMatrix_unk3 0x004c3c78 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {-0.5, 1.5, -1.5, 0.5}, {1.0, -2.0, 1.0, 0.0}, {-0.5, 0.0, 0.5, 0.0}}
     extern rdMatrix44  rdMatrix_unk3;
-    
+
     // Line 81: rdMatrix_unk1 0x004c3cb8 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {-1.0, 3.0, -3.0, 1.0}, {1.0, -2.0, 1.0, 0.0}}
     extern rdMatrix44  rdMatrix_unk1;
-    
+
     // Line 82: rdMatrix_unk6 0x004c3cf8 rdMatrix44 = {{-1.0, 3.0, -3.0, 1.0}, {3.0, -6.0, 3.0, 0.0}, {-3.0, 3.0, 0.0, 0.0}, {1.0, 0.0, 0.0, 0.0}}
     extern rdMatrix44  rdMatrix_unk6;
-    
+
     // Line 83: rdMatrix_unk4 0x004c3d38 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {-3.0, 9.0, -9.0, 3.0}, {6.0, -12.0, 6.0, 0.0}, {-3.0, 3.0, 0.0, 0.0}}
     extern rdMatrix44  rdMatrix_unk4;
-    
+
     // Line 84: rdMatrix_unk2 0x004c3d78 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {-6.0, 18.0, -18.0, 6.0}, {6.0, -12.0, 6.0, 0.0}}
     extern rdMatrix44  rdMatrix_unk2;
-    
+
     // Line 86: ai_level 0x004c707c float
     extern float ai_level;
-    
+
     // Line 87: ai_spread 0x004c7080 float
     extern float ai_spread;
-    
+
     // Line 89: Main_sound_3dimpact 0x004c7aa8 int = -1
     extern int  Main_sound_3dimpact;
-    
+
     // Line 91: death_speedMin 0x004c7bb8 float
     extern float death_speedMin;
-    
+
     // Line 92: death_speedDrop 0x004c7bbc float
     extern float death_speedDrop;
-    
+
     // Line 94: Main_sound_gain_const 0x004c7d70 float = 0.8
     extern float  Main_sound_gain_const;
-    
+
     // Line 95: Main_sound_doppler_scale 0x004c7d74 float = 1.0
     extern float  Main_sound_doppler_scale;
-    
+
     // Line 96: Main_sound_rolloff 0x004c7d78 float = 0.15
     extern float  Main_sound_rolloff;
-    
+
     // Line 97: Main_sound_gain 0x004c7d7c float = 1.0
     extern float  Main_sound_gain;
-    
+
     // Line 99: swrRace_AILevel 0x004c707c int
     extern int swrRace_AILevel;
-    
+
     // Line 101: swrRace_DeathSpeedMin 0x004c7bb8 float = 325.00
     extern float  swrRace_DeathSpeedMin;
-    
+
     // Line 102: swrRace_DeathSpeedDrop 0x004c7bbc float = 140.0
     extern float  swrRace_DeathSpeedDrop;
-    
+
     // Line 104: swrRace_FireTimer 0x004c7bc0 float = -1.0
     extern float  swrRace_FireTimer;
-    
+
     // Line 106: DirectDraw_CooperativeLevel 0x004c86bc int
     extern int DirectDraw_CooperativeLevel;
-    
+
     // Line 107: directDraw_BltFillColor 0x004c86c0 int
     extern int directDraw_BltFillColor;
-    
+
     // Line 109: d3d_FogEnabled 0x004c98b0 int = 1
     extern int  d3d_FogEnabled;
-    
-    // Line 110: d3d_CurrentScene 0x004c98b4 int = 1 
+
+    // Line 110: d3d_CurrentScene 0x004c98b4 int = 1
     extern int  d3d_CurrentScene;
-    
+
     // Line 112: stdMath_SinTable 0x004c98e8 float[4096]
     extern float stdMath_SinTable[4096];
-    
+
     // Line 113: stdMath_TanTable 0x004cd8e8 float[4096]
     extern float stdMath_TanTable[4096];
-    
+
     // Line 115: wuRegistry_lpClass 0x004d55cc LPSTR
     extern LPSTR wuRegistry_lpClass;
-    
+
     // Line 117: multiplayer_enabled 0x004d5e00 int
     extern int multiplayer_enabled;
-    
+
     // Line 119: swrText_keyNameText 0x004d5f38 char[128]
     extern char swrText_keyNameText[128];
-    
+
     // Line 121: swrConfig_mouse_enabled 0x004d6b38 int
     extern int swrConfig_mouse_enabled;
-    
+
     // Line 123: rdLight_1 0x004d6b78 rdLight
     extern rdLight rdLight_1;
-    
+
     // Line 124: rdLight_2 0x004d6ba8 rdLight
     extern rdLight rdLight_2;
-    
+
     // Line 126: directDrawSurface4_ptr2 0x004d6be0 LPDIRECTDRAWSURFACE4
     extern LPDIRECTDRAWSURFACE4 directDrawSurface4_ptr2;
-    
+
     // Line 127: ddSurfaceDesc_2 0x004d6be4 DDSURFACEDESC
     extern DDSURFACEDESC ddSurfaceDesc_2;
-    
+
     // Line 129: swrSpriteTexIsTGA 0x004d79f8 int[149]
     extern int swrSpriteTexIsTGA[149];
-    
+
     // Line 131: swrSpriteTexItems 0x004d7c68 swrSpriteTexItem[149]
     extern swrSpriteTexItem swrSpriteTexItems[149];
-    
+
     // Line 133: swrUI_unk4_ptr 0x004d878c swrUI_unk*
     extern swrUI_unk* swrUI_unk4_ptr;
-    
+
     // Line 134: swrUI_unk5_ptr 0x004d8790 swrUI_unk*
     extern swrUI_unk* swrUI_unk5_ptr;
-    
+
     // Line 135: swrUI_unk6_ptr 0x004d8794 swrUI_unk*
     extern swrUI_unk* swrUI_unk6_ptr;
-    
+
     // Line 137: multiplayer_in_mp 0x004d87a0 int
     extern int multiplayer_in_mp;
-    
+
     // Line 139: swrUI_unk_array 0x004d8110 swrUI_unk[20]
     extern swrUI_unk swrUI_unk_array[20];
-    
+
     // Line 141: swrUI_unk_array_count 0x004d87a4 int
     extern int swrUI_unk_array_count;
-    
+
     // Line 143: time_buffer 0x004e9f20 char[256]
     extern char time_buffer[256];
-    
+
     // Line 145: g_objHang1 0x004eb21c swrObjHang*
     extern swrObjHang* g_objHang1;
-    
+
     // Line 147: multiplayer_sync_timer_ms 0x004eb230 int
     extern int multiplayer_sync_timer_ms;
-    
+
     // Line 149: multiplayer_race_button_toggle 0x004eb238 int
     extern int multiplayer_race_button_toggle;
-    
+
     // Line 151: multiplayer_track_change_permission 0x004eb388 int
     extern int multiplayer_track_change_permission;
-    
+
     // Line 153: playerNumber 0x004eb3b4 int
     extern int playerNumber;
-    
+
     // Line 155: swrText_racerTab_array 0x004eb3c4 char**
     extern char** swrText_racerTab_array;
-    
+
     // Line 156: swrText_racerTab_buffer 0x004eb3c8 char*
     extern char* swrText_racerTab_buffer;
-    
+
     // Line 158: swrText_nbLinesRacerTab 0x004eb3cc int
     extern int swrText_nbLinesRacerTab;
-    
+
     // Line 160: ia3dSourceThreadId 0x004eb3f8 DWORD
     extern DWORD ia3dSourceThreadId;
-    
+
     // Line 161: ia3dSourceEventHandle 0x004eb3fc HANDLE
     extern HANDLE ia3dSourceEventHandle;
-    
+
     // Line 162: ia3dSourceEventHandle2 0x004eb400 HANDLE
     extern HANDLE ia3dSourceEventHandle2;
-    
+
     // Line 164: iA3DSource_ptr 0x004eb414 IA3dSource*
     extern IA3dSource* iA3DSource_ptr;
-    
+
     // Line 166: swrRace_music_enabled 0x004eb45c int
     extern int swrRace_music_enabled;
-    
+
     // Line 168: swrSoundUnk1 0x004eb464 swrSoundUnk
     extern swrSoundUnk swrSoundUnk1;
-    
+
     // Line 170: ia3dSourceThreadHandle 0x004eb478 HANDLE
     extern HANDLE ia3dSourceThreadHandle;
-    
+
     // Line 171: ia3d_thread_running 0x004eb47c int
     extern int ia3d_thread_running;
-    
+
     // Line 173: iDirectDrawSurface_ptr3 0x004eb480 LPDIRECTDRAWSURFACE
     extern LPDIRECTDRAWSURFACE iDirectDrawSurface_ptr3;
-    
+
     // Line 174: ddSurfaceDesc_3 0x004eb484 DDSURFACEDESC
     extern DDSURFACEDESC ddSurfaceDesc_3;
-    
+
     // Line 176: swrMain_initialized 0x0050b5a0 int
     extern int swrMain_initialized;
-    
+
     // Line 178: array_classes_unk_counter 0x0050b5ec int
     extern int array_classes_unk_counter;
-    
+
     // Line 180: rdVector_sound_pos 0x0050b5f0 rdVector4
     extern rdVector4 rdVector_sound_pos;
-    
+
     // Line 182: Main_settings_RegFullScreen 0x0050b560 int
     extern int Main_settings_RegFullScreen;
-    
+
     // Line 183: Main_settings_RegFixFlicker 0x0050b564 int
     extern int Main_settings_RegFixFlicker;
-    
+
     // Line 184: Main_settings_RegDevMode 0x0050b568 int
     extern int Main_settings_RegDevMode;
-    
+
     // Line 185: Main_settings_RegUseFett 0x0050b56c int
     extern int Main_settings_RegUseFett;
-    
-    // Line 187: Main_hWnd 0x0050b59c HWND 
+
+    // Line 187: Main_hWnd 0x0050b59c HWND
     extern HWND  Main_hWnd;
-    
+
     // Line 189: Main_settings_menu_only 0x0050b5b0 int
     extern int Main_settings_menu_only;
-    
+
     // Line 190: Main_settings_debug_hud 0x0050b5c0 int
     extern int Main_settings_debug_hud;
-    
+
     // Line 192: swrSprite_unk1_r 0x0050b704 char
     extern char swrSprite_unk1_r;
-    
+
     // Line 193: swrSprite_unk1_g 0x0050b705 char
     extern char swrSprite_unk1_g;
-    
+
     // Line 194: swrSprite_unk1_b 0x0050b706 char
     extern char swrSprite_unk1_b;
-    
+
     // Line 195: swrSprite_unk1_a 0x0050b707 char
     extern char swrSprite_unk1_a;
-    
+
     // Line 196: swrSprite_unk2_r 0x0050b708 char
     extern char swrSprite_unk2_r;
-    
+
     // Line 197: swrSprite_unk2_g 0x0050b709 char
     extern char swrSprite_unk2_g;
-    
+
     // Line 198: swrSprite_unk2_b 0x0050b70a char
     extern char swrSprite_unk2_b;
-    
+
     // Line 199: swrSprite_unk2_a 0x0050b70b char
     extern char swrSprite_unk2_a;
-    
+
     // Line 201: swrRace_DebugLevel 0x0050c040 int
     extern int swrRace_DebugLevel;
-    
-    // Line 202: swrRace_DebugMenu 0x0050c044 int 
+
+    // Line 202: swrRace_DebugMenu 0x0050c044 int
     extern int  swrRace_DebugMenu;
-    
-    // Line 203: swrRace_DebugFlag 0x0050c048 char 
+
+    // Line 203: swrRace_DebugFlag 0x0050c048 char
     extern char  swrRace_DebugFlag;
-    
+
     // Line 205: swrLoader_sprite_file 0x0050c08c FILE*
     extern FILE* swrLoader_sprite_file;
-    
+
     // Line 206: swrLoader_spline_file 0x0050c090 FILE*
     extern FILE* swrLoader_spline_file;
-    
+
     // Line 207: swrLoader_texture_file 0x0050c094 FILE*
     extern FILE* swrLoader_texture_file;
-    
+
     // Line 208: swrLoader_model_file 0x0050c098 FILE*
     extern FILE* swrLoader_model_file;
-    
+
     // Line 210: swrRace_SelectedRacer 0x0050c118 int
     extern int swrRace_SelectedRacer;
-    
+
     // Line 212: alpha_unk 0x0050c2e8 float
     extern float alpha_unk;
-    
+
     // Line 213: gamma_unk 0x0050c2ec float
     extern float gamma_unk;
-    
+
     // Line 215: swrRace_TournamentTrugutGain 0x0050c53c int
     extern int swrRace_TournamentTrugutGain;
-    
+
     // Line 217: g_objHang2 0x0050c454 swrObjHang*
     extern swrObjHang* g_objHang2;
-    
+
     // Line 219: nb_AI_racers 0x0050c558 int
     extern int nb_AI_racers;
-    
+
     // Line 221: rdMatrixStack44_size 0x0050c5e8 int
     extern int rdMatrixStack44_size;
-    
+
     // Line 223: assetBufferIndex 0x0050c614 int
     extern int assetBufferIndex;
-    
+
     // Line 225: swrSound_Orientation1 0x0050c648 rdVector4
     extern rdVector4 swrSound_Orientation1;
-    
+
     // Line 226: swrSound_Orientation2 0x0050c658 rdVector4
     extern rdVector4 swrSound_Orientation2;
-    
+
     // Line 227: swrSound_Position 0x0050c668 rdVector4
     extern rdVector4 swrSound_Position;
-    
+
     // Line 229: swrSound_unk_init 0x0050c68c int
     extern int swrSound_unk_init;
-    
+
     // Line 230: swrSound_Velocity 0x0050c690 rdVector3
     extern rdVector3 swrSound_Velocity;
-    
+
     // Line 232: IA3dSource2_ptr 0x0050c6a0 IA3dSource*
     extern IA3dSource* IA3dSource2_ptr;
-    
+
     // Line 233: IA3dSource3_ptr 0x0050c6a4 IA3dSource*
     extern IA3dSource* IA3dSource3_ptr;
-    
+
     // Line 235: swr_unk1_ptr 0x0050c6b0 swr_unk1*
     extern swr_unk1* swr_unk1_ptr;
-    
+
     // Line 236: swrUI_unk3 0x0050cb6b4 swrUI_Unk3*
     extern swrUI_Unk3* swrUI_unk3;
-    
+
     // Line 238: rdVector_unk5 0x0050c6e8 rdVector3
     extern rdVector3 rdVector_unk5;
-    
-    // Line 240: swrTextEntries1Count 0x0050c750 int 
+
+    // Line 240: swrTextEntries1Count 0x0050c750 int
     extern int  swrTextEntries1Count;
-    
-    // Line 242: swrTextEntries2Count 0x0050c758 int 
+
+    // Line 242: swrTextEntries2Count 0x0050c758 int
     extern int  swrTextEntries2Count;
-    
+
     // Line 244: rdMatrixStack34_size 0x0050c6f4 int
     extern int rdMatrixStack34_size;
-    
+
     // Line 246: debug_showSurfaceFlags 0x0050c88c int
     extern int debug_showSurfaceFlags;
-    
+
     // Line 248: debug_showSplineMarkers 0x0050ca24 int
     extern int debug_showSplineMarkers;
-    
+
     // Line 249: swrRace_IsInvincible 0x0050ca28 int
     extern int swrRace_IsInvincible;
-    
+
     // Line 251: swr_systemTimeMs 0x0050cb60 DWORD
     extern DWORD swr_systemTimeMs;
-    
+
     // Line 253: swr_FastMode 0x0050cb68 int
     extern int swr_FastMode;
-    
+
     // Line 255: debug_buffer 0x0050cd18 char[2048]
     extern char debug_buffer[2048];
-    
+
     // Line 257: stdPlatform_hostServices_initialized 0x0050d518 int
     extern int stdPlatform_hostServices_initialized;
-    
+
     // Line 259: a3dCaps_hardware 0x0050d520 A3DCAPS_HARDWARE
     extern A3DCAPS_HARDWARE a3dCaps_hardware;
-    
+
     // Line 260: a3dOutputGain 0x0050d544 float
     extern float a3dOutputGain;
-    
+
     // Line 261: IA3d4_ptr 0x0050d548 IA3d4*
     extern IA3d4* IA3d4_ptr;
-    
+
     // Line 263: Sound_enabled_3d 0x0050d550 int
     extern int Sound_enabled_3d;
-    
+
     // Line 265: IA3dListener_ptr 0x0050d560 IA3dListener*
     extern IA3dListener* IA3dListener_ptr;
-    
+
     // Line 267: DirectInputKeyboards 0x0050d658 void*
     extern void* DirectInputKeyboards;
-    
+
     // Line 269: iDirectInputDeviceA_ptr 0x0050d89c LPDIRECTINPUTDEVICEA
     extern LPDIRECTINPUTDEVICEA iDirectInputDeviceA_ptr;
-    
+
     // Line 271: DirectInput_initialized 0x0050fea8 int
     extern int DirectInput_initialized;
-    
+
     // Line 273: iDirectInputA_ptr 0x0050feb8 LPDIRECTINPUTA
     extern LPDIRECTINPUTA iDirectInputA_ptr;
-    
-    // Line 274: DirectInputNbKeyboard 0x00febc int 
+
+    // Line 274: DirectInputNbKeyboard 0x00febc int
     extern int  DirectInputNbKeyboard;
-    
-    // Line 276: DirectInputNbMouses 0x0050fec0 int 
+
+    // Line 276: DirectInputNbMouses 0x0050fec0 int
     extern int  DirectInputNbMouses;
-    
-    // Line 278: DirectInputNbJoysticks 0x0050fec8 int 
+
+    // Line 278: DirectInputNbJoysticks 0x0050fec8 int
     extern int  DirectInputNbJoysticks;
-    
+
     // Line 279: DirectInputTimeMs 0x0050fecc int
     extern int DirectInputTimeMs;
-    
+
     // Line 280: DirectInputPreviousTimeMs 0x0050fed0 int
     extern int DirectInputPreviousTimeMs;
-    
+
     // Line 282: DirectInputDeltaTimeMs 0x0050fed8 int
     extern int DirectInputDeltaTimeMs;
-    
+
     // Line 284: iDirectPlay4_ptr 0x00510254 IDirectPlay4*
     extern IDirectPlay4* iDirectPlay4_ptr;
-    
+
     // Line 286: swrConfig_filename 0x005138b8 char[0x80]
     extern char swrConfig_filename[0x80];
-    
+
     // Line 288: swrConfig_buffer3 0x005143d8 char[0x80]
     extern char swrConfig_buffer3[0x80];
-    
+
     // Line 290: swrConfig_file2NbLines 0x005284f8 int
     extern int swrConfig_file2NbLines;
-    
+
     // Line 292: swrConfig_buffer 0x00528500 char[0x1000]
     extern char swrConfig_buffer[0x1000];
-    
+
     // Line 294: swrConfig_file_ready 0x00529500 int
     extern int swrConfig_file_ready;
-    
+
     // Line 296: swrConfig_file2 0x00529504 FILE*
     extern FILE* swrConfig_file2;
-    
+
     // Line 297: swrConfig_file 0x00529508 FILE*
     extern FILE* swrConfig_file;
-    
+
     // Line 299: swrMain_fontHandle 0x00529510 HFONT
     extern HFONT swrMain_fontHandle;
-    
+
     // Line 300: directDrawSelectedDeviceIndex 0x00529514 int
     extern int directDrawSelectedDeviceIndex;
-    
+
     // Line 302: directDraw_FontWidth 0x0052951c int
     extern int directDraw_FontWidth;
-    
+
     // Line 303: directDraw_FontHeight_unused 0x00529520 int
     extern int directDraw_FontHeight_unused;
-    
+
     // Line 305: iDirectDrawSurface_ptr 0x00529578 LPDIRECTDRAWSURFACE
     extern LPDIRECTDRAWSURFACE iDirectDrawSurface_ptr;
-    
+
     // Line 306: _ddSurfaceDesc 0x0052957c DDSURFACEDESC2
     extern DDSURFACEDESC2 _ddSurfaceDesc;
-    
+
     // Line 307: swrDisplayModes 0x005295f8 swrDisplayMode[32]
     extern swrDisplayMode swrDisplayModes[32];
-    
+
     // Line 309: swrDrawDevicesArray 0x0052a9f8 swrDrawDevice[16]
     extern swrDrawDevice swrDrawDevicesArray[16];
-    
+
     // Line 311: directDrawInitialized 0x0052d438 int
     extern int directDrawInitialized;
-    
+
     // Line 312: directDrawDisplayModesReady 0x0052d43c int
     extern int directDrawDisplayModesReady;
-    
+
     // Line 314: directDrawSurfacesInitialized 0x0052d440 int
     extern int directDrawSurfacesInitialized;
-    
+
     // Line 315: directDrawNbDevices 0x0052d444 int
     extern int directDrawNbDevices;
-    
+
     // Line 316: selectedSwrDrawDevice 0x0052d448 swrDrawDevice*
     extern swrDrawDevice* selectedSwrDrawDevice;
-    
+
     // Line 317: directDrawNbDisplayModes 0x0052d44c int
     extern int directDrawNbDisplayModes;
-    
+
     // Line 318: displayModeUnk 0x0052d450 swrDisplayMode*
     extern swrDisplayMode* displayModeUnk;
-    
+
     // Line 319: iDirectDraw4 0x0052d454 LPDIRECTDRAW
     extern LPDIRECTDRAW iDirectDraw4;
-    
+
     // Line 321: directDrawSpecialDeviceId 0x0052d45c int
     extern int directDrawSpecialDeviceId;
-    
+
     // Line 323: d3dDeviceDesc 0x0052d460 D3DDEVICEDESC
     extern D3DDEVICEDESC d3dDeviceDesc;
-    
+
     // Line 325: swrNb3DDevices 0x0052d56c int
     extern int swrNb3DDevices;
-    
+
     // Line 326: swr3DTextureFormats 0x0052d570 swr3DTextureFormat[8]
-    extern swr3DTextureFormat swr3DTextureFormats[8];
-    
+    //extern swr3DTextureFormats swr3DTextureFormats[8];
+
     // Line 328: swr3DDevices 0x0052d870 swr3DDevice[4]
     extern swr3DDevice swr3DDevices[4];
-    
+
     // Line 329: d3dRenderState 0x0052e610 unsigned int
     extern unsigned int d3dRenderState;
-    
+
     // Line 330: d3dMipFilter 0x0052e614 unsigned int
     extern unsigned int d3dMipFilter;
-    
+
     // Line 332: Direct3D_NbTextureFormats 0x0052e61c int
     extern int Direct3D_NbTextureFormats;
-    
+
     // Line 334: Direct3DFoundValidTextureFormat 0x0052e620 int
     extern int Direct3DFoundValidTextureFormat;
-    
+
     // Line 335: d3dMaxVertices 0x0052d624 unsigned int
     extern unsigned int d3dMaxVertices;
-    
+
     // Line 336: d3dCurrentTexture 0x0052e628 IDirect3DTexture2*
     extern IDirect3DTexture2* d3dCurrentTexture;
-    
+
     // Line 338: iDirectDraw4_2 0x0052e638 LPDIRECTDRAW
     extern LPDIRECTDRAW iDirectDraw4_2;
-    
+
     // Line 339: iDirectDrawPalette_ptr 0x0052e63c LPDIRECTDRAWPALETTE
     extern LPDIRECTDRAWPALETTE iDirectDrawPalette_ptr;
-    
+
     // Line 340: iDirect3D3_ptr 0x0052e640 LPDIRECT3D3
     extern LPDIRECT3D3 iDirect3D3_ptr;
-    
+
     // Line 341: iDirect3DDevice3_ptr 0x0052e644 LPDIRECT3DDEVICE3
     extern LPDIRECT3DDEVICE3 iDirect3DDevice3_ptr;
-    
+
     // Line 342: iDirect3DViewport_ptr 0x0052e648 IDirect3DViewport3*
     extern IDirect3DViewport3* iDirect3DViewport_ptr;
-    
-    // Line 343: direct3DInterfaceInitialized 0x0052e64c int 
+
+    // Line 343: direct3DInterfaceInitialized 0x0052e64c int
     extern int  direct3DInterfaceInitialized;
-    
+
     // Line 345: stdFilePrintf_buffer 0x0052e658 char[0x800]
     extern char stdFilePrintf_buffer[0x800];
-    
+
     // Line 347: Window_GUID 0x0052ee60 GUID
     extern GUID Window_GUID;
-    
+
     // Line 348: Window_hWnd 0x0052ee70 HWND
     extern HWND Window_hWnd;
-    
+
     // Line 349: Window_hinstance 0x0052ee74 HINSTANCE
     extern HINSTANCE Window_hinstance;
-    
+
     // Line 351: stdConsole_hConsoleOutput 0x0052ee78 HANDLE
     extern HANDLE stdConsole_hConsoleOutput;
-    
+
     // Line 352: stdConsole_wAttributes 0x0052ee7c WORD
     extern WORD stdConsole_wAttributes;
-    
+
     // Line 354: daAlloc_struct 0x0052ee98 void*
     extern void* daAlloc_struct;
-    
+
     // Line 356: swrRenders 0x005330c0 swrRenderUnk[1024]
     extern swrRenderUnk swrRenders[1024];
-    
+
     // Line 358: swr_RenderState 0x006830c8 unsigned int
     extern unsigned int swr_RenderState;
-    
-    // Line 360: swrNbRenders 0x00af30d8 int 
+
+    // Line 360: swrNbRenders 0x00af30d8 int
     extern int  swrNbRenders;
-    
-    // Line 362: d3d_IndexBuffer 0x00af30e8 WORD[2] 
+
+    // Line 362: d3d_IndexBuffer 0x00af30e8 WORD[2]
     extern WORD d3d_IndexBuffer[2] ;
-    
-    // Line 364: d3d_VertexBuffer 0x00b6b0e8 void* 
+
+    // Line 364: d3d_VertexBuffer 0x00b6b0e8 void*
     extern void*  d3d_VertexBuffer;
-    
+
     // Line 366: rdCamera_camRotation 0x00df7f20 rdVector3
     extern rdVector3 rdCamera_camRotation;
-    
+
     // Line 367: rdCamera_pCurCamera 0x00df7f2c rdCamera*
     extern rdCamera* rdCamera_pCurCamera;
-    
+
     // Line 368: bRDroidStartup 0x00df7f30 int
     extern int bRDroidStartup;
-    
+
     // Line 370: g_hWnd 0x00dfaa28 HWND
     extern HWND g_hWnd;
-    
+
     // Line 371: g_nCmdShow 0x00dfaa2c int
     extern int g_nCmdShow;
-    
+
     // Line 372: g_WndProc 0x00dfaa30 Window_MSGHANDLER_ptr
     extern Window_MSGHANDLER_ptr g_WndProc;
-    
+
     // Line 373: Window_width 0x00dfaa34 int
     extern int Window_width;
-    
+
     // Line 374: Window_height 0x00dfaa38 int
     extern int Window_height;
-    
+
     // Line 375: wuRegistry_bInitted 0x00dfaa3c int
     extern int wuRegistry_bInitted;
-    
+
     // Line 376: wuRegistry_lpSubKey 0x00dfaa40 LPCSTR
     extern LPCSTR wuRegistry_lpSubKey;
-    
+
     // Line 377: wuRegistry_hKey 0x00dfaa44 HKEY
     extern HKEY wuRegistry_hKey;
-    
+
     // Line 379: swrTextEntries1Colors 0x00e2b480 char[128][4]
     extern char swrTextEntries1Colors[128][4];
-    
+
     // Line 381: swrTextEntries1Text 0x00e2c380 char[128][128]
     extern char swrTextEntries1Text[128][128];
-    
+
     // Line 382: swrTextEntries2Text 0x00e303a0 char[128][128]
     extern char swrTextEntries2Text[128][128];
-    
+
     // Line 383: swrTextEntries2Colors 0x00e343a0 char[128][4]
     extern char swrTextEntries2Colors[128][4];
-    
+
     // Line 385: swrTextEntries2Pos 0x00e34660 short[32][2]
     extern short swrTextEntries2Pos[32][2];
-    
+
     // Line 386: swrTextEntries1Pos 0x00e34860 short[128][2]
     extern short swrTextEntries1Pos[128][2];
-    
+
     // Line 388: translation_unk 0x00e996c0 rdVector3
     extern rdVector3 translation_unk;
-    
+
     // Line 389: rotation_unk 0x00e996cc rdVector3
     extern rdVector3 rotation_unk;
-    
+
     // Line 391: rdMatrix_unk7 0x00e9ba44 rdMatrix44
     extern rdMatrix44 rdMatrix_unk7;
-    
+
     // Line 393: swrSprite_array 0x00e9ba60 swrSprite
     extern swrSprite swrSprite_array;
-    
+
     // Line 395: swrModel_unk_array 0x00dfb040 swrModel_unk[4]
     extern swrModel_unk swrModel_unk_array[4];
-    
+
     // Line 397: rdCamera_toggle 0x00dfb1b0 int
     extern int rdCamera_toggle;
-    
+
     // Line 398: rdCamera_transform 0x00dfb1dc  rdMatrix44
     extern  rdMatrix44 rdCamera_transform;
-    
+
     // Line 400: rdMatrix44_unk 0x00dfb21c rdMatrix44
     extern rdMatrix44 rdMatrix44_unk;
-    
+
     // Line 402: cameraFOV 0x00dfb2e0 float
     extern float cameraFOV;
-    
+
     // Line 403: cameraAspectRatio 0x00dfb2e4 float
     extern float cameraAspectRatio;
-    
+
     // Line 405: swrRace_frameTimeMs 0x00e22a40 float
     extern float swrRace_frameTimeMs;
-    
+
     // Line 406: swrRace_deltaTimeMs 0x00e22a50 float
     extern float swrRace_deltaTimeMs;
-    
+
     // Line 408: rdMatrix44_00e25960 0x00e25960 rdMatrix44
     extern rdMatrix44 rdMatrix44_00e25960;
-    
+
     // Line 410: swrRace_FireLocation 0x00e25e00 float
     extern float swrRace_FireLocation;
-    
+
     // Line 412: swrRace_Transition 0x00e295a0 float
     extern float swrRace_Transition;
-    
+
     // Line 414: swrRace_MenuMaxSelection 0x00e295cc int
     extern int swrRace_MenuMaxSelection;
-    
+
     // Line 415: swrRace_MenuSelectedItem 0x00e295d0 int
     extern int swrRace_MenuSelectedItem;
-    
+
     // Line 417: rdMatrix44_unk4 0x00e298c0 rdMatrix44
     extern rdMatrix44 rdMatrix44_unk4;
-    
+
     // Line 419: rdVector3_unk1 0x00e29b90 rdVector3
     extern rdVector3 rdVector3_unk1;
-    
+
     // Line 421: swrRace_antiskid 0x00e29bdc float
     extern float swrRace_antiskid;
-    
+
     // Line 422: swrRace_turn_response 0x00e29be0 float
     extern float swrRace_turn_response;
-    
+
     // Line 423: swrRace_max_turn_rate 0x00e29be4 float
     extern float swrRace_max_turn_rate;
-    
+
     // Line 424: swrRace_acceleration 0x00e29be8 float
     extern float swrRace_acceleration;
-    
+
     // Line 425: swrRace_top_speed 0x00e29bec float
     extern float swrRace_top_speed;
-    
+
     // Line 426: swrRace_air_brake_interval 0x00e29bf0 float
     extern float swrRace_air_brake_interval;
-    
+
     // Line 427: swrRace_deceleration_interval 0x00e29bf4 float
     extern float swrRace_deceleration_interval;
-    
+
     // Line 428: swrRace_boost_thrust 0x00e29bf8 float
     extern float swrRace_boost_thrust;
-    
+
     // Line 429: swrRace_heat_rate 0x00e29bfc float
     extern float swrRace_heat_rate;
-    
+
     // Line 430: swrRace_cool_rate 0x00e29c00 float
     extern float swrRace_cool_rate;
-    
+
     // Line 431: swrRace_hover_height 0x00e29c04 float
     extern float swrRace_hover_height;
-    
+
     // Line 432: swrRace_repair_rate 0x00e29c08 float
     extern float swrRace_repair_rate;
-    
+
     // Line 433: swrRace_bump_mass 0x00e29c0c float
     extern float swrRace_bump_mass;
-    
+
     // Line 434: swrRace_damage_immunity 0x00e29c10 float
     extern float swrRace_damage_immunity;
-    
+
     // Line 435: swrRace_intersect_radius 0x00e29c14 float
     extern float swrRace_intersect_radius;
-    
+
     // Line 437: swrRace_results_P1_Position 0x00e29c1c int
     extern int swrRace_results_P1_Position;
-    
+
     // Line 438: swrRace_results_P1_Lap1 0x00e29c20 float
     extern float swrRace_results_P1_Lap1;
-    
+
     // Line 439: swrRace_results_P1_Lap2 0x00e29c24 float
     extern float swrRace_results_P1_Lap2;
-    
+
     // Line 440: swrRace_results_P1_Lap3 0x00e29c28 float
     extern float swrRace_results_P1_Lap3;
-    
+
     // Line 441: swrRace_results_P1_Lap4 0x00e29c2c float
     extern float swrRace_results_P1_Lap4;
-    
+
     // Line 442: swrRace_results_P1_Lap5 0x00e29c30 float
     extern float swrRace_results_P1_Lap5;
-    
+
     // Line 443: swrRace_results_P1_total_time 0x00e29c34 float
     extern float swrRace_results_P1_total_time;
-    
+
     // Line 444: swrRace_results_P1_Lap 0x00e29c38 float
     extern float swrRace_results_P1_Lap;
-    
+
     // Line 445: swrRace_lastRaceDamage 0x00e29c40 float
     extern float swrRace_lastRaceDamage;
-    
+
     // Line 446: swrRace_P1_UI_writer_ptr 0x00e29c44 void*
     extern void* swrRace_P1_UI_writer_ptr;
-    
+
     // Line 448: rdMatrix44_unk3 0x00e2ae80 rdMatrix44
     extern rdMatrix44 rdMatrix44_unk3;
-    
+
     // Line 450: rdVector_unk4 0x00e2af90 rdVector3
     extern rdVector3 rdVector_unk4;
-    
+
     // Line 452: rdVector3_unk2 0x00e2b470 rdVector3
     extern rdVector3 rdVector3_unk2;
-    
+
     // Line 454: sound_music_volume 0x00e364a6 short
     extern short sound_music_volume;
-    
+
     // Line 456: swrRace_UnlockDataBase 0x00e35a84 int
     extern int swrRace_UnlockDataBase;
-    
+
     // Line 458: swrRace_truguts 0x00e35a98 int
     extern int swrRace_truguts;
-    
+
     // Line 460: swrRace_nbPitDroids 0x00e35aa0 char
     extern char swrRace_nbPitDroids;
-    
+
     // Line 461: swrRace_traction_upgrade_level 0x00e35aa1 char
     extern char swrRace_traction_upgrade_level;
-    
+
     // Line 462: swrRace_turning_upgrade_level 0x00e35aa2 char
     extern char swrRace_turning_upgrade_level;
-    
+
     // Line 463: swrRace_acceleration_upgrade_level 0x00e35aa3 char
     extern char swrRace_acceleration_upgrade_level;
-    
+
     // Line 464: swrRace_topspeed_upgrade_level 0x00e35aa4 char
     extern char swrRace_topspeed_upgrade_level;
-    
+
     // Line 465: swrRace_airbrake_upgrade_level 0x00e35aa5 char
     extern char swrRace_airbrake_upgrade_level;
-    
+
     // Line 466: swrRace_cooling_upgrade_level 0x00e35aa6 char
     extern char swrRace_cooling_upgrade_level;
-    
+
     // Line 467: swrRace_repair_upgrade_level 0x00e35aa7 char
     extern char swrRace_repair_upgrade_level;
-    
+
     // Line 468: swrRace_traction_upgrade_health 0x00e35aa8 char
     extern char swrRace_traction_upgrade_health;
-    
+
     // Line 469: swrRace_turning_upgrade_health 0x00e35aa9 char
     extern char swrRace_turning_upgrade_health;
-    
+
     // Line 470: swrRace_acceleration_upgrade_health 0x00e35aaa char
     extern char swrRace_acceleration_upgrade_health;
-    
+
     // Line 471: swrRace_topspeed_upgrade_health 0x00e35aab char
     extern char swrRace_topspeed_upgrade_health;
-    
+
     // Line 472: swrRace_airbrake_upgrade_health 0x00e35aac char
     extern char swrRace_airbrake_upgrade_health;
-    
+
     // Line 473: swrRace_cooling_upgrade_health 0x00e35aad char
     extern char swrRace_cooling_upgrade_health;
-    
+
     // Line 474: swrRace_repair_upgrade_health 0x00e35aae char
     extern char swrRace_repair_upgrade_health;
-    
+
     // Line 476: traction_upgrade_level 0x00e364f5 char
     extern char traction_upgrade_level;
-    
+
     // Line 477: turning_upgrade_level 0x00e364f6 char
     extern char turning_upgrade_level;
-    
+
     // Line 478: acceleration_upgrade_level 0x00e364f7 char
     extern char acceleration_upgrade_level;
-    
+
     // Line 479: topspeed_upgrade_level 0x00e364f8 char
     extern char topspeed_upgrade_level;
-    
+
     // Line 480: airbrake_upgrade_level 0x00e364f9 char
     extern char airbrake_upgrade_level;
-    
+
     // Line 481: cooling_upgrade_level 0x00e364fa char
     extern char cooling_upgrade_level;
-    
+
     // Line 482: repair_upgrade_level 0x00e364fb char
     extern char repair_upgrade_level;
-    
+
     // Line 484: rdMatrix_unk8 0x00e37480 rdMatrix44
     extern rdMatrix44 rdMatrix_unk8;
-    
+
     // Line 486: rdMatrix44_00e37580 0x00e37580 rdMatrix44
     extern rdMatrix44 rdMatrix44_00e37580;
-    
+
     // Line 487: rdMatrixStack34 0x00e375c0 rdMatrix34[33]
     extern rdMatrix34 rdMatrixStack34[33];
-    
-    // Line 489: texture_buffer 0x00e93860 void*[1700] 
+
+    // Line 489: texture_buffer 0x00e93860 void*[1700]
     extern void* texture_buffer[1700] ;
-    
+
     // Line 491: assetBufferEnd 0x00e981e4 char*
     extern char* assetBufferEnd;
-    
-    // Line 493: assetBuffer 0x00e98200 char* 
+
+    // Line 493: assetBuffer 0x00e98200 char*
     extern char*  assetBuffer;
-    
+
     // Line 495: texture_count 0x00e9823c unsigned int
     extern unsigned int texture_count;
-    
+
     // Line 497: rdMatrix44_stack 0x00e985c0 rdMatrix44[32]
     extern rdMatrix44 rdMatrix44_stack[32];
-    
+
     // Line 499: swrRace_SelectIndex 0x00e99240 int
     extern int swrRace_SelectIndex;
-    
+
     // Line 501: swrRace_PodRotationAnimation 0x00e99384 float
     extern float swrRace_PodRotationAnimation;
-    
+
     // Line 503: rdMatrix44_unk2 0x00e9b9e8 rdMatrix44
     extern rdMatrix44 rdMatrix44_unk2;
-    
+
     // Line 505: sound_3d_gain_adjust 0x00e9e048 float
     extern float sound_3d_gain_adjust;
-    
-    // Line 507: unk_statuses 0x00e9ed60 int[24] 
+
+    // Line 507: unk_statuses 0x00e9ed60 int[24]
     extern int unk_statuses[24] ;
-    
-    // Line 508: array_classes_unk 0x00e9edc0 void*[300] 
+
+    // Line 508: array_classes_unk 0x00e9edc0 void*[300]
     extern void* array_classes_unk[300] ;
-    
+
     // Line 510: stdPlatform_hostServices 0x00e9f280 HostServices
     extern HostServices stdPlatform_hostServices;
-    
+
     // Line 512: unicode_unk 0x00e9f3c4 wchar_t[32]
     extern wchar_t unicode_unk[32];
-    
+
     // Line 514: unicode_unk2 0x00e9f380 wchar_t[32]
     extern wchar_t unicode_unk2[32];
-    
+
     // Line 516: multiplayer_racer1_id 0x00ea0260 int
     extern int multiplayer_racer1_id;
-    
+
     // Line 517: multiplayer_racer2_id 0x00ea0264 int
     extern int multiplayer_racer2_id;
-    
+
     // Line 518: multiplayer_racer3_id 0x00ea0268 int
     extern int multiplayer_racer3_id;
-    
+
     // Line 519: multiplayer_racer4_id 0x00ea026c int
     extern int multiplayer_racer4_id;
-    
+
     // Line 520: multiplayer_racer5_id 0x00ea0270 int
     extern int multiplayer_racer5_id;
-    
+
     // Line 521: multiplayer_racer6_id 0x00ea0274 int
     extern int multiplayer_racer6_id;
-    
+
     // Line 522: multiplayer_racer7_id 0x00ea0278 int
     extern int multiplayer_racer7_id;
-    
+
     // Line 523: multiplayer_racer8_id 0x00ea027c int
     extern int multiplayer_racer8_id;
-    
+
     // Line 524: multiplayer_racer9_id 0x00ea0280 int
     extern int multiplayer_racer9_id;
-    
+
     // Line 525: multiplayer_racer10_id 0x00ea0284 int
     extern int multiplayer_racer10_id;
-    
+
     // Line 526: multiplayer_racer11_id 0x00ea0288 int
     extern int multiplayer_racer11_id;
-    
+
     // Line 527: multiplayer_racer12_id 0x00ea028c int
     extern int multiplayer_racer12_id;
-    
+
     // Line 528: multiplayer_racer13_id 0x00ea0290 int
     extern int multiplayer_racer13_id;
-    
+
     // Line 529: multiplayer_racer14_id 0x00ea0294 int
     extern int multiplayer_racer14_id;
-    
+
     // Line 530: multiplayer_racer15_id 0x00ea0298 int
     extern int multiplayer_racer15_id;
-    
+
     // Line 531: multiplayer_racer16_id 0x00ea029c int
     extern int multiplayer_racer16_id;
-    
+
     // Line 532: multiplayer_racer17_id 0x00ea02a0 int
     extern int multiplayer_racer17_id;
-    
+
     // Line 533: multiplayer_racer18_id 0x00ea02a4 int
     extern int multiplayer_racer18_id;
-    
+
     // Line 534: multiplayer_racer19_id 0x00ea02a8 int
     extern int multiplayer_racer19_id;
-    
+
     // Line 535: multiplayer_racer20_id 0x00ea02ac int
     extern int multiplayer_racer20_id;
-    
+
     // Line 536: multiplayer_track_select 0x00ea02b0 swrRace_TRACK
     extern swrRace_TRACK multiplayer_track_select;
-    
+
     // Line 538: multiplayer_laps 0x00ea02b8 int
     extern int multiplayer_laps;
-    
+
     // Line 540: swrConfig_FORCE_STRENGTH 0x00ec83e0 int
     extern int swrConfig_FORCE_STRENGTH;
-    
+
     // Line 541: swrConfig_FORCE_AUTOCENTER 0x00ec83e4 int
     extern int swrConfig_FORCE_AUTOCENTER;
-    
+
     // Line 542: swrConfig_FORCE_COLLISIONS 0x00ec83e8 int
     extern int swrConfig_FORCE_COLLISIONS;
-    
+
     // Line 543: swrConfig_FORCE_DAMAGE 0x00ec83ec int
     extern int swrConfig_FORCE_DAMAGE;
-    
+
     // Line 544: swrConfig_FORCE_TERRAIN 0x00ec83f0 int
     extern int swrConfig_FORCE_TERRAIN;
-    
+
     // Line 545: swrConfig_FORCE_PODACTIONS 0x00ec83f4 int
     extern int swrConfig_FORCE_PODACTIONS;
-    
+
     // Line 546: swrConfig_FORCE_GFORCES 0x00ec83f8 int
     extern int swrConfig_FORCE_GFORCES;
-    
+
     // Line 547: swrConfig_FORCE_ENGINERUMBLE 0x00ec83fc int
     extern int swrConfig_FORCE_ENGINERUMBLE;
-    
+
     // Line 549: rdCamera_mat 0x00ec8580 rdMatrix34
     extern rdMatrix34 rdCamera_mat;
-    
+
     // Line 551: screen_height 0x00ec85e8 int
     extern int screen_height;
-    
+
     // Line 552: rdCamera_main_ptr 0x00ec85ec rdCamera*
     extern rdCamera* rdCamera_main_ptr;
-    
+
     // Line 554: swrConfig_VIDEO_REFLECTIONS 0x00ec86a0 int
     extern int swrConfig_VIDEO_REFLECTIONS;
-    
+
     // Line 555: swrConfig_VIDEO_ZEFFECTS 0x00ec86a4 int
     extern int swrConfig_VIDEO_ZEFFECTS;
-    
+
     // Line 556: swrConfig_VIDEO_DYNAMIC_LIGHTING 0x00ec86a8 int
     extern int swrConfig_VIDEO_DYNAMIC_LIGHTING;
-    
+
     // Line 557: swrConfig_VIDEO_VSYNC 0x00ec86ac int
     extern int swrConfig_VIDEO_VSYNC;
-    
+
     // Line 558: swrConfig_VIDEO_LENSFLARE 0x00ec86b0 int
     extern int swrConfig_VIDEO_LENSFLARE;
-    
+
     // Line 559: swrConfig_VIDEO_ENGINEEXHAUST 0x00ec86b4 int
     extern int swrConfig_VIDEO_ENGINEEXHAUST;
-    
+
     // Line 560: swrConfig_VIDEO_TEXTURE_RES 0x00ec86b8 int
     extern int swrConfig_VIDEO_TEXTURE_RES;
-    
+
     // Line 561: swrConfig_VIDEO_MODEL_DETAIL 0x00ec86bc int
     extern int swrConfig_VIDEO_MODEL_DETAIL;
-    
+
     // Line 562: swrConfig_VIDEO_DRAWDISTANCE 0x00ec86c0 int
     extern int swrConfig_VIDEO_DRAWDISTANCE;
-    
+
     // Line 563: screen_width 0x00ec86c4 int
     extern int screen_width;
-    
+
     // Line 565: tagRect 0x00ec86d0 tagRECT
     extern tagRECT tagRect;
-    
+
     // Line 567: rdCanvas_main_ptr 0x00ec86e0 rdCanvas*
     extern rdCanvas* rdCanvas_main_ptr;
-    
+
     // Line 569: g_mouse_x 0x00ec874c int
     extern int g_mouse_x;
-    
+
     // Line 570: g_mouse_x2 0x00ec8750 int
     extern int g_mouse_x2;
-    
+
     // Line 572: g_mouse_y 0x00ec8754 int
     extern int g_mouse_y;
-    
+
     // Line 573: g_mouse_y2 0x00ec8754 int
     extern int g_mouse_y2;
-    
+
     // Line 575: Deadzone 0x00ec876c float
     extern float Deadzone;
-    
+
     // Line 577: flip_x_axis 0x00ec8790 int
     extern int flip_x_axis;
-    
+
     // Line 578: flip_y_axis 0x00ec8794 int
     extern int flip_y_axis;
-    
+
     // Line 579: flip_z_axis 0x00ec8798 int
     extern int flip_z_axis;
-    
+
     // Line 581: swrRace_ThrottleInput 0x00ec8830 float
     extern float swrRace_ThrottleInput;
-    
+
     // Line 583: swrRace_PitchInput 0x00ec883c float
     extern float swrRace_PitchInput;
-    
+
     // Line 585: swrRace_ThrustInput 0x00ec884c float
     extern float swrRace_ThrustInput;
-    
+
     // Line 586: swrRace_BoostInput 0x00ec8850 float
     extern float swrRace_BoostInput;
-    
+
     // Line 588: stdPlatfom_FPU1 0x00ec8c80 unsigned short
     extern unsigned short stdPlatfom_FPU1;
-    
+
     // Line 589: stdPlatfom_FPU2 0x00ec8c82 unsigned short
     extern unsigned short stdPlatfom_FPU2;
-    
+
     // Line 590: stdPlatfom_FPU3 0x00ec8c84 unsigned int
     extern unsigned int stdPlatfom_FPU3;
-    
+
     // Line 592: iDirectDrawSurface4_ptr 0x00ec8d00 LPDIRECTDRAWSURFACE4
     extern LPDIRECTDRAWSURFACE4 iDirectDrawSurface4_ptr;
-    
+
     // Line 593: _ddSurfaceDesc2_2 0x00ec8d04 DDSURFACEDESC2
     extern DDSURFACEDESC2 _ddSurfaceDesc2_2;
-    
+
     // Line 595: directDrawVidMemTotal 0x00ec8d80 int;
-    extern int; directDrawVidMemTotal;
-    
+    extern int directDrawVidMemTotal;
+
     // Line 597: stdVBuffer_main 0x00ec8da0 stdVBuffer
     extern stdVBuffer stdVBuffer_main;
-    
+
     // Line 602: swrConfig_nbTokens 0x00ec8e80 int
     extern int swrConfig_nbTokens;
-    
+
     // Line 604: swrConfig_TokenBuffer 0x00ec8e84 char*[0x400]
     extern char* swrConfig_TokenBuffer[0x400];
-    
-    // Line 606: swrConfig_buffer2 0x00ec9e84 char* 
+
+    // Line 606: swrConfig_buffer2 0x00ec9e84 char*
     extern char*  swrConfig_buffer2;
-    
+
     // Line 608: DirectInputJoysticks 0x00ec9ea0 void*
     extern void* DirectInputJoysticks;
-    
+
     // Line 610: DirectInputJoystickGUID 0x00ec9ea4 GUID
     extern GUID DirectInputJoystickGUID;
-    
+
     // Line 612: DirectInputMouses 0x00ecb240 void*
     extern void* DirectInputMouses;
-    
+
     // Line 614: iDirectInputDeviceA_ptr2 0x00ecb484 LPDIRECTINPUTDEVICEA
     extern LPDIRECTINPUTDEVICEA iDirectInputDeviceA_ptr2;
-    
+
     // Line 615: diDevCaps_ptr 0x00ecb488 LPDIDEVCAPS
     extern LPDIDEVCAPS diDevCaps_ptr;
-    
+
     // Line 617: std_output_buffer 0x00ecbc20 char[0x800]
     extern char std_output_buffer[0x800];
-    
+
     // Line 619: stdPlatform_hostServices_ptr 0x00ecc420 HostServices*
     extern HostServices* stdPlatform_hostServices_ptr;
-    
+
     // Line 620: rdroid_hostServices_ptr 0x00ecc428 HostServices*
     extern HostServices* rdroid_hostServices_ptr;
-    
+
     // Line 621: rdCamera_screen_width 0x00ecc42c float
     extern float rdCamera_screen_width;
-    
+
     // Line 623: rdCamera_camMatrix 0x00ecc440 rdMatrix34
     extern rdMatrix34 rdCamera_camMatrix;
-    
+
     // Line 625: nbVertexBuffer1 0x00ecc480
- 
-    extern  nbVertexBuffer1;
-    
+
+    extern int nbVertexBuffer1;
+
     // Line 627: VertexBuffer1 0x00ecc48c rdVector3*
     extern rdVector3* VertexBuffer1;
-    
+
     // Line 629: VertexBuffer1_projected 0x00ecc49c rdVector3*
     extern rdVector3* VertexBuffer1_projected;
-    
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -17,6 +17,19 @@ extern "C"
 {
 #endif
 
+    struct swrModel_unk;
+    struct swrUI_unk;
+    struct swrUI_unk2;
+    struct swr_unk3;
+    struct RdFace;
+    struct swrDisplayMode;
+    struct swrSoundUnk2;
+    struct RdModel3;
+    struct RdPuppet;
+    struct RdPolyline;
+    struct rdSprite3;
+    struct RdParticle;
+
     typedef struct
     {
         union
@@ -32,11 +45,11 @@ extern "C"
         uint8_t data[]; // 0 Pointer which is actually returned
     } Allocation;
 
-    typedef struct tagPOINT
-    {
+    typedef POINT tagPOINT;
+    /*{
         long x;
         long y;
-    } tagPOINT;
+    } tagPOINT;*/
 
     typedef FILE* stdFile_t;
 
@@ -914,6 +927,27 @@ extern "C"
     typedef int (*swrUI_unk_F1)(swrUI_unk* self, int param_2, void* param_3, int param_4);
     typedef int (*swrUI_unk_F2)(swrUI_unk* self, unsigned int param_2, void* param_3, swrUI_unk* param_4);
 
+    typedef struct swrUI_unk2
+    {
+        int flag;
+        int unk0;
+        int id;
+        float unk2;
+        float unk3;
+        int unk31;
+        int unk32;
+        int unk33;
+        int unk34;
+        void* unk35;
+        void* unk36;
+        int unk37;
+        int unk38;
+        char unk4;
+        char unk5;
+        char unk6;
+        char unk7;
+    } swrUI_unk2; // sizeof(0x38) in a [20]
+
     typedef struct swrUI_unk
     {
         swrUI_unk* prev2;
@@ -968,27 +1002,6 @@ extern "C"
         int unk1_50;
         char unk2[4232];
     } swrUI_unk; // sizeof(0x15c0 + unk size)
-
-    typedef struct swrUI_unk2
-    {
-        int flag;
-        int unk0;
-        int id;
-        float unk2;
-        float unk3;
-        int unk31;
-        int unk32;
-        int unk33;
-        int unk34;
-        void* unk35;
-        void* unk36;
-        int unk37;
-        int unk38;
-        char unk4;
-        char unk5;
-        char unk6;
-        char unk7;
-    } swrUI_unk2; // sizeof(0x38) in a [20]
 
     typedef struct swrModel_unk
     {
@@ -1583,6 +1596,23 @@ extern "C"
         float distance;
     } SithSurfaceAdjoin;
 
+    // Indy
+    typedef struct RdFace
+    {
+        int num;
+        RdFaceFlag flags;
+        RdGeometryMode geometryMode;
+        RdLightMode lightingMode;
+        unsigned int numVertices;
+        int* aVertIdxs;
+        int* aTexIdxs;
+        RdMaterial* pMaterial;
+        int matCelNum;
+        rdVector2 texVertOffset;
+        rdVector4 extraLight;
+        rdVector3 normal;
+    } RdFace;
+
     typedef struct SithSurface
     {
         int renderTick;
@@ -1692,8 +1722,37 @@ extern "C"
         unsigned int msecLastFidgetStillMoveTime;
     } SithPuppetState;
 
-    // forward declaration of RdThing
-    typedef struct RdThing RdThing;
+    typedef union RdThingData
+    {
+        RdModel3* pModel3;
+        RdPolyline* pPolyline;
+        rdSprite3* pSprite3;
+        RdParticle* pParticle;
+        rdCamera* pCamera;
+        rdLight* pLight;
+    } RdThingData;
+
+    // Indy
+    // ~= swrUnk3
+    typedef struct RdThing // doesn't seem to match swe1r
+    {
+        RdThingType type;
+        RdThingData data;
+        char unk8[4];
+        char unkc[4];
+        RdPuppet* pPuppet;
+        int bSkipBuildingJoints;
+        int rdFrameNum;
+        rdMatrix34* paJointMatrices;
+        rdVector3* apTweakedAngles;
+        int* paJointAmputationFlags;
+        int matCelNum; // 0x28
+        int geosetNum; // 0x2c
+        char unk30[4];
+        RdLightMode lightMode; // 0x34
+        int frustumCullStatus;
+        SithThing* pThing; // 0x3c
+    } RdThing;
 
     typedef struct SithSpriteInfo
     {
@@ -2126,23 +2185,6 @@ extern "C"
     } SithThing;
 
     // Indy
-    typedef struct RdFace
-    {
-        int num;
-        RdFaceFlag flags;
-        RdGeometryMode geometryMode;
-        RdLightMode lightingMode;
-        unsigned int numVertices;
-        int* aVertIdxs;
-        int* aTexIdxs;
-        RdMaterial* pMaterial;
-        int matCelNum;
-        rdVector2 texVertOffset;
-        rdVector4 extraLight;
-        rdVector3 normal;
-    } RdFace;
-
-    // Indy
     typedef struct rdModel3Mesh
     {
         char name[64];
@@ -2251,16 +2293,6 @@ extern "C"
         rdVector3 insertOffset;
     } RdParticle;
 
-    typedef union RdThingData
-    {
-        RdModel3* pModel3;
-        RdPolyline* pPolyline;
-        rdSprite3* pSprite3;
-        RdParticle* pParticle;
-        rdCamera* pCamera;
-        rdLight* pLight;
-    } RdThingData;
-
     typedef struct RdKeyframeMarker
     {
         float frame;
@@ -2327,28 +2359,6 @@ extern "C"
         RdThing* pThing;
         RdPuppetTrack aTracks[8]; // Jkdf has 4. TODO: Check !
     } RdPuppet;
-
-    // Indy
-    // ~= swrUnk3
-    typedef struct RdThing // doesn't seem to match swe1r
-    {
-        RdThingType type;
-        RdThingData data;
-        char unk8[4];
-        char unkc[4];
-        RdPuppet* pPuppet;
-        int bSkipBuildingJoints;
-        int rdFrameNum;
-        rdMatrix34* paJointMatrices;
-        rdVector3* apTweakedAngles;
-        int* paJointAmputationFlags;
-        int matCelNum; // 0x28
-        int geosetNum; // 0x2c
-        char unk30[4];
-        RdLightMode lightMode; // 0x34
-        int frustumCullStatus;
-        SithThing* pThing; // 0x3c
-    } RdThing;
 
     typedef struct rdPrimit3
     {

--- a/src/types_directx.h
+++ b/src/types_directx.h
@@ -19,13 +19,13 @@
 // and https://github.com/apitrace/dxsdk/blob/master/Include/ddraw.h
 //
 
-typedef struct tagRECT
+/*typedef struct tagRECT
 {
     LONG left;
     LONG top;
     LONG right;
     LONG bottom;
-} RECT, *PRECT;
+} RECT, *PRECT;*/
 
 typedef int WINBOOL;
 typedef WINBOOL(__attribute__((__stdcall__)) * LPDDENUMCALLBACKA)(GUID*, LPSTR, LPSTR, LPVOID);

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -11,9 +11,9 @@ typedef enum rdTexFormatMode
 // Indy stdDisplay_SetMode
 typedef enum tColorMode // i32
 {
-    STDCOLOR_PAL = 0x0,
-    STDCOLOR_RGB = 0x1,
-    STDCOLOR_RGBA = 0x2,
+    T_STDCOLOR_PAL = 0x0,
+    T_STDCOLOR_RGB = 0x1,
+    T_STDCOLOR_RGBA = 0x2,
 } tColorMode;
 
 typedef enum StdColorFormatType


### PR DESCRIPTION
I have updated the scripts to make the base code compile, using a default g++ compiler on Windows 11

Main fixes:

1) there were a lot of missing forward declarations, rearranged things to remove issues with no definition, or partial types being used not as pointers before declaration
2) -fpermissive was required on the compiler
3) roll/pitch/yaw on on tr_rot is all one variable (an rdVector3) convert those
4) UUID vs GUID issues
5) incorrectly generated globals
6) some redefined types that are included by existing headers
