### PR TITLE
Custom track fixes

### DIFF
--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -207,6 +207,11 @@ swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
         id,
     };
 
+    // setting this to 0 skips the generation of the renderDroid scene graph in the RenderAll
+    // functions. it's not needed since the renderer replacement uses the swrModel_Node scene graph #
+    // directly.
+    assetBufferModelLoaded = 0;
+
     return header;
 }
 

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -1,0 +1,58 @@
+#include <macros.h>
+#include "swrObjJdge_delta.h"
+
+extern "C" {
+#include <Swr/swrObj.h>
+#include <globals.h>
+
+extern FILE* hook_log;
+}
+
+#include "../hook_helper.h"
+
+int fixup_invalid_node_ptrs(swrModel_Node *&node) {
+    if (!node)
+        return 0;
+
+    switch (node->type) {
+        case NODE_MESH_GROUP:
+            break;
+        case NODE_BASIC:
+            break;
+        case NODE_SELECTOR:
+            break;
+        case NODE_LOD_SELECTOR:
+            break;
+        case NODE_TRANSFORMED:
+            break;
+        case NODE_TRANSFORMED_WITH_PIVOT:
+            break;
+        case NODE_TRANSFORMED_COMPUTED:
+            break;
+        default:
+            // this model type is invalid, set it to null.
+            node = nullptr;
+            return 1;
+    }
+
+    int num_removed_nodes = 0;
+    if (node->type & NODE_HAS_CHILDREN) {
+        for (int i = 0; i < node->num_children; i++)
+            num_removed_nodes += fixup_invalid_node_ptrs(node->children.nodes[i]);
+    }
+    return num_removed_nodes;
+}
+
+// TODO hack: this is a workaround for a crash when loading custom tracks. sometimes the scene graph
+//  contains nodes with invalid child pointers, this happens after playing a vanilla track and
+//  afterwards a custom track. can be reproduced playing "Spice Mine Run" and then "Bowsers Castle 1".
+unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore *scores) {
+    const unsigned int x = hook_call_original(swrObjJdge_InitTrack, judge, scores);
+    const int num_removed_nodes = fixup_invalid_node_ptrs(swrViewport_array[0].model_root_node);
+    if (num_removed_nodes != 0)
+    {
+        fprintf(hook_log, "[swrObjJdge_InitTrack_delta] HACK: removed %d nodes with an invalid node type.\n", num_removed_nodes);
+        fflush(hook_log);
+    }
+    return x;
+}

--- a/dinput_hook/game_deltas/swrObjJdge_delta.h
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "types.h"
+
+unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore * scores);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1080,18 +1080,6 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) swrSpline_LoadSplineById_ADDR);
     hook_replace(swrSpline_LoadSplineById, swrSpline_LoadSplineById_delta);
 
-    fprintf(hook_log, "Patching memory addresses\n");
-    fflush(hook_log);
-
-    patchMemoryAccess(0x0045b437 + 2,
-                      ((uint8_t *) g_aNewTrackInfos) + offsetof(TrackInfo, trackID));
-    patchMemoryAccess(0x0045b42d + 2,
-                      ((uint8_t *) g_aNewTrackInfos) + offsetof(TrackInfo, splineID));
-    patchMemoryAccess(0x0045b426 + 3,
-                      ((uint8_t *) g_aNewTrackInfos) + offsetof(TrackInfo, PlanetIdx));
-    patchMemoryAccess(0x0045b441 + 3,
-                      ((uint8_t *) g_aNewTrackInfos) + offsetof(TrackInfo, planetTrackNumber));
-
     fprintf(hook_log, "Done\n");
     fflush(hook_log);
 }

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include "./game_deltas/stdConsole_delta.h"
 #include "./game_deltas/swrModel_delta.h"
 #include "./game_deltas/swrSpline_delta.h"
+#include "./game_deltas/swrObjJdge_delta.h"
 
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
@@ -1066,6 +1067,9 @@ extern "C" void init_renderer_hooks() {
 
     hook_function("swrObjHang_InitTrackSprites", (uint32_t) swrObjHang_InitTrackSprites_ADDR,
                   (uint8_t *) swrObjHang_InitTrackSprites_delta);
+    hook_function("swrObjJdge_InitTrack", (uint32_t) swrObjJdge_InitTrack,
+                  (uint8_t *) swrObjJdge_InitTrack_ADDR);
+    hook_replace(swrObjJdge_InitTrack, swrObjJdge_InitTrack_delta);
 
     hook_function("swrRace_CourseSelectionMenu", (uint32_t) swrRace_CourseSelectionMenu_ADDR,
                   (uint8_t *) swrRace_CourseSelectionMenu_delta);

--- a/dinput_hook/replacements.cpp
+++ b/dinput_hook/replacements.cpp
@@ -604,7 +604,7 @@ void load_replacement_if_missing(MODELID model_id) {
 
         std::string filename;
         // Custom track, use folder to search for replacement model
-        if (currentCustomTrack.has_value() && model_id > CUSTOM_TRACK_MODELID_BEGIN) {
+        if (currentCustomTrack.has_value()) {
             std::filesystem::path lastDir = currentCustomTrack.value().folder.lexically_normal();
             if (lastDir.has_filename()) {
                 lastDir = lastDir.filename();

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -368,6 +368,12 @@ void InitAISettingsForTrack(swrObjJdge*)
     HANG("TODO");
 }
 
+// 0x00466BD0
+unsigned int swrObjJdge_InitTrack(swrObjJdge* judge, swrScore* scores)
+{
+    HANG("TODO");
+}
+
 // 0x00467cd0
 void swrObjElmo_F0(swrObjElmo* elmo)
 {

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -89,6 +89,8 @@
 
 #define InitAISettingsForTrack_ADDR (0x004667E0)
 
+#define swrObjJdge_InitTrack_ADDR (0x00466BD0)
+
 #define swrObjElmo_F0_ADDR (0x00467cd0)
 
 #define swrObjElmo_F3_ADDR (0x00468570)
@@ -237,6 +239,8 @@ void LoadTrackSpline(swrObjJdge*);
 void InitPrimaryLight();
 
 void InitAISettingsForTrack(swrObjJdge*);
+
+unsigned int swrObjJdge_InitTrack(swrObjJdge* judge, swrScore* scores);
 
 void swrObjElmo_F0(swrObjElmo* elmo);
 


### PR DESCRIPTION
this is a workaround for the crash when loading custom tracks after vanilla tracks. the workaround is in swrObjJdge_InitTrack_delta. 

theres also another small fix for a bug in the load_replacement_if_missing function