### PR TITLE
swrSound: map the audio subsystem (cache, playback, mixer)

### DIFF
--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -5,6 +5,26 @@
 
 #define swrSound_Startup_ADDR (0x00421D90)
 
+// Sound resource cache. A "bank" of 0x4c-byte sound descriptors lives at
+// PTR_DAT_004b6d34 (count +0x20, capacity +0x24, descriptor array +0x28). Each
+// descriptor: name +0x00, index +0x20, flags +0x24, dataSize +0x28, rate +0x2c,
+// bits +0x30, channels +0x34, durationMs +0x38, dataOffset +0x3c, source +0x48.
+// Audio data is loaded on demand within a byte budget with clock eviction.
+#define swrSound_Teardown_ADDR (0x00421eb0)
+#define swrSound_LoadSoundMap_ADDR (0x00421f30)
+#define swrSound_LoadDefaultBank_ADDR (0x00422060)
+#define swrSound_SetDefaultConfig_ADDR (0x004220b0)
+#define swrSound_FreeBank_ADDR (0x004226c0)
+#define swrSound_AllocBank_ADDR (0x00422770)
+#define swrSound_RegisterSound_ADDR (0x004227e0)
+#define swrSound_GetEntry_ADDR (0x00422a90)
+#define swrSound_LoadSound_ADDR (0x00422ac0)
+#define swrSound_UnloadSound_ADDR (0x00422d10)
+#define swrSound_UnloadAll_ADDR (0x00422da0)
+#define swrSound_AcquireSource_ADDR (0x00422e30)
+#define swrSound_ReadIntoSource_ADDR (0x00422f00)
+#define swrSound_EvictSounds_ADDR (0x00422f60)
+
 #define swrSound_CreateSourceFromFile_ADDR (0x00423050)
 
 #define swrSound_Find_ADDR (0x004231b0)
@@ -15,6 +35,23 @@
 #define swrSound_ThreadRoutine_ADDR (0x00423330)
 
 #define swrSound_SetPlayEvent_ADDR (0x00423350)
+
+// High-level SFX playback. A (category, id) pair is resolved to a bank index,
+// then played 3D-positionally (distance-attenuated) via playASoundImpl.
+#define swrSound_PlaySpatialRange_ADDR (0x00426d10)
+#define swrSound_PlaySpatial_ADDR (0x00426d80)
+#define swrSound_ResolveSfxId_ADDR (0x00427110)
+#define swrSound_UpdateEngineAudio_ADDR (0x00427b20)
+#define swrSound_PreloadSoundSet_ADDR (0x00427d90)
+#define swrSound_PreloadRacerSounds_ADDR (0x00427f10)
+#define swrSound_PreloadSfx_ADDR (0x00427fb0)
+
+// Runtime channel mixer: 8 channels (DAT_00e67e40, stride 0x44). swrSound_Update
+// is the per-frame tick (acquire/position/play/release each channel + listener).
+#define swrSound_ResetChannel_ADDR (0x00449e00)
+#define swrSound_RewindChannels_ADDR (0x00449e50)
+#define swrSound_ResetChannels_ADDR (0x00449ea0)
+#define swrSound_Update_ADDR (0x00449ef0)
 
 #define swrSound_Init_ADDR (0x004848a0)
 #define swrSound_Shutdown_ADDR (0x00484a20)
@@ -45,6 +82,52 @@
 
 int swrSound_Startup();
 
+// Tear down the sound manager (free bank, stop/terminate the streaming thread,
+// free the index). fullShutdown != 0 also releases A3D; == 0 only suspends.
+int swrSound_Teardown(int fullShutdown);
+
+// Parse data/sounds.map (NUMSOUNDS / NUMVOICES) and register every listed sound.
+int swrSound_LoadSoundMap(void);
+
+// Fallback when sounds.map is absent: register a hardcoded list of wavs.
+int swrSound_LoadDefaultBank(void);
+
+// Reset the audio config globals (master/hi-res/doppler/gain/voices) to defaults.
+void swrSound_SetDefaultConfig(void);
+
+// Free every descriptor's audio source and the bank array.
+void swrSound_FreeBank(void);
+
+// Allocate the descriptor bank for count entries.
+int swrSound_AllocBank(int count);
+
+// Register a sound by name: locate its wav, parse the header into a new
+// descriptor, and index it. Returns the descriptor; load != 0 also loads audio.
+void* swrSound_RegisterSound(char* name, int load);
+
+// Return the descriptor at index (bounds-checked), or NULL.
+void* swrSound_GetEntry(int index);
+
+// Load a descriptor's audio into a new A3D source on demand, evicting other
+// sounds first if the byte budget would be exceeded.
+int swrSound_LoadSound(void* entry);
+
+// Release a descriptor's A3D source and reclaim its bytes (keeps the descriptor).
+int swrSound_UnloadSound(void* entry);
+
+// Unload every loaded sound's audio (keeps descriptors) and reset all channels.
+void swrSound_UnloadAll(void);
+
+// Ensure the sound is loaded and return a playable A3D source, duplicating it
+// for polyphony if the existing source is already playing (under the voice cap).
+IA3dSource* swrSound_AcquireSource(void* entry, int context, int* createDedicated);
+
+// Lock the descriptor's source buffer, read its wav data from file, unlock.
+int swrSound_ReadIntoSource(stdFile_t file, void* entry);
+
+// Reclaim at least bytesNeeded by unloading idle (non-playing) sounds; returns bytes freed.
+unsigned int swrSound_EvictSounds(unsigned int bytesNeeded);
+
 IA3dSource* swrSound_CreateSourceFromFile(char* wave_filename);
 
 char* swrSound_Find(char* filename_wav);
@@ -55,6 +138,42 @@ int swrSound_TerminateThread(void);
 DWORD swrSound_ThreadRoutine(LPVOID lpThreadParameter);
 
 void swrSound_SetPlayEvent(void);
+
+// Resolve a (category 0..7, id) pair to a bank sound index via per-category
+// lookup tables; returns the index or -1.
+int swrSound_ResolveSfxId(int category, int variant, int id);
+
+// Per-frame engine/surface SFX: select and play loop sounds keyed by speed.
+void swrSound_UpdateEngineAudio(int param1, int param2, float* param3);
+
+// Play a sound 3D-positionally: attenuate gain by distance from the listener,
+// cull if out of range, then dispatch to playASoundImpl.
+void swrSound_PlaySpatial(int soundId, short param2, float param3, float gain, rdVector3* position, int param6, unsigned int flags);
+
+// As swrSound_PlaySpatial, but with explicit min/max audible distances.
+void swrSound_PlaySpatialRange(int soundId, short param2, float param3, float gain, rdVector3* position, int param6, unsigned int flags, float minDist, float maxDist);
+
+// Resolve and preload (acquire an A3D source for) a single SFX.
+void swrSound_PreloadSfx(int category, int variant, int id);
+
+// Preload every racer's per-pod sound list.
+void swrSound_PreloadRacerSounds(void);
+
+// Preload the sound set for a scenario/context.
+void swrSound_PreloadSoundSet(int scenario, int param2);
+
+// Reset one channel slot (index -1, default gain/pitch/pan).
+void swrSound_ResetChannel(void* channel);
+
+// Rewind every active channel's source.
+void swrSound_RewindChannels(void);
+
+// Reset all 8 channels.
+void swrSound_ResetChannels(void);
+
+// Per-frame audio tick: drive all 8 channels (acquire/position/doppler/play/
+// release) and update the listener transform, then flush.
+void swrSound_Update(void);
 
 int swrSound_Init(void);
 void swrSound_Shutdown(void);

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -35,6 +35,7 @@
 #define swrSound_ThreadRoutine_ADDR (0x00423330)
 
 #define swrSound_SetPlayEvent_ADDR (0x00423350)
+#define swrSound_UpdateStreaming_ADDR (0x004234c0)
 
 // High-level SFX playback. A (category, id) pair is resolved to a bank index,
 // then played 3D-positionally (distance-attenuated) via playASoundImpl.
@@ -145,6 +146,10 @@ int swrSound_TerminateThread(void);
 DWORD swrSound_ThreadRoutine(LPVOID lpThreadParameter);
 
 void swrSound_SetPlayEvent(void);
+
+// Streaming pump: refills the active streamed (large) sound's buffer by reading the next
+// ~0x15888-byte chunk from its source. Driven by the audio thread / play-event signal.
+void swrSound_UpdateStreaming(void);
 
 // Resolve a (category 0..7, id) pair to a bank sound index via per-category
 // lookup tables; returns the index or -1.

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -41,6 +41,13 @@
 #define swrSound_PlaySpatialRange_ADDR (0x00426d10)
 #define swrSound_PlaySpatial_ADDR (0x00426d80)
 #define swrSound_ResolveSfxId_ADDR (0x00427110)
+// Throttled one-shot SFX play: a (category, variant) cooldown plus a 3-entry recently-played
+// ring guard against retriggering the same sound too often (announcer lines, one-shots).
+#define swrSound_IsSfxOnCooldown_ADDR (0x00427360)
+#define swrSound_PushRecentSfx_ADDR (0x004273b0)
+#define swrSound_WasSfxRecentlyPlayed_ADDR (0x004273e0)
+#define swrSound_PlaySfxThrottled_ADDR (0x00427410)
+#define swrSound_MarkSfxPlayed_ADDR (0x00427530)
 #define swrSound_UpdateEngineAudio_ADDR (0x00427b20)
 #define swrSound_PreloadSoundSet_ADDR (0x00427d90)
 #define swrSound_PreloadRacerSounds_ADDR (0x00427f10)
@@ -142,6 +149,20 @@ void swrSound_SetPlayEvent(void);
 // Resolve a (category 0..7, id) pair to a bank sound index via per-category
 // lookup tables; returns the index or -1.
 int swrSound_ResolveSfxId(int category, int variant, int id);
+
+// Throttled one-shot SFX: skip if voices are disabled, the (category, variant) is on
+// cooldown, the sound was recently played, or it is already active on a channel; otherwise
+// resolve, play (positional via PlaySpatialRange if position != NULL, else playASound), and
+// record the play. Guards announcer / one-shot lines against spamming.
+void swrSound_PlaySfxThrottled(int category, int variant, int id, rdVector3* position);
+// True if (category, variant) is still within its post-play cooldown window.
+int swrSound_IsSfxOnCooldown(int category, int variant);
+// Push a sound index into the 3-entry recently-played ring buffer; returns the wrap count.
+int swrSound_PushRecentSfx(short soundId);
+// True if the sound index is currently in the recently-played ring.
+int swrSound_WasSfxRecentlyPlayed(int soundId);
+// Record the play time/category so later calls can apply the cooldown + recent-played checks.
+void swrSound_MarkSfxPlayed(int category, int variant, int soundId, int param4);
 
 // Per-frame engine/surface SFX: select and play loop sounds keyed by speed.
 void swrSound_UpdateEngineAudio(int param1, int param2, float* param3);


### PR DESCRIPTION
Name 25 functions of the A3D-based audio subsystem, with _ADDR defines and documented prototypes in swrSound.h. The subsystem: register sounds by name, load their audio on demand within a byte budget (with LRU/clock eviction), resolve and play them 3D-positionally, and mix across 8 channels each frame.

Resource cache: AllocBank, FreeBank, RegisterSound, LoadSoundMap, LoadDefaultBank, LoadSound, UnloadSound, ReadIntoSource, EvictSounds. Manager: Teardown, SetDefaultConfig, GetEntry, AcquireSource, UnloadAll. Playback/SFX: ResolveSfxId, PlaySpatial, PlaySpatialRange, PreloadSfx, PreloadRacerSounds, PreloadSoundSet, UpdateEngineAudio. Channel mixer: Update (the per-frame tick), ResetChannel, ResetChannels, RewindChannels.

The 0x4c-byte bank descriptor layout is documented inline. Source/descriptor pointers are typed void* for now (no swrSoundEntry struct yet). No behavior change; header-only.