### PR TITLE
swrSprite: add CreateFromTextureId, FindFreeId, SetPosF declarations

### DIFF
--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -1251,12 +1251,6 @@ void swrSprite_UpdateLensFlareSpriteSettings(int16_t id, int a2, int a3, float a
     HANG("TODO");
 }
 
-// 0x0042BB00
-void swrSprite_SetScreenPos(int16_t id, int16_t x, int16_t y)
-{
-    HANG("TODO");
-}
-
 // 0x0042BE60
 void UpdateDepthValuesOfSpritesWithZBuffer()
 {

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -34,7 +34,6 @@
 #define swrModel_NodeSetColorsOnAllMaterials_ADDR (0x0042B640)
 #define ProjectPointOntoScreen_ADDR (0x0042B710)
 #define swrSprite_UpdateLensFlareSpriteSettings_ADDR (0x0042BA20)
-#define swrSprite_SetScreenPos_ADDR (0x0042BB00)
 #define UpdateSunAndLensFlareSprites2_ADDR (0x0042BB50)
 #define UpdateDepthValuesOfSpritesWithZBuffer_ADDR (0x42BE60)
 #define UpdateSunAndLensFlareSprites_ADDR (0x0042C1A0)
@@ -159,7 +158,6 @@ void swrModel_MeshMaterialSetColors(swrModel_MeshMaterial* a1, int16_t a2, int16
 void swrModel_NodeSetColorsOnAllMaterials(swrModel_Node* a1_pJdge0x10, int a2, int a3, int a4, int a5_G, int a6, int a7);
 void ProjectPointOntoScreen(swrViewport* arg0, rdVector3* position, float* pixel_pos_x, float* pixel_pos_y, float* pixel_depth, float* pixel_w, bool position_is_global);
 void swrSprite_UpdateLensFlareSpriteSettings(int16_t id, int a2, int a3, float a4, float width, float a6, uint8_t r, uint8_t g, uint8_t b);
-void swrSprite_SetScreenPos(int16_t id, int16_t x, int16_t y);
 void UpdateSunAndLensFlareSprites2(int a1, int a2, int a3);
 void UpdateDepthValuesOfSpritesWithZBuffer();
 void UpdateSunAndLensFlareSprites(swrViewport* a1);

--- a/src/Swr/swrSprite.h
+++ b/src/Swr/swrSprite.h
@@ -19,11 +19,15 @@
 
 #define swrSprite_LoadFromId_ADDR (0x00412e90)
 
+#define swrSprite_CreateFromTextureId_ADDR (0x00412f20)
+
 #define swrSprite_ClearSprites_ADDR (0x00412f60)
 
 #define swrSprite_AssignTextureToId_ADDR (0x00416fd0)
 
 #define swrSprite_GetTextureFromId_ADDR (0x00417010)
+
+#define swrSprite_FindFreeId_ADDR (0x00417040)
 
 #define swrSprite_GetTextureDimFromId_ADDR (0x00417120)
 
@@ -56,6 +60,8 @@
 #define swrSprite_SetColor_ADDR (0x00428740)
 #define swrSprite_SetFlag_ADDR (0x004287e0)
 #define swrSprite_UnsetFlag_ADDR (0x00428800)
+
+#define swrSprite_SetPosF_ADDR (0x0042bb00)
 
 #define swrSprite_setCurrentTextPos_ADDR (0x0042D910)
 #define swrSprite_getCurrentTextPos_ADDR (0x0042D930)
@@ -102,11 +108,15 @@ void swrSprite_UnloadAllSprites(void);
 
 int swrSprite_LoadFromId(swrSprite_NAME id, char* tga_file_optional);
 
+int swrSprite_CreateFromTextureId(int textureId);
+
 void swrSprite_ClearSprites(swrUI_unk* swrui_unk);
 
 void swrSprite_AssignTextureToId(swrSpriteTexture* spriteTex, int id, int from_tga);
 
 swrSpriteTexture* swrSprite_GetTextureFromId(int id);
+
+int swrSprite_FindFreeId(void);
 
 void swrSprite_GetTextureDimFromId(swrSprite_NAME spriteId, int* out_width, int* out_height);
 
@@ -139,6 +149,8 @@ void swrSprite_SetRotation(short id, float);
 void swrSprite_SetColor(short id, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 void swrSprite_SetFlag(short id, unsigned int flag);
 void swrSprite_UnsetFlag(short id, unsigned int flag);
+
+void swrSprite_SetPosF(short id, float x, float y);
 
 int16_t swrSprite_setCurrentTextPos(int16_t, int16_t);
 short swrSprite_getCurrentTextPos(int16_t*, int16_t*);


### PR DESCRIPTION
Adds three newly-identified function addresses and prototypes:
- swrSprite_CreateFromTextureId @ 0x00412f20
- swrSprite_FindFreeId          @ 0x00417040
- swrSprite_SetPosF             @ 0x0042bb00