### PR TITLE
spline: complete LoadSpline byteswap + map the spline runtime

### DIFF
--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -83,6 +83,8 @@
 
 #define LoadTrackModels_ADDR (0x00465510)
 
+#define swrObjJdge_InitSplineCursor_ADDR (0x00465CB0)
+
 #define LoadTrackSpline_ADDR (0x00465D00)
 
 #define InitPrimaryLight_ADDR (0x00466370)
@@ -233,6 +235,8 @@ void swrObjSmok_AddFireballModelsToScene();
 void AddFireballToModelScene();
 
 void LoadTrackModels(swrObjJdge* judge);
+
+void swrObjJdge_InitSplineCursor(swrObjJdge* judge);
 
 void LoadTrackSpline(swrObjJdge*);
 

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -115,7 +115,13 @@
 
 #define swrRace_PoddAnimateSteeringParts_ADDR (0x00472A50)
 
+#define swrRace_GetSplineLookahead_ADDR (0x00473e40)
+#define swrRace_ResetToSpline_ADDR (0x00473f40)
+
 #define swrRace_Explode_ADDR (0x004741D0)
+
+#define swrRace_UpdateSplineCursor_ADDR (0x004744b0)
+#define swrRace_PlaceOnTrack_ADDR (0x004746b0)
 
 #define swrObjTest_F4_ADDR (0x00474d80)
 
@@ -268,7 +274,22 @@ void swrRace_PoddAnimateVariousThings(swrRace* arg0);
 
 void swrRace_PoddAnimateSteeringParts(swrRace* a1);
 
+// Compute a steering/target point one segment ahead on the spline (raised and
+// terrain-adjusted); used by swrObjTest_F4.
+void swrRace_GetSplineLookahead(rdVector3* out, swrRace* racer);
+
+// Snap the racer's position + orientation onto its spline cursor at offset t
+// and zero its momentum/physics state (respawn / reset primitive).
+void swrRace_ResetToSpline(swrRace* racer, float t);
+
 void swrRace_Explode(swrRace*, char);
+
+// Per-frame: advance the racer's spline cursor along the track (by speed, or
+// re-sync from position when mode != 0), validating the track surface.
+void swrRace_UpdateSplineCursor(swrRace* racer, rdMatrix44* out, int mode);
+
+// One-time placement of the racer onto the spline at race start.
+void swrRace_PlaceOnTrack(swrRace* racer);
 
 int swrObjTest_F4(swrRace* player, int* subEvent, int ghost);
 

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -24,13 +24,49 @@ void swrSpline_LoadSpline(int index, unsigned short** b)
     indices_bound[0] = SWAP32(indices_bound[0]);
     indices_bound[1] = SWAP32(indices_bound[1]);
 
-    void* _DstBuf = swrAssetBuffer_GetBuffer();
-    swrLoader_ReadAt(swrLoader_TYPE_SPLINE_BLOCK, indices_bound[0], _DstBuf, indices_bound[1] - indices_bound[0]);
-    unsigned short* unk = *b;
-    b = NULL;
+    const unsigned int spline_size = indices_bound[1] - indices_bound[0];
+    swrSpline* spline = (swrSpline*)swrAssetBuffer_GetBuffer();
+    swrLoader_ReadAt(swrLoader_TYPE_SPLINE_BLOCK, indices_bound[0], spline, spline_size);
 
-    HANG("TODO");
+    *b = (unsigned short*)spline;
+    // the on-disk 4-byte slot at offset 0xc is repurposed as the runtime
+    // pointer to the control point array, which follows the 0x10 byte header.
+    spline->control_points = (swrSplineControlPoint*)((char*)spline + sizeof(swrSpline));
 
+    spline->unk0 = SWAP16(spline->unk0);
+    // note: unk1 is intentionally left un-swapped, matching the original
+    spline->num_control_points = SWAP32(spline->num_control_points);
+    spline->num_segments = SWAP32(spline->num_segments);
+
+    for (int i = 0; i < (int)spline->num_control_points; i++)
+    {
+        swrSplineControlPoint* cp = &spline->control_points[i];
+
+        cp->next_count = SWAP16(cp->next_count);
+        cp->prev_count = SWAP16(cp->prev_count);
+        cp->next1 = SWAP16(cp->next1);
+        cp->next2 = SWAP16(cp->next2);
+        cp->prev1 = SWAP16(cp->prev1);
+        cp->prev2 = SWAP16(cp->prev2);
+        cp->prev3 = SWAP16(cp->prev3);
+        cp->prev4 = SWAP16(cp->prev4);
+
+        for (int j = 0; j < 3; j++)
+            FLOAT_SWAP32_INPLACE(&cp->position.x + j);
+        for (int j = 0; j < 3; j++)
+            FLOAT_SWAP32_INPLACE(&cp->rotation.x + j);
+        for (int j = 0; j < 3; j++)
+            FLOAT_SWAP32_INPLACE(&cp->handle1.x + j);
+        for (int j = 0; j < 3; j++)
+            FLOAT_SWAP32_INPLACE(&cp->handle2.x + j);
+
+        cp->progress = SWAP16(cp->progress);
+        for (int j = 0; j < 8; j++)
+            cp->unk_set[j] = SWAP16(cp->unk_set[j]);
+        // note: cp->unk is intentionally left un-swapped, matching the original
+    }
+
+    swrAssetBuffer_SetBuffer((char*)spline + spline_size);
     swrLoader_CloseBlock(swrLoader_TYPE_SPLINE_BLOCK);
 }
 

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -1,12 +1,96 @@
 #ifndef SWRSPLINE_H
 #define SWRSPLINE_H
 
+#include "types.h"
+
 #define swrSpline_LoadSpline_ADDR (0x00446fc0)
 
 #define swrSpline_LoadSplineById_ADDR (0x004472e0)
 
+// Runtime cursor primitives. A "cursor" is a 0x30 byte walker tracking a
+// position moving along the spline graph (the swrObjJdge embeds one at +0x34):
+//   [0] spline   [1] velocity   [2] segment t   [3] tangent length
+//   [4..7] 4 node lookahead window   [8] end flag   [9] start flag
+//   [10] branch selector   [0xb] branch flag bits
+#define swrSpline_FindNodeByProgress_ADDR (0x0044e5e0)
+#define swrSpline_CursorGetNode_ADDR (0x0044e620)
+#define swrSpline_Interpolate_ADDR (0x0044e660)
+#define swrSpline_CursorStep_ADDR (0x0044eaa0)
+#define swrSpline_CursorEvaluate_ADDR (0x0044ec40)
+#define swrSpline_EvaluateToMatrix_ADDR (0x0044ed80)
+#define swrSpline_EvaluateAtOffset_ADDR (0x0044eeb0)
+#define swrSpline_CursorSeek_ADDR (0x0044eef0)
+
+// Graph traversal, post-load baking, and point projection (control points form
+// a directed graph keyed by a per-node "progress" band; baking assigns
+// arc-length progress and tessellates each segment).
+#define swrSpline_CursorInit_ADDR (0x0047e880)
+#define swrSpline_ProjectPoint_ADDR (0x0047eb60)
+#define swrSpline_ForEachSample_ADDR (0x0047ee20)
+#define swrSpline_TraceProgress_ADDR (0x0047f060)
+#define swrSpline_BuildProgressTable_ADDR (0x0047f470)
+#define swrSpline_ResetNodeProgress_ADDR (0x0047f6c0)
+#define swrSpline_Build_ADDR (0x0047f6f0)
+
 void swrSpline_LoadSpline(int index, unsigned short** b);
 
 char* swrSpline_LoadSplineById(char* splineBuffer);
+
+// Scan control points from startIndex for one whose progress field equals
+// progress; returns its index or -1.
+int swrSpline_FindNodeByProgress(swrSpline* spline, int progress, int startIndex);
+
+// Resolve the node index at lookahead level (0..3), honoring the cursor branch
+// flag bits.
+int swrSpline_CursorGetNode(void* cursor, int level);
+
+// Core cubic interpolation kernel. Builds the {t^3, t^2, t, 1} basis, applies
+// the spline-type basis matrices, and writes the components selected by mask
+// (bit 1 = position, bit 2 = tangent, bit 4 = normal, bit 8 = up) into out.
+void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeIndices, float* out);
+
+// Step the cursor to the next (direction 1) or previous (direction 2) control
+// point, shifting the lookahead window and tracking branch selection.
+void swrSpline_CursorStep(void* spline, int direction, void* cursor);
+
+// Advance the cursor parameter by its velocity, crossing segment boundaries,
+// then evaluate position + tangent + up into out.
+void swrSpline_CursorEvaluate(void* cursor, float* out);
+
+// Evaluate the cursor's current point into a position+orientation matrix (the
+// path tangent becomes the forward axis).
+void swrSpline_EvaluateToMatrix(void* cursor, rdMatrix44* out);
+
+// Advance the cursor parameter by t, then evaluate it into a matrix.
+void swrSpline_EvaluateAtOffset(void* cursor, rdMatrix44* out, float t);
+
+// Seed the cursor to nodeIndex and fill its 4 level lookahead chain.
+void swrSpline_CursorSeek(void* cursor, int nodeIndex);
+
+// Initialize a cursor for spline (zeroes it then seeks to the start). Returns
+// the cursor.
+void* swrSpline_CursorInit(void* cursor, swrSpline* spline);
+
+// Advance the cursor to the point on the spline nearest the given world point
+// (used to map a world position back to a spline parameter / progress).
+void swrSpline_ProjectPoint(void* cursor, rdVector3* point);
+
+// Walk every segment, subdivide it into fixed steps, and invoke callback per
+// sample.
+void swrSpline_ForEachSample(swrSpline* spline, float step, void* arg3, void* arg4, void* callback);
+
+// Trace one graph path, integrating arc length to assign each visited node a
+// normalized progress value.
+void swrSpline_TraceProgress(void* cursor, float segmentLength, unsigned short* order, short* counter);
+
+// Walk all graph paths and build the per-node progress table.
+void swrSpline_BuildProgressTable(swrSpline* spline, float segmentLength, unsigned short* order);
+
+// Clear the runtime progress/state arrays for one node index.
+void swrSpline_ResetNodeProgress(int nodeIndex);
+
+// Top level post-load processing (called by LoadTrackSpline): resets junction
+// nodes, builds the progress table, then tessellates.
+void swrSpline_Build(swrSpline* spline, int unk);
 
 #endif // SWRSPLINE_H


### PR DESCRIPTION
Finish the swrSpline_LoadSpline reimplementation (the control-point endian-swap loop; swrSplineControlPoint already matched the on-disk layout). Map and name the spline runtime/baking engine: control points form a directed graph keyed by a per-node progress band, baked at load into an arc-length progress table + fixed-step tessellation, and followed at runtime by an embedded cursor evaluated into orientation matrices.

16 functions named with _ADDR defines + prototypes in swrSpline.h / swrObj.h: loader (LoadSpline, LoadSplineById); cursor traversal/eval (CursorInit, CursorSeek, CursorStep, CursorGetNode, CursorEvaluate, Interpolate, EvaluateToMatrix, EvaluateAtOffset, FindNodeByProgress, ProjectPoint); post-load baking (Build, BuildProgressTable, TraceProgress, ForEachSample, ResetNodeProgress); and swrObjJdge_InitSplineCursor.