### PR TITLE
swrSprite: add ResetAllSprites + SetPosF, backfill 2 names, fix mismatch

### DIFF
--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -135,7 +135,7 @@ void swrSprite_GetTextureDimFromId(swrSprite_NAME spriteId, int* out_width, int*
 }
 
 // 0x00417090
-void swrSprite_FreeSprites(void)
+void swrSprite_FreeSpritesMaterials(void)
 {
     swrSpriteTexItem* texItems;
     uint32_t* page_offset;

--- a/src/Swr/swrSprite.h
+++ b/src/Swr/swrSprite.h
@@ -19,21 +19,27 @@
 
 #define swrSprite_LoadFromId_ADDR (0x00412e90)
 
+#define swrSprite_CreateFromTextureId_ADDR (0x00412f20)
+
 #define swrSprite_ClearSprites_ADDR (0x00412f60)
 
 #define swrSprite_AssignTextureToId_ADDR (0x00416fd0)
 
 #define swrSprite_GetTextureFromId_ADDR (0x00417010)
 
+#define swrSprite_FindFreeId_ADDR (0x00417040)
+
 #define swrSprite_GetTextureDimFromId_ADDR (0x00417120)
 
-#define swrSprite_FreeSprites_ADDR (0x00417090)
+#define swrSprite_FreeSpritesMaterials_ADDR (0x00417090)
 
 #define swrSprite_GetBBoxFromId_ADDR (0x00417150)
 
 #define swrSprite_MoveBBoxTo_ADDR (0x00417900)
 
 #define swrSprite_NewSprite_ADDR (0x004282f0)
+
+#define swrSprite_ResetAllSprites_ADDR (0x00428370)
 
 #define swrSprite_SetVisible_ADDR (0x004285d0)
 
@@ -46,6 +52,8 @@
 #define swrSprite_SetFlag_ADDR (0x004287e0)
 
 #define swrSprite_UnsetFlag_ADDR (0x00428800)
+
+#define swrSprite_SetPosF_ADDR (0x0042bb00)
 
 #define swrSprite_UpperPowerOfTwo_ADDR (0x00445c90)
 #define swrSprite_LoadTexture_ADDR (0x00446ca0)
@@ -67,11 +75,15 @@ void swrSprite_UnloadAllSprites(void);
 
 int swrSprite_LoadFromId(SPRTID id, char* tga_file_optional);
 
+int swrSprite_CreateFromTextureId(int textureId);
+
 void swrSprite_ClearSprites(swrUI_unk* swrui_unk);
 
 void swrSprite_AssignTextureToId(swrSpriteTexture* spriteTex, int id, int from_tga);
 
 swrSpriteTexture* swrSprite_GetTextureFromId(int id);
+
+int swrSprite_FindFreeId(void);
 
 void swrSprite_GetTextureDimFromId(swrSprite_NAME spriteId, int* out_width, int* out_height);
 
@@ -82,6 +94,8 @@ void swrSprite_GetBBoxFromId(swrSprite_NAME spriteId, swrSprite_BBox* box);
 void swrSprite_MoveBBoxTo(swrSprite_BBox* box, int newX, int newY);
 
 void swrSprite_NewSprite(short id, swrSpriteTexture* tex);
+
+void swrSprite_ResetAllSprites(void);
 
 void swrSprite_SetVisible(short id, int visible);
 
@@ -94,6 +108,8 @@ void swrSprite_SetColor(short id, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 void swrSprite_SetFlag(short id, unsigned int flag);
 
 void swrSprite_UnsetFlag(short id, unsigned int flag);
+
+void swrSprite_SetPosF(short id, float x, float y);
 
 int swrSprite_UpperPowerOfTwo(int x);
 


### PR DESCRIPTION
Cleanup and additions in `src/Swr/swrSprite.h` driven by Ghidra analysis (using Claude).

New names
- `swrSprite_ResetAllSprites @ 0x00428370` — calls `UnloadAllSprites`, re-initializes
  every active sprite slot via `NewSprite(i, NULL)`, then zeroes `SpriteCount`. Used
  as the first step of race-setup sprite loading (e.g. caller `FUN_00464630`).
- `swrSprite_SetPosF @ 0x0042bb00` — float-arg wrapper around `swrSprite_SetPos`;
  converts via `__ftol` and forwards. Used from HUD/rearview code that already
  has screen coords as floats.

Backfilled to header (already named in Ghidra)
- `swrSprite_FindFreeId @ 0x00417040`
- `swrSprite_CreateFromTextureId @ 0x00412f20`

Consistency fix
- `swrSprite_FreeSprites_ADDR` → `swrSprite_FreeSpritesMaterials_ADDR` so the
  `_ADDR` macro matches the prototype (both now `swrSprite_FreeSpritesMaterials`).
- Same rename applied to the WIP definition in `swrSprite.c:138`. Note: `swrSprite.c`
  isn't in `compile.bat`'s source list, so this is staging-only — no build impact.