### PR TITLE
disable glfw dinput replacement for now to make gamepads work correctly.

### DIFF
--- a/dinput_hook/CMakeLists.txt
+++ b/dinput_hook/CMakeLists.txt
@@ -42,6 +42,7 @@ if (NOT USE_RELEASE_HOOK)
         ${HOOK_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/generated/hook_generated.c
     )
+    target_compile_definitions(dinput_hook PRIVATE ENABLE_GLFW_INPUT_HANDLING=0)
     target_link_libraries(dinput_hook PRIVATE swe1r_functions swe1r_globals imgui kernel32  Dwmapi dxguid detours ddraw opengl32 glad glfw fastgltf)
     target_link_options(dinput_hook PRIVATE "-Wl,--kill-at")
 

--- a/dinput_hook/game_deltas/Window_delta.c
+++ b/dinput_hook/game_deltas/Window_delta.c
@@ -176,8 +176,10 @@ static void key_callback(GLFWwindow *window, int key, int scancode, int action, 
 
     const bool pressed = action != GLFW_RELEASE;
 
+#if ENABLE_GLFW_INPUT_HANDLING
     stdControl_aKeyInfos[dik_key] = pressed;
     stdControl_g_aKeyPressCounter[dik_key] += pressed;
+#endif
 
     UINT vk = MapVirtualKeyA(dik_key, MAPVK_VSC_TO_VK);
     if (vk == 0) {
@@ -203,9 +205,11 @@ static void key_callback(GLFWwindow *window, int key, int scancode, int action, 
 }
 
 static void mouse_button_callback(GLFWwindow *window, int button, int action, int mods) {
+#if ENABLE_GLFW_INPUT_HANDLING
     const bool pressed = action != GLFW_RELEASE;
     stdControl_aKeyInfos[512 + button] = pressed;
     stdControl_g_aKeyPressCounter[512 + button] += pressed;
+#endif
 }
 
 extern FILE *hook_log;
@@ -381,6 +385,11 @@ int Window_Main_delta(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLin
 
     while (!glfwWindowShouldClose(window)) {
         swrMain2_GuiAdvance();
+#if !ENABLE_GLFW_INPUT_HANDLING
+        // if glfw input handling is enabled, glfwPollEvents is called in stdControl_ReadControls
+        // instead. this is important for the timing of the input state.
+        glfwPollEvents();
+#endif
     }
 
     return 0;

--- a/dinput_hook/game_deltas/stdControl_delta.c
+++ b/dinput_hook/game_deltas/stdControl_delta.c
@@ -1,3 +1,4 @@
+#if ENABLE_GLFW_INPUT_HANDLING
 #include "stdControl_delta.h"
 
 #include "globals.h"
@@ -36,3 +37,4 @@ int stdControl_SetActivation_delta(int bActive) {
 
     return 0;
 }
+#endif

--- a/dinput_hook/game_deltas/stdControl_delta.h
+++ b/dinput_hook/game_deltas/stdControl_delta.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if ENABLE_GLFW_INPUT_HANDLING
 #include "types.h"
 
 int stdControl_Startup_delta(void);
@@ -7,3 +8,4 @@ int stdControl_Startup_delta(void);
 void stdControl_ReadControls_delta(void);
 
 int stdControl_SetActivation_delta(int bActive);
+#endif

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -961,6 +961,7 @@ extern "C" void init_renderer_hooks() {
     hook_function("std3D_PurgeTextureCache", (uint32_t) 0x0048bb50,
                   (uint8_t *) std3D_PurgeTextureCache_delta);
 
+#if ENABLE_GLFW_INPUT_HANDLING
     // stdControl
     hook_function("stdControl_Startup", (uint32_t) 0x00485360,
                   (uint8_t *) stdControl_Startup_delta);
@@ -968,6 +969,7 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) stdControl_ReadControls_delta);
     hook_function("stdControl_SetActivation", (uint32_t) 0x00485a30,
                   (uint8_t *) stdControl_SetActivation_delta);
+#endif
 
     // swrDisplay
     hook_function("swrDisplay_SetWindowSize", (uint32_t) 0x004238a0,


### PR DESCRIPTION
i tried to add gamepad support to the stdControl dinput replacement functions. this did work, but the joystick mappings menu is broken and cannot be used properly. this is why i disabled the dinput replacement for now. 

this means that gamepads should work normally now. 