### PR TITLE
Fix multiplayer compile errors under cmake

### DIFF
--- a/src/Swr/swrMultiplayer.c
+++ b/src/Swr/swrMultiplayer.c
@@ -3,8 +3,8 @@
 #include "globals.h"
 #include "macros.h"
 
-#include <stdComm.h>
-#include <sithMulti.h>
+#include <Win95/stdComm.h>
+#include <Dss/sithMulti.h>
 
 // 0x00412640
 void swrMultiplayer_SetInMultiplayer(int bInMultiplayer)


### PR DESCRIPTION
Most files when referencing other headers use #include <Folder/header.h>. This was changed in the latest update for this file to include raw header includes

Use this style over including all headers in the cmake build, unless the intention is to change to this style everywhere