### PR TITLE
Document weather/HUD/viewport subsystems

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1230,3 +1230,15 @@ rdModel3_g_numDrawnAlphaFaces 0x00ecc474 int # unused
 VertexBuffer1 0x00ecc48c rdVector3*
 
 VertexBuffer1_projected 0x00ecc49c rdVector3*
+
+# swrWeather particle effect (rain/snow/dust) -- see src/Swr/swrWeather.h
+swrWeather_enabled 0x004b9520 int
+swrWeather_particleColor 0x004b9524 uint8_t[4]
+swrWeather_velocityX 0x004b9528 float
+swrWeather_velocityY 0x004b952c float
+swrWeather_stretchFactor 0x004b9530 float
+swrWeather_particleCap 0x004b9534 int
+swrWeather_particlePositions 0x00e99860 rdVector3[80]
+swrWeather_particleScreenPositions 0x00e9a000 rdVector2[80]
+swrWeather_particleSpriteIds 0x00e9a280 int[80]
+swrWeather_particleStates 0x00e9a960 char[80]

--- a/src/Swr/swrLoader.c
+++ b/src/Swr/swrLoader.c
@@ -8,7 +8,7 @@
 #include <macros.h>
 
 // 0x0042D520
-void swrLoader_DecompressData(char* compressed, char* decompressed)
+void swrLoader_DecompressLZSS(char* compressed, char* decompressed)
 {
     HANG("TODO");
 }

--- a/src/Swr/swrLoader.h
+++ b/src/Swr/swrLoader.h
@@ -4,13 +4,13 @@
 #include <stdio.h>
 #include "types.h"
 
-#define swrLoader_DecompressData_ADDR (0x0042D520)
+#define swrLoader_DecompressLZSS_ADDR (0x0042D520)
 #define swrLoader_TypeToFile_ADDR (0x0042d600)
 #define swrLoader_ReadAt_ADDR (0x0042d640)
 #define swrLoader_OpenBlock_ADDR (0x0042d680)
 #define swrLoader_CloseBlock_ADDR (0x0042d6f0)
 
-void swrLoader_DecompressData(char* compressed, char* decompressed);
+void swrLoader_DecompressLZSS(char* compressed, char* decompressed);
 FILE** swrLoader_TypeToFile(swrLoader_TYPE type);
 size_t swrLoader_ReadAt(swrLoader_TYPE type, long _Offset, void* _DstBuf, size_t _ElementSize);
 void swrLoader_OpenBlock(swrLoader_TYPE type);

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -96,7 +96,7 @@ swrModel_Header* swrModel_LoadFromId(MODELID id)
         if (decompressed_size + 8 <= swrAssetBuffer_RemainingSize() && compressed_data_buff >= (char*)model_buff + decompressed_size)
         {
             swrLoader_ReadAt(swrLoader_TYPE_MODEL_BLOCK, offsets.model_offset + 12, compressed_data_buff, model_size - 12);
-            swrLoader_DecompressData(compressed_data_buff, (char*)model_buff);
+            swrLoader_DecompressLZSS(compressed_data_buff, (char*)model_buff);
             swrAssetBuffer_SetBuffer((char*)model_buff + decompressed_size);
         }
         else

--- a/src/Swr/swrPlayerHUD.h
+++ b/src/Swr/swrPlayerHUD.h
@@ -7,7 +7,7 @@
 //
 // Call graph per frame:
 //   swrPlayerHUD_RenderAllViewports (the per-frame render loop, from FUN_00445980)
-//     -> swrViewport_Activate / swrViewport_Setup  (per viewport, see swrViewport.h)
+//     -> swrViewport_SetCurrent / swrViewport_UpdateViewTransforms  (per viewport, see swrViewport.h)
 //     -> swrPlayerHUD_RenderViewport(viewport, secondaryPass)
 //          if (DAT_004b94c0)  // HUD orchestrator enable, set by swrPlayerHUD_Enable
 //              -> FUN_0042c1a0            (target indicators -- not yet named)
@@ -47,7 +47,7 @@
 
 // swrPlayerHUD_SampleOcclusion is called once per frame at the start of the
 // render phase (from FUN_00445980, before the per-viewport render loop). It
-// locks the back buffer via DirectDraw_LockMainSurface and samples raw pixel
+// locks the back buffer via DirectDraw_LockZBuffer and samples raw pixel
 // data around every HUD marker's projected screen position to detect
 // occlusion by world geometry. The resulting "coverage" counts are stored at
 // DAT_00e9a3c0 (target indicators), DAT_00e9a7e0 (distance text labels),

--- a/src/Swr/swrPlayerHUD.h
+++ b/src/Swr/swrPlayerHUD.h
@@ -1,0 +1,93 @@
+#ifndef SWRPLAYERHUD_H
+#define SWRPLAYERHUD_H
+
+#include "types.h"
+
+// Per-player split-screen HUD/overlay subsystem.
+//
+// Call graph per frame:
+//   swrPlayerHUD_RenderAllViewports (the per-frame render loop, from FUN_00445980)
+//     -> swrViewport_Activate / swrViewport_Setup  (per viewport, see swrViewport.h)
+//     -> swrPlayerHUD_RenderViewport(viewport, secondaryPass)
+//          if (DAT_004b94c0)  // HUD orchestrator enable, set by swrPlayerHUD_Enable
+//              -> FUN_0042c1a0            (target indicators -- not yet named)
+//              -> swrPlayerHUD_RenderRearview
+//              -> swrPlayerHUD_RenderWorldSprites
+//              -> swrWeather_RenderParticles   (see swrWeather.h)
+//              -> swrPlayerHUD_RenderDistanceText
+//          else only RenderDistanceText runs.
+//
+// Race HUD setup (at track load):
+//   swrPlayerHUD_LoadRaceHUD  -> swrSprite_ResetAllSprites, loads speedometer / engine /
+//     starting-grid / flag sprites, then -> swrPlayerHUD_SetupTrackOverlay, which loads
+//     the per-track HUD elements AND configures weather (swrWeather_Enable/SetColor/
+//     SetVelocity/SetParticleCap/SetStretchFactor) based on the track/weather scenario.
+//
+// swrPlayerHUD_SampleOcclusion runs once per frame before the loop (also from
+// FUN_00445980); it CPU-reads the back buffer for HUD-marker occlusion -- see the
+// high-resolution caveat below and the fuller analysis in swrWeather.h.
+
+#define swrPlayerHUD_RenderDistanceText_ADDR (0x0042c510)
+
+#define swrPlayerHUD_RenderRearview_ADDR (0x0042c800)
+
+#define swrPlayerHUD_RenderWorldSprites_ADDR (0x0042cb00)
+
+#define swrPlayerHUD_Enable_ADDR (0x0042d500)
+
+#define swrPlayerHUD_RenderViewport_ADDR (0x0042d490)
+
+#define swrPlayerHUD_SampleOcclusion_ADDR (0x0042be60)
+
+#define swrPlayerHUD_RenderAllViewports_ADDR (0x00483cb0)
+
+#define swrPlayerHUD_SetupTrackOverlay_ADDR (0x00464010)
+
+#define swrPlayerHUD_LoadRaceHUD_ADDR (0x00464630)
+
+// swrPlayerHUD_SampleOcclusion is called once per frame at the start of the
+// render phase (from FUN_00445980, before the per-viewport render loop). It
+// locks the back buffer via DirectDraw_LockMainSurface and samples raw pixel
+// data around every HUD marker's projected screen position to detect
+// occlusion by world geometry. The resulting "coverage" counts are stored at
+// DAT_00e9a3c0 (target indicators), DAT_00e9a7e0 (distance text labels),
+// DAT_00e99d80 (rearview-tracked points), and DAT_00e9a8e0 (world sprites);
+// each sub-renderer reads them later to decide whether to draw its marker.
+//
+// KNOWN ISSUE -- broken on modern high-resolution displays:
+//   The inner 8x8 sample loop's per-pixel comparison only handles bpp == 1
+//   (8-bit) and bpp == 2 (16-bit). For bpp 3 (24-bit) and bpp 4 (32-bit) --
+//   which is what modern DirectDraw wrappers emulate -- the pixel-coverage
+//   test is silently skipped, degrading occlusion to "out-of-screen-margin
+//   pixels only." HUD markers then draw through walls.
+//   The function also has the same buggy bpp dispatch switch documented in
+//   swrWeather.h (no default case, cases 3 and 4 read swapped globals).
+
+void swrPlayerHUD_RenderDistanceText(void* viewport, bool secondaryPass);
+
+void swrPlayerHUD_RenderRearview(void* viewport);
+
+void swrPlayerHUD_RenderWorldSprites(void* viewport);
+
+void swrPlayerHUD_Enable(void);
+
+void swrPlayerHUD_RenderViewport(void* viewport, bool secondaryPass);
+
+void swrPlayerHUD_SampleOcclusion(void);
+
+// Per-frame render loop: iterates the active player viewports (struct array at
+// DAT_00dfb040, stride 0x16c, up to 4), activates each, and calls
+// swrPlayerHUD_RenderViewport. Interleaves swrSprite render-all passes (modes 1/2/3).
+void swrPlayerHUD_RenderAllViewports(void);
+
+// Loads the per-track HUD element sprites and configures the weather subsystem
+// (enable/color/velocity/cap/stretch) for the given HUD type + weather level.
+// hudType selects the layout (cockpit variants, etc.); weatherLevel selects
+// none/light/heavy precipitation. Called by swrPlayerHUD_LoadRaceHUD.
+void swrPlayerHUD_SetupTrackOverlay(int hudType, int weatherLevel);
+
+// Master race-HUD loader: resets all sprites, loads speedometer / engine / starting
+// grid / placement-flag sprites, then calls swrPlayerHUD_SetupTrackOverlay.
+void swrPlayerHUD_LoadRaceHUD(int hudType, int weatherLevel, int racerData);
+
+#endif // SWRPLAYERHUD_H

--- a/src/Swr/swrPlayerHUD.h
+++ b/src/Swr/swrPlayerHUD.h
@@ -9,9 +9,9 @@
 //   swrPlayerHUD_RenderAllViewports (the per-frame render loop, from FUN_00445980)
 //     -> swrViewport_SetCurrent / swrViewport_UpdateViewTransforms  (per viewport, see swrViewport.h)
 //     -> swrPlayerHUD_RenderViewport(viewport, secondaryPass)
-//          if (DAT_004b94c0)  // HUD orchestrator enable, set by swrPlayerHUD_Enable
+//          if (InRaceSpritesEnabled)  // HUD orchestrator enable, set by swrPlayerHUD_Enable
 //              -> FUN_0042c1a0            (target indicators -- not yet named)
-//              -> swrPlayerHUD_RenderRearview
+//              -> UpdateLightStreakSprites     (light-streak motion-blur sprites, see swrModel.h)
 //              -> swrPlayerHUD_RenderWorldSprites
 //              -> swrWeather_RenderParticles   (see swrWeather.h)
 //              -> swrPlayerHUD_RenderDistanceText
@@ -29,7 +29,9 @@
 
 #define swrPlayerHUD_RenderDistanceText_ADDR (0x0042c510)
 
-#define swrPlayerHUD_RenderRearview_ADDR (0x0042c800)
+// NOTE: 0x0042c800 (the light-streak motion-blur updater) is declared as
+// UpdateLightStreakSprites in swrModel.h, alongside the rest of the light-streak
+// family (InitLightStreak / ResetLightStreakSprites / SetLightStreakSpriteIDs).
 
 #define swrPlayerHUD_RenderWorldSprites_ADDR (0x0042cb00)
 
@@ -50,9 +52,10 @@
 // locks the back buffer via DirectDraw_LockZBuffer and samples raw pixel
 // data around every HUD marker's projected screen position to detect
 // occlusion by world geometry. The resulting "coverage" counts are stored at
-// DAT_00e9a3c0 (target indicators), DAT_00e9a7e0 (distance text labels),
-// DAT_00e99d80 (rearview-tracked points), and DAT_00e9a8e0 (world sprites);
-// each sub-renderer reads them later to decide whether to draw its marker.
+// DAT_00e9a3c0 (target indicators), player_sprite_depth_values (0x00e9a7e0,
+// minimap player markers), light_streak_depth_values (0x00e99d80, light-streak
+// points), and DAT_00e9a8e0 (world sprites); each sub-renderer reads them later
+// to decide whether to draw its marker.
 //
 // KNOWN ISSUE -- broken on modern high-resolution displays:
 //   The inner 8x8 sample loop's per-pixel comparison only handles bpp == 1
@@ -64,8 +67,6 @@
 //   swrWeather.h (no default case, cases 3 and 4 read swapped globals).
 
 void swrPlayerHUD_RenderDistanceText(void* viewport, bool secondaryPass);
-
-void swrPlayerHUD_RenderRearview(void* viewport);
 
 void swrPlayerHUD_RenderWorldSprites(void* viewport);
 

--- a/src/Swr/swrViewport.h
+++ b/src/Swr/swrViewport.h
@@ -7,6 +7,8 @@
 
 #define swrViewport_UpdateCameras_ADDR (0x00429540)
 
+#define swrViewport_ProjectToScreen_ADDR (0x0042b710)
+
 #define swrViewport_GetNumViewports_ADDR (0x004318c0)
 #define swrViewport_Get_ADDR (0x004318d0)
 #define swrViewport_ExtractViewTransform_ADDR (0x00431900)
@@ -32,6 +34,12 @@
 
 #define swrViewport_SetRootNodeForAllViewports_ADDR (0x00483fc0)
 #define swrViewport_SetNodeFlagsForAllViewports_ADDR (0x00483ff0)
+
+// Projects a world (or camera-relative) point to screen pixels for the given viewport.
+// Outputs go to outScreenX / outScreenY (set to -1000.0 if off the projection rect),
+// outZ and outDepth. pointIsCameraRelative == 0 means worldPos is absolute world space
+// and gets made camera-relative first.
+void swrViewport_ProjectToScreen(void* viewport, rdVector4* worldPos, float* outScreenX, float* outScreenY, float* outZ, float* outDepth, int pointIsCameraRelative);
 
 int swrViewport_GetNumViewports();
 swrViewport* swrViewport_Get(int index);

--- a/src/Swr/swrWeather.h
+++ b/src/Swr/swrWeather.h
@@ -25,22 +25,22 @@
 // a patch, Layer 3 is partially understood with a workaround.
 //
 // LAYER 1 -- TRACK DATA (by design, not a bug): many "weather planet" tracks ship
-//   with weatherLevel == 0, which selects swrWeather_SetParticleCap(0) and produces
-//   zero particles regardless of resolution or renderer. weatherLevel is
-//   swrObjJdge.weatherLevel (offset 0x1c0), bulk-loaded from the level .dat file
+//   with planet_track_number == 0, which selects swrWeather_SetParticleCap(0) and produces
+//   zero particles regardless of resolution or renderer. planet_track_number is
+//   swrObjJdge.planet_track_number (offset 0x1c0), bulk-loaded from the level .dat file
 //   into swrObjScen + 0x28 by the swrObj loader, then copied to the Jdge in
 //   swrObjJdge_F4's "Begn" handler (0x00463a50).
 //   Empirical per-track caps measured in-game (cap stored at DAT_004b9534):
 //
-//     Snow planet (hudType == 1):
-//       Howler Gorge ............. cap 20  (weatherLevel 1, light)
-//       Andobi Mountain Run ...... cap 40  (weatherLevel 2, heavy)
-//       Andobi Prime Centrum ..... cap  0  (weatherLevel 0, no configured particles)
-//     Rain planet (hudType == 4):
-//       Baroo Coast .............. cap 20  (weatherLevel 0 in rain path -> 0x14)
-//       Grabvine Gateway ......... cap 60  (weatherLevel 1/2)
-//       Fire Mountain Rally ...... cap 60  (weatherLevel 1/2)
-//       Inferno .................. cap  0  (weatherLevel 3 disables, or non-rain path)
+//     Snow planet (planetId == 1):
+//       Howler Gorge ............. cap 20  (planet_track_number 1, light)
+//       Andobi Mountain Run ...... cap 40  (planet_track_number 2, heavy)
+//       Andobi Prime Centrum ..... cap  0  (planet_track_number 0, no configured particles)
+//     Rain planet (planetId == 4):
+//       Baroo Coast .............. cap 20  (planet_track_number 0 in rain path -> 0x14)
+//       Grabvine Gateway ......... cap 60  (planet_track_number 1/2)
+//       Fire Mountain Rally ...... cap 60  (planet_track_number 1/2)
+//       Inferno .................. cap  0  (planet_track_number 3 disables, or non-rain path)
 //
 //   So the "Ando Prime has no snow" symptom many users report on the Centrum track
 //   is NOT a renderer bug -- that track is shipped without particles. Layers 2 and 3
@@ -118,7 +118,7 @@
 //        per frame) does not produce the trail effect during turns; particles
 //        instead appear and disappear as they cross the viewport edges.
 //
-//     B. Rain (hudType == 4) only renders intermittently even after the Layer 2
+//     B. Rain (planetId == 4) only renders intermittently even after the Layer 2
 //        patch. Forcing swrWeather_SetStretchFactor(1.0) so rain uses the
 //        point-particle path makes it somewhat visible but still mostly broken,
 //        suggesting rain's very high vertical velocity (vy = 1000 for heavy rain)
@@ -168,7 +168,7 @@
 //     param_5, sprite secondary endpoints) at 1920x1080 vs 640x480 while a snow
 //     track is rendered mid-turn; the divergence will identify the streak bug.
 //     For rain specifically, consider patching swrPlayerHUD_SetupTrackOverlay to
-//     force stretch_factor = 1.0 for hudType == 4 as a partial workaround.
+//     force stretch_factor = 1.0 for planetId == 4 as a partial workaround.
 // =====================================================================================
 
 #define swrWeather_RenderParticles_ADDR (0x0042cca0)

--- a/src/Swr/swrWeather.h
+++ b/src/Swr/swrWeather.h
@@ -1,0 +1,214 @@
+#ifndef SWRWEATHER_H
+#define SWRWEATHER_H
+
+#include "types.h"
+
+// Weather particle effects (rain/snow/dust).
+//
+// swrWeather_RenderParticles is invoked per viewport from swrPlayerHUD_RenderViewport
+// (only when the HUD orchestrator flag DAT_004b94c0 is set), and only runs when the
+// weather enable flag DAT_004b9520 is set. Each particle slot has a state machine
+// (0 = empty, 1 = active, 2 = visible-this-frame). Particles spawn around the camera
+// world position with random offsets along the camera basis vectors, integrate against
+// the velocity set via swrWeather_SetVelocity, and despawn when projected off-screen.
+//
+// Per-track configuration (enable, color, velocity, particle cap, stretch) is set by
+// swrPlayerHUD_SetupTrackOverlay during race HUD load. The SNW / NSNW collision tags on
+// the track toggle DAT_004b9520 on/off per region as the camera moves, so weather is a
+// dynamic per-region effect, not a static per-track one.
+//
+// =====================================================================================
+// KNOWN ISSUES -- weather visibility on modern displays.
+//
+// What "weather doesn't work at high resolutions" actually splits into THREE
+// independent layers. Layer 1 is by design, Layer 2 has been root-caused and has
+// a patch, Layer 3 is partially understood with a workaround.
+//
+// LAYER 1 -- TRACK DATA (by design, not a bug): many "weather planet" tracks ship
+//   with weatherLevel == 0, which selects swrWeather_SetParticleCap(0) and produces
+//   zero particles regardless of resolution or renderer. weatherLevel is
+//   swrObjJdge.weatherLevel (offset 0x1c0), bulk-loaded from the level .dat file
+//   into swrObjScen + 0x28 by the swrObj loader, then copied to the Jdge in
+//   swrObjJdge_F4's "Begn" handler (0x00463a50).
+//   Empirical per-track caps measured in-game (cap stored at DAT_004b9534):
+//
+//     Snow planet (hudType == 1):
+//       Howler Gorge ............. cap 20  (weatherLevel 1, light)
+//       Andobi Mountain Run ...... cap 40  (weatherLevel 2, heavy)
+//       Andobi Prime Centrum ..... cap  0  (weatherLevel 0, no configured particles)
+//     Rain planet (hudType == 4):
+//       Baroo Coast .............. cap 20  (weatherLevel 0 in rain path -> 0x14)
+//       Grabvine Gateway ......... cap 60  (weatherLevel 1/2)
+//       Fire Mountain Rally ...... cap 60  (weatherLevel 1/2)
+//       Inferno .................. cap  0  (weatherLevel 3 disables, or non-rain path)
+//
+//   So the "Ando Prime has no snow" symptom many users report on the Centrum track
+//   is NOT a renderer bug -- that track is shipped without particles. Layers 2 and 3
+//   below only affect tracks with cap > 0.
+//
+// LAYER 2 -- HARDCODED -1000.0f SENTINEL IN swrViewport_ProjectToScreen (ROOT CAUSE
+//   FOUND, PATCH AVAILABLE):
+//
+//   At screen_width (DAT_00ec86c4) >= 1000, the initial batch of particles renders
+//   for one cycle and then never respawns. Particles all end up stuck at state 1
+//   (active but invisible, drifting off-screen forever) because the way-off-screen
+//   despawn at swrWeather_RenderParticles+0x42D078 never fires.
+//
+//   The reason: swrViewport_ProjectToScreen initializes its outputs to a sentinel
+//   value of -1000.0f and only overwrites them with the real projected coordinate
+//   when the projected point falls within the viewport bounds box:
+//
+//     0042b868: MOV dword ptr [ESI], 0xC47A0000   ; *outScreenX = -1000.0f
+//     0042b87f: MOV dword ptr [EDI], 0xC47A0000   ; *outScreenY = -1000.0f
+//     ... projection math, four bounds-box checks ...
+//     0042ba06: MOV [ESI], EDX                    ; only if in bounds, write real X
+//     0042ba08: MOV [EDI], EAX                    ; only if in bounds, write real Y
+//
+//   The weather despawn condition reads:
+//
+//     if (local_3c < (float)-DAT_00ec86c4 || ...)   // < -screen_width
+//         state = 0;
+//
+//   With the sentinel held at exactly -1000.0f:
+//     screen_width = 999   -> -1000.0 < -999.0  TRUE  -> despawn fires
+//     screen_width = 1000  -> -1000.0 < -1000.0 FALSE -> particles immortal
+//     screen_width = 1080+ -> -1000.0 > -1080.0 FALSE -> particles immortal
+//
+//   That is the exact 999/1000 threshold, originating from a developer assuming
+//   in 1999 that no screen would ever be >= 1000 pixels wide.
+//
+//   Earlier investigation hypothesized this was a dgVoodoo2 (DirectDraw -> D3D
+//   wrapper) limit on lockable back-buffer width. That hypothesis was REFUTED
+//   empirically: running under DDrawCompat (an independent DirectDraw
+//   implementation) reproduces the exact same < 1000 threshold. Two different
+//   wrappers, same threshold -> the wrapper is not the cause; the EXE is.
+//
+//   PATCH (8 bytes total, two 4-byte immediate edits inside two MOV instructions):
+//
+//     +-----------------+--------------------+--------------------+
+//     | address         | original bytes (4) | patched bytes (4)  |
+//     +-----------------+--------------------+--------------------+
+//     | 0x0042B86A      | 00 00 7A C4        | 00 00 80 FF        |
+//     | 0x0042B881      | 00 00 7A C4        | 00 00 80 FF        |
+//     +-----------------+--------------------+--------------------+
+//
+//   The 4-byte immediate at +2 inside each MOV is the IEEE-754 single-precision
+//   float being stored. 0xC47A0000 LE = -1000.0f. 0xFF800000 LE = -INF.
+//
+//   After the patch, the sentinel is -INFINITY instead of -1000.0f. Effects:
+//     - Despawn comparison local_3c < -screen_width fires at any resolution
+//       (-INF is strictly less than any finite number).
+//     - On-screen check local_3c <= 0 still routes off-screen particles to the
+//       despawn branch as before (-INF <= 0 is true).
+//     - The other 4 callers of swrViewport_ProjectToScreen (HUD distance text,
+//       rearview, world sprites, target indicators) use the output only as a
+//       sprite coordinate; the sprite renderer clips naturally, so changing the
+//       sentinel from -1000.0f to -INF is a no-op for them in practice.
+//     - Tested: snow renders correctly at 1920x1080 on Howler Gorge and Andobi
+//       Mountain Run.
+//
+// LAYER 3 -- REMAINING ARTIFACTS AFTER LAYER 2 PATCH (partially understood):
+//
+//   With Layer 2 patched, two artifacts remain:
+//
+//     A. Snow particles flicker / fail to render during sharp camera turns. On the
+//        N64 and Dreamcast versions the corresponding behaviour is visible motion
+//        blur (streaks). On PC after the Layer 2 patch the streak flag (swrSprite
+//        flag 0x4000, set in swrWeather_RenderParticles when |delta_screen| >= 3
+//        per frame) does not produce the trail effect during turns; particles
+//        instead appear and disappear as they cross the viewport edges.
+//
+//     B. Rain (hudType == 4) only renders intermittently even after the Layer 2
+//        patch. Forcing swrWeather_SetStretchFactor(1.0) so rain uses the
+//        point-particle path makes it somewhat visible but still mostly broken,
+//        suggesting rain's very high vertical velocity (vy = 1000 for heavy rain)
+//        makes particles cross the viewport in a single frame and immediately
+//        cycle through despawn->respawn faster than they can render coherently.
+//
+//   Two candidate causes, neither yet root-caused:
+//
+//     1. Inherent particle cycle rate at modern resolutions. With Layer 2 fixed,
+//        particles despawn the moment they project off-screen. At 1920x1080 the
+//        camera basis vectors during a turn project particles across the viewport
+//        edges far more often than at the engine's design resolution (640x480 or
+//        320x240), so the spawn/despawn cycle becomes too rapid to look stable.
+//        The N64/Dreamcast versions did not exhibit this because their native
+//        resolution kept particles inside the viewport for many more frames.
+//
+//     2. A streak-rendering bug in the sprite render primitive FUN_0044f670
+//        (0x0044f670), which has explicit flag-0x4000 handling that reads sprite
+//        secondary endpoints from sprite_struct + 0x2 / + 0x4 (written by
+//        FUN_0042d330 -> FUN_004286c0 at DAT_00e9ba64 + sprite_id * 0x20). The
+//        streak path multiplies coordinates by param_5 and adds (param_3 -
+//        local_3c) offsets; one of these intermediate computations may have a
+//        precision or sign issue at modern resolutions, but tracing has not yet
+//        confirmed which.
+//
+//   An attempted fix (NOP-ing the 4 viewport-bounds-box checks in
+//   swrViewport_ProjectToScreen at 0x0042B994, 0x0042B9B6, 0x0042B9D1, 0x0042B9F6,
+//   so that real projected coords are always written instead of letting the
+//   sentinel persist for off-screen points) produced no visible change. So
+//   Layer 3's cause is NOT just sentinel data flowing into the streak endpoint
+//   computation -- it lives elsewhere.
+//
+// SECONDARY (real, but neither a Layer 2 nor Layer 3 root cause): the bpp dispatch
+//   in the occlusion pixel-sampling (here and in swrPlayerHUD_SampleOcclusion) has
+//   no default case for bpp outside {1,2,3,4} (default path leaves the scale factor
+//   as (bpp-1) reinterpreted as a denormal float), and cases 3/4 read swapped scale
+//   globals (case 3 -> DAT_004b94bc, case 4 -> DAT_004b94b8; slots are calibrated
+//   1/255, 1/65535, 1/2^24-1, 1/2^32-1). These break occlusion accuracy at 24/32-bit,
+//   but particles are SetVisible(1) regardless of occlusion outcome, so they do not
+//   by themselves prevent rendering.
+//
+// MODERN FIX SUMMARY (for a swr_reimpl.dll hook or direct EXE patch):
+//   - Layer 2 (snow at high res): patch the two 4-byte sentinel immediates listed
+//     above. 8 bytes total. Closes the primary "no weather at high res" bug.
+//   - Layer 3 (rain + snow flicker on turn): no patch yet. Suggested follow-up
+//     work: instrument FUN_0044f670 to log its streak path inputs (param_3,
+//     param_5, sprite secondary endpoints) at 1920x1080 vs 640x480 while a snow
+//     track is rendered mid-turn; the divergence will identify the streak bug.
+//     For rain specifically, consider patching swrPlayerHUD_SetupTrackOverlay to
+//     force stretch_factor = 1.0 for hudType == 4 as a partial workaround.
+// =====================================================================================
+
+#define swrWeather_RenderParticles_ADDR (0x0042cca0)
+
+#define swrWeather_HideAllParticles_ADDR (0x0042d380)
+
+#define swrWeather_SetVelocity_ADDR (0x0042d3c0)
+
+#define swrWeather_SetColor_ADDR (0x0042d3e0)
+
+#define swrWeather_SetParticleCap_ADDR (0x0042d410)
+
+#define swrWeather_SetStretchFactor_ADDR (0x0042d430)
+
+#define swrWeather_Disable_ADDR (0x0042d440)
+
+#define swrWeather_Enable_ADDR (0x0042d450)
+
+void swrWeather_RenderParticles(void* viewport);
+
+void swrWeather_HideAllParticles(void);
+
+void swrWeather_SetVelocity(float vx, float vy);
+
+void swrWeather_SetColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+
+void swrWeather_SetParticleCap(int max);
+
+// Sets DAT_004b9530, the rain-streak stretch factor (1.0 = point particle, 7.0 = long
+// rain streak). With the Layer 2 patch applied, rain still does not render reliably
+// even with stretch_factor = 1.0 -- see Layer 3 of the KNOWN ISSUES block above.
+// Forcing this to 1.0 makes rain take the point-particle code path and become
+// somewhat visible (partial workaround), but the underlying cause of "rain doesn't
+// render properly at modern resolutions" is not yet root-caused.
+void swrWeather_SetStretchFactor(float factor);
+
+// swrWeather_Disable clears DAT_004b9520 and hides all particle sprites.
+// swrWeather_Enable sets DAT_004b9520. Both are driven by the SNW/NSNW collision tags.
+void swrWeather_Disable(void);
+
+void swrWeather_Enable(void);
+
+#endif // SWRWEATHER_H

--- a/src/Swr/swrWeather.h
+++ b/src/Swr/swrWeather.h
@@ -6,16 +6,36 @@
 // Weather particle effects (rain/snow/dust).
 //
 // swrWeather_RenderParticles is invoked per viewport from swrPlayerHUD_RenderViewport
-// (only when the HUD orchestrator flag DAT_004b94c0 is set), and only runs when the
-// weather enable flag DAT_004b9520 is set. Each particle slot has a state machine
-// (0 = empty, 1 = active, 2 = visible-this-frame). Particles spawn around the camera
-// world position with random offsets along the camera basis vectors, integrate against
-// the velocity set via swrWeather_SetVelocity, and despawn when projected off-screen.
+// (only when the HUD orchestrator flag InRaceSpritesEnabled is set), and only runs when
+// the weather enable flag swrWeather_enabled is set. Each particle slot has a state
+// machine (0 = empty, 1 = active, 2 = visible-this-frame). Particles spawn around the
+// camera world position with random offsets along the camera basis vectors, integrate
+// against the velocity set via swrWeather_SetVelocity, and despawn when projected
+// off-screen.
 //
 // Per-track configuration (enable, color, velocity, particle cap, stretch) is set by
 // swrPlayerHUD_SetupTrackOverlay during race HUD load. The SNW / NSNW collision tags on
-// the track toggle DAT_004b9520 on/off per region as the camera moves, so weather is a
-// dynamic per-region effect, not a static per-track one.
+// the track toggle swrWeather_enabled on/off per region as the camera moves, so weather
+// is a dynamic per-region effect, not a static per-track one.
+//
+// =====================================================================================
+// GLOBAL STATE
+//
+//   Per-run configuration (set by swrPlayerHUD_SetupTrackOverlay through the setters):
+//     swrWeather_enabled         0x004b9520  int         master on/off (swrWeather_Enable/
+//                                                         _Disable + SNW/NSNW track tags)
+//     swrWeather_particleColor   0x004b9524  uint8_t[4]  RGBA tint (swrWeather_SetColor)
+//     swrWeather_velocityX       0x004b9528  float       drift/fall velocity X (swrWeather_SetVelocity)
+//     swrWeather_velocityY       0x004b952c  float       drift/fall velocity Y (swrWeather_SetVelocity)
+//     swrWeather_stretchFactor   0x004b9530  float       rain-streak stretch (swrWeather_SetStretchFactor)
+//     swrWeather_particleCap     0x004b9534  int         active slot count, <= 80 (swrWeather_SetParticleCap)
+//
+//   Particle pool -- four parallel arrays of 80 slots, walked in lockstep (slot index)
+//   by swrWeather_RenderParticles and swrWeather_HideAllParticles:
+//     swrWeather_particlePositions        0x00e99860  rdVector3[80]  world-space position
+//     swrWeather_particleScreenPositions  0x00e9a000  rdVector2[80]  last projected screen x/y
+//     swrWeather_particleSpriteIds        0x00e9a280  int[80]        swrSprite id (-1 = unallocated)
+//     swrWeather_particleStates           0x00e9a960  char[80]       0 = empty, 1 = active, 2 = visible-this-frame
 //
 // =====================================================================================
 // KNOWN ISSUES -- weather visibility on modern displays.
@@ -30,7 +50,7 @@
 //   swrObjJdge.planet_track_number (offset 0x1c0), bulk-loaded from the level .dat file
 //   into swrObjScen + 0x28 by the swrObj loader, then copied to the Jdge in
 //   swrObjJdge_F4's "Begn" handler (0x00463a50).
-//   Empirical per-track caps measured in-game (cap stored at DAT_004b9534):
+//   Empirical per-track caps measured in-game (cap stored at swrWeather_particleCap):
 //
 //     Snow planet (planetId == 1):
 //       Howler Gorge ............. cap 20  (planet_track_number 1, light)
@@ -49,7 +69,7 @@
 // LAYER 2 -- HARDCODED -1000.0f SENTINEL IN swrViewport_ProjectToScreen (ROOT CAUSE
 //   FOUND, PATCH AVAILABLE):
 //
-//   At screen_width (DAT_00ec86c4) >= 1000, the initial batch of particles renders
+//   At screen_width (0x00ec86c4) >= 1000, the initial batch of particles renders
 //   for one cycle and then never respawns. Particles all end up stuck at state 1
 //   (active but invisible, drifting off-screen forever) because the way-off-screen
 //   despawn at swrWeather_RenderParticles+0x42D078 never fires.
@@ -66,7 +86,7 @@
 //
 //   The weather despawn condition reads:
 //
-//     if (local_3c < (float)-DAT_00ec86c4 || ...)   // < -screen_width
+//     if (local_3c < (float)-screen_width || ...)   // < -screen_width
 //         state = 0;
 //
 //   With the sentinel held at exactly -1000.0f:
@@ -197,7 +217,7 @@ void swrWeather_SetColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 void swrWeather_SetParticleCap(int max);
 
-// Sets DAT_004b9530, the rain-streak stretch factor (1.0 = point particle, 7.0 = long
+// Sets swrWeather_stretchFactor, the rain-streak stretch factor (1.0 = point particle, 7.0 = long
 // rain streak). With the Layer 2 patch applied, rain still does not render reliably
 // even with stretch_factor = 1.0 -- see Layer 3 of the KNOWN ISSUES block above.
 // Forcing this to 1.0 makes rain take the point-particle code path and become
@@ -205,8 +225,8 @@ void swrWeather_SetParticleCap(int max);
 // render properly at modern resolutions" is not yet root-caused.
 void swrWeather_SetStretchFactor(float factor);
 
-// swrWeather_Disable clears DAT_004b9520 and hides all particle sprites.
-// swrWeather_Enable sets DAT_004b9520. Both are driven by the SNW/NSNW collision tags.
+// swrWeather_Disable clears swrWeather_enabled and hides all particle sprites.
+// swrWeather_Enable sets swrWeather_enabled. Both are driven by the SNW/NSNW collision tags.
 void swrWeather_Disable(void);
 
 void swrWeather_Enable(void);

--- a/src/swr.h
+++ b/src/swr.h
@@ -13,8 +13,6 @@
 
 #define swr_noop3_ADDR (0x00483ba0)
 
-#define decompressLZSS_ADDR (0x0042d520)
-
 void swr_noop2(void);
 
 void  playASoundImpl(int, short, float, float, short, int, int, int *);
@@ -26,7 +24,5 @@ void swr_noop4(void);
 void swr_noop1(void);
 
 void swr_noop3(void);
-
-void decompressLZSS(char* compressed, char* out);
 
 #endif // SWR_H

--- a/src/swr.h
+++ b/src/swr.h
@@ -13,6 +13,8 @@
 
 #define swr_noop3_ADDR (0x00483ba0)
 
+#define decompressLZSS_ADDR (0x0042d520)
+
 void swr_noop2(void);
 
 void  playASoundImpl(int, short, float, float, short, int, int, int *);
@@ -24,5 +26,7 @@ void swr_noop4(void);
 void swr_noop1(void);
 
 void swr_noop3(void);
+
+void decompressLZSS(char* compressed, char* out);
 
 #endif // SWR_H


### PR DESCRIPTION
## Summary

Adds documentation headers for three subsystems mapped during a weather/HUD reverse-engineering investigation:

- **`src/Swr/swrWeather.h`** (new) — particle effects (rain/snow). Includes a three-layer analysis of "weather doesn't render on modern displays" and a verified 8-byte EXE patch that fixes the primary cause (Layer 2: a hard-coded `-1000.0f` off-screen sentinel in `swrViewport_ProjectToScreen` that immortalises particles once `screen_width >= 1000`).
- **`src/Swr/swrPlayerHUD.h`** (new) — per-player split-screen HUD/overlay orchestrator: render loop, target indicators, rearview, world sprites, weather, distance text. Also documents the back-buffer occlusion sampler that silently skips its per-pixel test on modern 24/32-bit surfaces.
- **`src/Swr/swrViewport.h`** (+8) — adds `swrViewport_ProjectToScreen` (the `-1000.0f` sentinel write site, world-to-screen projection used by every HUD/weather renderer).
- **`src/swr.h`** (+4) — adds `decompressLZSS` (called by `swrModel_LoadFromId`).

Header-only PR — `_ADDR` defines, declarations, and documentation comments. No `.c` implementations and no behavioral changes.

## Verified weather-render bug fix

- Reproduced "no snow at 1920x1080" empirically. Particles spawn for one frame and then never respawn because the despawn condition `local_3c < -screen_width` cannot fire once the off-screen sentinel `-1000.0f` is no longer strictly less than `-screen_width`.
- Earlier dgVoodoo2-as-cause hypothesis refuted under DDrawCompat: both wrappers show the exact same `< 1000` threshold, so the bug is in the EXE, not the wrapper.
- **Patch:** rewrite the sentinel from `0xC47A0000` (`-1000.0f`) to `0xFF800000` (`-INF`) at `0x0042B86A` and `0x0042B881`. 8 bytes total. Tested on Howler Gorge and Andobi Mountain Run at 1920x1080.
- Full RCA, byte table, remaining Layer 3 artefacts (rain flicker, snow trails during sharp turns), and proposed follow-up work all live in [`src/Swr/swrWeather.h`](src/Swr/swrWeather.h).