### PR TITLE
input: map the controller subsystem (bindings, polling, force-feedback)

### DIFF
--- a/src/Main/swrControl.h
+++ b/src/Main/swrControl.h
@@ -5,27 +5,105 @@
 
 #define swrControl_MappingsMenu_ADDR (0x00402250)
 
+#define swrControl_Initialize_ADDR (0x00404b10)
 #define swrControl_Shutdown_ADDR (0x00404da0)
 #define swrControl_ProcessInputs_ADDR (0x00404dd0)
+#define swrControl_ClearDeviceState_ADDR (0x00405cf0)
+#define swrControl_SetDefaultMappings_ADDR (0x00405ea0)
+#define swrControl_LoadMappings_ADDR (0x00406470)
 
 #define swrControl_RemoveMapping_ADDR (0x00407500)
+#define swrControl_ApplyAxisConfig_ADDR (0x00407630)
+#define swrControl_ClearBindings_ADDR (0x00407800)
+
+#define swrControl_ReplaceMapping_ADDR (0x004078a0)
 
 #define swrControl_AddMapping_ADDR (0x004078e0)
 
-#define swrControl_ReplaceMapping_ADDR (0x004078a0)
+// Config parsers + per-frame input helpers.
+#define swrControl_ParseKeyName_ADDR (0x00407a90)
+#define swrControl_ParseFunctionName_ADDR (0x00407cd0)
+#define swrControl_PollAccept_ADDR (0x00407ea0)
+#define swrControl_PollCancel_ADDR (0x00407f80)
+#define swrControl_AxisAsButton_ADDR (0x00408040)
+#define swrControl_SnapshotKeyboard_ADDR (0x00408120)
+
+// Force feedback (DirectInput effects loaded from data/bundle*.fcr via cifr_*).
+#define swrControl_LoadForceEffects_ADDR (0x00409d70)
+#define swrControl_PlayForceEffect_ADDR (0x00409ee0)
+#define swrControl_StopForceEffect_ADDR (0x0040a0b0)
+#define swrControl_StopAllForceEffects_ADDR (0x0040a120)
+#define swrControl_PrepareForceEffect_ADDR (0x0040a240)
 
 #define swrControl_Startup_ADDR (0x00423efd)
 
 int swrControl_MappingsMenu(swrUI_unk* param_1, unsigned int param_2, unsigned int param_3, int param_4);
 
+// Initialize the control system: start/open stdControl, enable joystick + mouse
+// axes, load force-feedback config and key bindings (default fallback). 0 = ok.
+int swrControl_Initialize(void);
+
 int swrControl_Shutdown(void);
 void swrControl_ProcessInputs(void);
 
+// Clear a device class's accumulated input state (-1 = final outputs too,
+// 0 = joystick, 1 = mouse, 2 = keyboard).
+void swrControl_ClearDeviceState(int deviceClass);
+
+// Build a device's default binding table from the hardcoded list
+// (device 0 = joystick, 1 = mouse, 2 = keyboard).
+void swrControl_SetDefaultMappings(int device);
+
+// Parse a config file into the binding tables (KEY/BUTTON/FUNCTION/AXIS_RANGE/
+// FLIP_AXIS/SENSITIVITY/DEADZONE/ENABLED). deviceFilter -1 = all devices.
+int swrControl_LoadMappings(int deviceFilter, char* configName, int useDefaultDir);
+
 int swrControl_RemoveMapping(void* cid, char* mondo_text, int param_3, int whichone, int bool_unk);
+
+// Push the parsed sensitivity/deadzone for an axis into its stdControl registration.
+void swrControl_ApplyAxisConfig(int axis);
+
+// Clear binding tables + action outputs (deviceFilter -1 = all, 0/1/2 = device).
+void swrControl_ClearBindings(int deviceFilter);
+
+void swrControl_ReplaceMapping(void* cid, char* fnStr, int whichOne, int bAnalogCapture, int unk, int controllerBinding);
 
 int swrControl_AddMapping(void* cid, char* fnStr, int controllerBinding, int bAnalogCapture, int unk, int unk2);
 
-void swrControl_ReplaceMapping(void* cid, char* fnStr, int whichOne, int bAnalogCapture, int unk, int controllerBinding);
+// Parse a key/button name (via keyMapping tables) to its input code.
+int swrControl_ParseKeyName(char* name, void* keyTable);
+
+// Parse a FUNCTION (action) name to its action id + flags, writing into outEntry.
+int swrControl_ParseFunctionName(void* outEntry, char* name, int mode);
+
+// Poll the unified accept action (Enter / Space / numpad-enter / a joystick
+// button / forward axis); excludeDevice skips one source. Returns 1 if active.
+int swrControl_PollAccept(int excludeDevice);
+
+// Poll the unified cancel/back action (Escape + buttons). Returns 1 if active.
+int swrControl_PollCancel(int excludeDevice);
+
+// Return 1 if axis is pushed past threshold (direction 0 = either sign,
+// +/-1 = that sign); reads axisId when >= 0, otherwise tests value.
+int swrControl_AxisAsButton(int axisId, int direction, float value, float threshold);
+
+// Snapshot all 256 key states and drain the buffered-key (WndProc) queue.
+void swrControl_SnapshotKeyboard(void);
+
+// Load the force-feedback effect bundle for a device (data/bundle*.fcr).
+int swrControl_LoadForceEffects(int deviceType);
+
+// Play/update a force-feedback effect (magnitude / direction / duration).
+int swrControl_PlayForceEffect(int effectId, int magnitude, int direction, int duration);
+
+// Stop one force-feedback effect.
+int swrControl_StopForceEffect(int effectId);
+
+// Stop all force-feedback effects (reInit != 0 re-plays the default).
+void swrControl_StopAllForceEffects(int reInit);
+
+// Bind a force-feedback effect to a DirectInput effect slot before playing.
+int swrControl_PrepareForceEffect(int effectId, int param2);
 
 int swrControl_Startup(void);
 

--- a/src/Platform/cifr.h
+++ b/src/Platform/cifr.h
@@ -1,0 +1,64 @@
+#ifndef CIFR_H
+#define CIFR_H
+
+#include "types.h"
+
+// Force-feedback effect wrapper over the Immersion IFORCE / TouchSense SDK
+// (the _IF* imports). Effects are authored in an Immersion .fcr project file
+// (data/bundle.fcr / bundle2.fcr) and driven as DirectInput effects. An "effect"
+// is a ~0x174 byte slot holding up to N DirectInput effect interface pointers;
+// the controller owns an array of 6 effect slots. Used by the swrControl force
+// feedback layer (swrControl_PlayForceEffect etc.).
+
+#define cifr_Init_ADDR (0x00403e10)
+#define cifr_LoadProjectFile_ADDR (0x00403f30)
+#define cifr_LoadAllEffects_ADDR (0x00403fd0)
+#define cifr_CreateEffect_ADDR (0x004040a0)
+#define cifr_ReleaseEffect_ADDR (0x00404190)
+#define cifr_StartEffect_ADDR (0x004041c0)
+#define cifr_StopEffect_ADDR (0x00404230)
+#define cifr_IsPlaying_ADDR (0x00404280)
+#define cifr_GetDirection_ADDR (0x004042f0)
+#define cifr_SetDirection_ADDR (0x00404330)
+#define cifr_GetMagnitude_ADDR (0x004043d0)
+#define cifr_SetMagnitude_ADDR (0x00404400)
+#define cifr_GetDuration_ADDR (0x004044a0)
+#define cifr_SetDuration_ADDR (0x004044e0)
+
+// Initialize the 6 effect slots and select the force-feedback device.
+void cifr_Init(void* effects);
+
+// Load an Immersion .fcr project file and record each effect's name per slot.
+int cifr_LoadProjectFile(void* effects, char* projectFile, void* nameIndices, void* nameTable);
+
+// Create and download all of a controller's effects to the device.
+int cifr_LoadAllEffects(void* controller);
+
+// Create + download one effect (its DirectInput effect interfaces) to device.
+int cifr_CreateEffect(void* effect, void* params, void* device);
+
+// Release one effect's downloaded DirectInput interfaces.
+int cifr_ReleaseEffect(void* effect, void* device);
+
+// Start playing an effect (checkPlaying != 0 skips if already playing).
+int cifr_StartEffect(void* effect, int checkPlaying);
+
+// Stop an effect.
+int cifr_StopEffect(void* effect);
+
+// Return 1 if the effect is currently playing.
+int cifr_IsPlaying(void* effect);
+
+// Get / set the effect direction in degrees (0..360).
+int cifr_GetDirection(void* effect);
+int cifr_SetDirection(void* effect, int degrees, int deferred);
+
+// Get / set the effect magnitude as a percent (0..100).
+unsigned int cifr_GetMagnitude(void* effect);
+int cifr_SetMagnitude(void* effect, int percent, int deferred);
+
+// Get / set the effect duration in milliseconds (-1 = infinite).
+int cifr_GetDuration(void* effect);
+int cifr_SetDuration(void* effect, int durationMs, int deferred);
+
+#endif // CIFR_H

--- a/src/Platform/stdControl.h
+++ b/src/Platform/stdControl.h
@@ -15,6 +15,9 @@
 #define stdControl_ReadAxisAsKeyEx_ADDR (0x00485840)
 #define stdControl_ReadKey_ADDR (0x00485880)
 
+#define stdControl_SetAxisDeadzone_ADDR (0x004858e0)
+#define stdControl_SetMouseRange_ADDR (0x004859a0)
+
 #define stdControl_SetActivation_ADDR (0x00485a30)
 #define stdControl_InitJoysticks_ADDR (0x00485c40)
 #define stdControl_InitKeyboard_ADDR (0x00485f20)
@@ -36,6 +39,12 @@ float stdControl_ReadAxis(int controlId);
 float stdControl_ReadKeyAsAxis(unsigned int keyId);
 int stdControl_ReadAxisAsKeyEx(int controlId);
 int stdControl_ReadKey(unsigned int keyNum, int* pNumPressed);
+
+// Re-register a joystick axis (0..5) with a deadzone.
+void stdControl_SetAxisDeadzone(float deadzone, int joystick, int axis);
+
+// Set the mouse X/Y axis ranges from configured sensitivity.
+void stdControl_SetMouseRange(float xRange, float yRange);
 
 int stdControl_SetActivation(int bActive);
 void stdControl_InitJoysticks(void);


### PR DESCRIPTION
## What

Maps the input/controller subsystem — **33 functions** named with `_ADDR` defines and
documented prototypes (header-only, no behavior change). Two commits: the
`swrControl`/`stdControl` binding+polling+FF layer, then the lower-level `cifr_`
Immersion force-feedback effect wrapper in a new `src/Platform/cifr.h`.

The full flow: **initialize** the input devices → **load/parse** key + axis bindings
(deadzone, sensitivity, axis flip) → **poll** them per frame into game actions →
drive **force-feedback** effects via the Immersion SDK.

## swrControl / stdControl (commit 1)

**Input core** (per-frame polling, atop the now-documented `swrControl_ProcessInputs`):
- `swrControl_AxisAsButton` — analog-axis → digital threshold test
- `swrControl_ClearDeviceState` — clear a device class's accumulated inputs
- `swrControl_PollAccept` / `swrControl_PollCancel` — unified accept/cancel polls
- `swrControl_SnapshotKeyboard` — 256-key snapshot + buffered-key (WndProc) drain

**Bindings / config:**
- `swrControl_Initialize` — bring up the control system (devices, FF config, mappings)
- `swrControl_ClearBindings` / `swrControl_SetDefaultMappings` / `swrControl_LoadMappings` —
  clear, default-populate, and config-file-parse the binding tables
- `swrControl_ParseKeyName` / `swrControl_ParseFunctionName` — config token parsers
- `swrControl_ApplyAxisConfig` — push parsed sensitivity/deadzone into the axis registration

**stdControl axis setters:** `stdControl_SetAxisDeadzone`, `stdControl_SetMouseRange`

**Force-feedback (high level):** `swrControl_LoadForceEffects`, `swrControl_PlayForceEffect`,
`swrControl_StopForceEffect`, `swrControl_StopAllForceEffects`, `swrControl_PrepareForceEffect`

The binding-table layout (0xc-byte `{flags, inputId, actionId}` entries, terminated by
`0xff`; separate joystick/mouse/keyboard tables) and the deadzone/sensitivity globals are
documented inline.

## cifr_ — Immersion force-feedback effects (commit 2)

New `src/Platform/cifr.h` documenting the wrapper over the Immersion IFORCE / TouchSense
SDK (the `_IFCreateEffects_12` / `_IFReleaseEffects_8` / `_IFLoadProjectFile_8` imports).
Effects are authored in an Immersion `.fcr` project (`data/bundle.fcr`, `bundle2.fcr` for
wheels) and driven as DirectInput effects; the controller owns 6 effect slots.

`cifr_Init`, `cifr_LoadProjectFile`, `cifr_LoadAllEffects`, `cifr_CreateEffect`,
`cifr_ReleaseEffect`, `cifr_StartEffect`, `cifr_StopEffect`, `cifr_IsPlaying`,
`cifr_Get`/`SetDirection` (0–360°), `cifr_Get`/`SetMagnitude` (0–100%),
`cifr_Get`/`SetDuration` (ms, −1 = infinite).

## Testing

Builds clean (WinLibs GCC 13.2, MinGW); `dinput.dll` links. All headers are ASCII-only.

## Notes
- A couple of poll/helper names (`PollAccept`/`PollCancel`, `PrepareForceEffect`) are
  inferred from the read key codes / call sites and could be refined.
- Out of scope: the low-level `stdControl` DirectInput plumbing (device enumeration
  callbacks, `ReadJoysticks`/`ReadMouse` internals).