### PR TITLE
Decompile swrText_CreateEntry

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -345,6 +345,9 @@ swrTextEntries1Count 0x0050c750 int # < 0x80
 
 swrTextEntries2Count 0x0050c758 int # < 0x20
 
+swrTextFmtString1 0x004b2304 char[4] = "%s\0\0"
+swrTextFmtString2 0x004c3e48 char[8] = "~f%d%s\0\0"
+
 rdMatrixStack34_size 0x0050c6f4 int
 
 debug_showSurfaceFlags 0x0050c88c int

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -84,13 +84,62 @@ char* swrText_Translate(char* text)
     return NULL;
 }
 
-// 0x004503e0
-void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char* screenText, int formatInt, int isEntry2)
-{
-    HANG("TODO, easy");
+// 0x0049eb80
+int swrText_Sprintf(char *str, const char *format, ...) {
+    HANG("TODO");
+    return 0;
 }
 
-// 0x00450530
+// 0x004503e0 HOOK
+void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char* screenText, int formatInt, int isEntry2)
+{
+    if (isEntry2 == 0)
+    {
+        if (swrTextEntries1Count < 128)
+        {
+            if (formatInt < 0)
+            {
+                // DAT_004b2304 = "%s"
+                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],"%s%s",screenText);
+            }
+            else
+            {
+                // DAT_004c3e48 = "~f%d%s"
+                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count], "~f%d%s", formatInt, screenText);
+            }
+            swrTextEntries1Pos[swrTextEntries1Count][0] = x;
+            swrTextEntries1Pos[swrTextEntries1Count][1] = y;
+            swrTextEntries1Colors[swrTextEntries1Count][0] = r;
+            swrTextEntries1Colors[swrTextEntries1Count][1] = g;
+            swrTextEntries1Colors[swrTextEntries1Count][2] = b;
+            swrTextEntries1Colors[swrTextEntries1Count][3] = a;
+            swrTextEntries1Count = swrTextEntries1Count + 1;
+            return;
+        }
+    }
+    else if (swrTextEntries2Count < 32)
+    {
+        if (formatInt < 0)
+        {
+            // DAT_004b2304 = "%s"
+            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],"%s",screenText);
+        }
+        else
+        {
+            // DAT_004c3e48 = "~f%d%s"
+            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count], "~f%d%s", formatInt, screenText);
+        }
+        swrTextEntries2Pos[swrTextEntries2Count][0] = x;
+        swrTextEntries2Pos[swrTextEntries2Count][1] = y;
+        swrTextEntries2Colors[swrTextEntries2Count][0] = r;
+        swrTextEntries2Colors[swrTextEntries2Count][1] = g;
+        swrTextEntries2Colors[swrTextEntries2Count][2] = b;
+        swrTextEntries2Colors[swrTextEntries2Count][3] = a;
+        swrTextEntries2Count = swrTextEntries2Count + 1;
+    }
+}
+
+// 0x00450530 HOOK
 void swrText_CreateTextEntry1(int x, int y, int r, int g, int b, int a, char* screenText)
 {
     swrText_CreateEntry(x, y, r, g, b, a, screenText, -1, 0);

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -5,6 +5,8 @@
 
 #include <macros.h>
 
+#include <stdio.h>
+
 // 0x00407b00
 char* swrText_GetKeyNameText(int id, char* str)
 {
@@ -84,12 +86,6 @@ char* swrText_Translate(char* text)
     return NULL;
 }
 
-// 0x0049eb80
-int swrText_Sprintf(char *str, const char *format, ...) {
-    HANG("TODO");
-    return 0;
-}
-
 // 0x004503e0 HOOK
 void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char* screenText, int formatInt, int isEntry2)
 {
@@ -100,12 +96,12 @@ void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char*
             if (formatInt < 0)
             {
                 // DAT_004b2304 = "%s"
-                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],swrTextFmtString1,screenText);
+                sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],swrTextFmtString1,screenText);
             }
             else
             {
                 // DAT_004c3e48 = "~f%d%s"
-                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],swrTextFmtString2,formatInt, screenText);
+                sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],swrTextFmtString2,formatInt, screenText);
             }
             swrTextEntries1Pos[swrTextEntries1Count][0] = x;
             swrTextEntries1Pos[swrTextEntries1Count][1] = y;
@@ -122,12 +118,12 @@ void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char*
         if (formatInt < 0)
         {
             // DAT_004b2304 = "%s"
-            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],swrTextFmtString1,screenText);
+            sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],swrTextFmtString1,screenText);
         }
         else
         {
             // DAT_004c3e48 = "~f%d%s"
-            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],swrTextFmtString2, formatInt, screenText);
+            sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],swrTextFmtString2, formatInt, screenText);
         }
         swrTextEntries2Pos[swrTextEntries2Count][0] = x;
         swrTextEntries2Pos[swrTextEntries2Count][1] = y;

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -100,12 +100,12 @@ void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char*
             if (formatInt < 0)
             {
                 // DAT_004b2304 = "%s"
-                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],"%s%s",screenText);
+                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],swrTextFmtString1,screenText);
             }
             else
             {
                 // DAT_004c3e48 = "~f%d%s"
-                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count], "~f%d%s", formatInt, screenText);
+                swrText_Sprintf((char*)&swrTextEntries1Text[swrTextEntries1Count],swrTextFmtString2,formatInt, screenText);
             }
             swrTextEntries1Pos[swrTextEntries1Count][0] = x;
             swrTextEntries1Pos[swrTextEntries1Count][1] = y;
@@ -122,12 +122,12 @@ void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char*
         if (formatInt < 0)
         {
             // DAT_004b2304 = "%s"
-            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],"%s",screenText);
+            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],swrTextFmtString1,screenText);
         }
         else
         {
             // DAT_004c3e48 = "~f%d%s"
-            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count], "~f%d%s", formatInt, screenText);
+            swrText_Sprintf((char*)&swrTextEntries2Text[swrTextEntries2Count],swrTextFmtString2, formatInt, screenText);
         }
         swrTextEntries2Pos[swrTextEntries2Count][0] = x;
         swrTextEntries2Pos[swrTextEntries2Count][1] = y;

--- a/src/Swr/swrText.h
+++ b/src/Swr/swrText.h
@@ -12,6 +12,7 @@
 #define swrText_Shutdown_ADDR (0x00421330)
 #define swrText_Translate_ADDR (0x00421360)
 
+#define swrText_Sprintf_ADDR (0x0049eb80)
 #define swrText_CreateEntry_ADDR (0x004503e0)
 
 #define swrText_CreateTextEntry1_ADDR (0x00450530)
@@ -37,6 +38,7 @@ int swrText_CmpRacerTab(char** a, char** b);
 void swrText_Shutdown(void);
 char* swrText_Translate(char* text);
 
+int swrText_Sprintf(char *str, const char *format, ...);
 void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char* screenText, int formatInt, int isEntry2);
 
 void swrText_CreateTextEntry1(int x, int y, int r, int g, int b, int a, char* screenText);

--- a/src/Swr/swrText.h
+++ b/src/Swr/swrText.h
@@ -12,7 +12,6 @@
 #define swrText_Shutdown_ADDR (0x00421330)
 #define swrText_Translate_ADDR (0x00421360)
 
-#define swrText_Sprintf_ADDR (0x0049eb80)
 #define swrText_CreateEntry_ADDR (0x004503e0)
 
 #define swrText_CreateTextEntry1_ADDR (0x00450530)

--- a/src/Swr/swrText.h
+++ b/src/Swr/swrText.h
@@ -38,7 +38,6 @@ int swrText_CmpRacerTab(char** a, char** b);
 void swrText_Shutdown(void);
 char* swrText_Translate(char* text);
 
-int swrText_Sprintf(char *str, const char *format, ...);
 void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char* screenText, int formatInt, int isEntry2);
 
 void swrText_CreateTextEntry1(int x, int y, int r, int g, int b, int a, char* screenText);


### PR DESCRIPTION
Provide an implementation of swrText_CreateEntry (0x004503e0) and identify child function as a custom sprintf implementation, dubbed as "swrText_Sprintf"

Implement format strings as constants as they are present in the system memory like this being reused