### PR TITLE
swrObjJdge: map the race-manager (judge) subsystem

### DIFF
--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -95,6 +95,7 @@
 #define swrObjJdge_ScrollCredits_ADDR (0x0045d130)
 #define swrObjJdge_UpdateViewportLayout_ADDR (0x0045dad0)
 #define swrObjJdge_DrawRaceHUD_ADDR (0x0045f230)
+#define swrObjJdge_DrawHudBar_ADDR (0x00460320)
 #define swrObjJdge_DrawSplitDivider_ADDR (0x004610f0)
 #define swrObjJdge_IsRacerRacing_ADDR (0x00462a70)
 #define swrObjJdge_UpdatePlayerHUD_ADDR (0x00462b20)
@@ -274,6 +275,9 @@ void swrObjJdge_UpdateViewportLayout(swrObjJdge* jdge, int mode);
 void swrObjJdge_ScrollCredits(swrObjJdge* jdge);
 // Standings/position HUD + full-screen minimap state machine (keyed on hud_mode).
 void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge);
+// Draws a centered HUD meter sprite (id 0x1a) sized/colored by a race metric (_DAT_00e9824c),
+// hidden below threshold. Exact metric uncertain (boost/charge-like bar).
+void swrObjJdge_DrawHudBar(void);
 // Per-racer HUD: in-race timer, engine UI, finish statistics and the lap marker.
 void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score);
 // Whether a racer is still actively racing (not finished / at the finish line).

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -100,6 +100,11 @@
 #define swrObjJdge_UpdatePlayerHUD_ADDR (0x00462b20)
 #define swrObjJdge_UpdateCountdownLights_ADDR (0x00462da0)
 #define swrObjJdge_UpdateMinimap_ADDR (0x004634a0)
+#define swrObjJdge_GetRacerProgress_ADDR (0x0045d410)
+#define swrObjJdge_TeardownRace_ADDR (0x0045dd80)
+#define swrObjJdge_StartPostRaceSequence_ADDR (0x0045dfe0)
+#define swrObjJdge_CycleHudMode_ADDR (0x0045e1a0)
+#define swrObjJdge_HideEngineUI_ADDR (0x00461150)
 
 #define swrObjElmo_F0_ADDR (0x00467cd0)
 
@@ -269,6 +274,16 @@ void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score);
 int swrObjJdge_IsRacerRacing(swrObjJdge* jdge, swrRace* racer);
 // Draws the 2-player split-screen divider bar.
 void swrObjJdge_DrawSplitDivider(void);
+// Returns a racer's race progress (laps + fractional checkpoint) for placement/standings.
+float swrObjJdge_GetRacerProgress(swrScore* score);
+// Tears down the race: clears all entities, resets HUD/cameras, then restarts the track or returns to the hangar.
+void swrObjJdge_TeardownRace(swrObjJdge* jdge, int event);
+// Begins the post-race sequence (camera 'Swee' sweep + state/viewport transition).
+void swrObjJdge_StartPostRaceSequence(swrObjJdge* jdge);
+// Cycles the standings/HUD display mode (hud_mode) on the HUD button.
+void swrObjJdge_CycleHudMode(swrObjJdge* jdge);
+// Hides a racer's engine-health UI sprites.
+void swrObjJdge_HideEngineUI(swrScore* score);
 
 void swrObjElmo_F0(swrObjElmo* elmo);
 

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -91,6 +91,16 @@
 
 #define swrObjJdge_InitTrack_ADDR (0x00466BD0)
 
+// race-manager HUD / display / state helpers
+#define swrObjJdge_ScrollCredits_ADDR (0x0045d130)
+#define swrObjJdge_UpdateViewportLayout_ADDR (0x0045dad0)
+#define swrObjJdge_DrawRaceHUD_ADDR (0x0045f230)
+#define swrObjJdge_DrawSplitDivider_ADDR (0x004610f0)
+#define swrObjJdge_IsRacerRacing_ADDR (0x00462a70)
+#define swrObjJdge_UpdatePlayerHUD_ADDR (0x00462b20)
+#define swrObjJdge_UpdateCountdownLights_ADDR (0x00462da0)
+#define swrObjJdge_UpdateMinimap_ADDR (0x004634a0)
+
 #define swrObjElmo_F0_ADDR (0x00467cd0)
 
 #define swrObjElmo_F3_ADDR (0x00468570)
@@ -241,6 +251,24 @@ void InitPrimaryLight();
 void InitAISettingsForTrack(swrObjJdge*);
 
 unsigned int swrObjJdge_InitTrack(swrObjJdge* judge, swrScore* scores);
+
+// race-manager HUD / display / state helpers:
+// "3-2-1-Go" countdown lights, start-gate node colors, and countdown sounds.
+void swrObjJdge_UpdateCountdownLights(swrObjJdge* jdge);
+// Per-racer minimap position dots.
+void swrObjJdge_UpdateMinimap(swrObjJdge* jdge);
+// Configures the viewport(s)/cameras for the current screen (in-race vs results, 1P vs 2P split).
+void swrObjJdge_UpdateViewportLayout(swrObjJdge* jdge, int mode);
+// End-of-game credits scroll; clears the judge when finished.
+void swrObjJdge_ScrollCredits(swrObjJdge* jdge);
+// Standings/position HUD + full-screen minimap state machine (keyed on hud_mode).
+void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge);
+// Per-racer HUD: in-race timer, engine UI, finish statistics and the lap marker.
+void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score);
+// Whether a racer is still actively racing (not finished / at the finish line).
+int swrObjJdge_IsRacerRacing(swrObjJdge* jdge, swrRace* racer);
+// Draws the 2-player split-screen divider bar.
+void swrObjJdge_DrawSplitDivider(void);
 
 void swrObjElmo_F0(swrObjElmo* elmo);
 

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -106,6 +106,12 @@
 #define swrObjJdge_CycleHudMode_ADDR (0x0045e1a0)
 #define swrObjJdge_HideEngineUI_ADDR (0x00461150)
 
+// race standings / positions / overtake feedback
+#define swrObjJdge_GetRacerRankValue_ADDR (0x0045d480)
+#define swrObjJdge_UpdateStandings_ADDR (0x0045d4a0)
+#define swrObjJdge_UpdateSplineGuideNodes_ADDR (0x0045e970)
+#define swrObjJdge_UpdateOvertakeSounds_ADDR (0x0045ef70)
+
 #define swrObjElmo_F0_ADDR (0x00467cd0)
 
 #define swrObjElmo_F3_ADDR (0x00468570)
@@ -284,6 +290,17 @@ void swrObjJdge_StartPostRaceSequence(swrObjJdge* jdge);
 void swrObjJdge_CycleHudMode(swrObjJdge* jdge);
 // Hides a racer's engine-health UI sprites.
 void swrObjJdge_HideEngineUI(swrScore* score);
+
+// Sort key for a racer: live race progress while racing, or an inverse-finish-time value once
+// finished (so finishers always sort ahead of still-racing pods).
+float swrObjJdge_GetRacerRankValue(swrScore* score);
+// Recomputes the field standings: ranks all racers by GetRacerRankValue, assigns each its
+// position (+0x5c) and the gap-to-leader / gap-ahead / gap-behind values, and sets catch-up flags.
+void swrObjJdge_UpdateStandings(swrObjJdge* jdge);
+// Places the 7 fading guide nodes that trail along the spline behind a racer.
+void swrObjJdge_UpdateSplineGuideNodes(int nodeOwner, swrScore* score);
+// On a position change, finds the adjacent racer and plays the positional overtake/taunt SFX.
+void swrObjJdge_UpdateOvertakeSounds(swrObjJdge* jdge);
 
 void swrObjElmo_F0(swrObjElmo* elmo);
 

--- a/src/types.h
+++ b/src/types.h
@@ -748,7 +748,7 @@ extern "C"
         rdMatrix44 unk64_mat;
         rdMatrix44 unk80_mat;
         rdMatrix44 unkbc_mat;
-        int unk124;
+        int hud_mode; // 0x124. annodue: _hud_mode
         int event;
         char unk128[4];
         void* unk12c;
@@ -766,8 +766,8 @@ extern "C"
         char unk1c4[4];
         int num_laps;
         float unk1cc_ms;
-        float best_lap_time_ms;
-        char unk1d4[4];
+        float best_lap_time_ms; // 0x1d0. annodue: RecordLap1
+        float recordLap3_ms; // 0x1d4. annodue: RecordLap3
         int unk1d8;
         int unk1dc;
         int unk1e0;


### PR DESCRIPTION
Names 13 functions in the race manager (`swrObjJdge`, annodue's "Jdge" entity) —
the race referee that runs the state machine, standings, and HUD. Declared in
`src/Swr/swrObj.h`. annodue gave the struct layout but no function names beyond
the stage slots, so naming is analysis-based; the `F0`/`F2`/`F3` stage slots are
left as-is per convention (they hold the state machine and progression engine).

### State-machine drivers
`UpdateCountdownLights` (3-2-1-Go lights/sounds), `StartPostRaceSequence`
(post-race camera sweep), `TeardownRace` (clear entities, reset HUD/cameras,
restart or return to hangar), `CycleHudMode`

### HUD / standings / display
`DrawRaceHUD` (standings + full-screen minimap), `UpdatePlayerHUD`,
`UpdateMinimap`, `DrawSplitDivider`, `ScrollCredits`, `HideEngineUI`,
`UpdateViewportLayout`

### Logic
`IsRacerRacing`, `GetRacerProgress` (lap + checkpoint placement metric)

### Struct
Added `hud_mode` (`0x124`) and `recordLap3_ms` (`0x1d4`) to `swrObjJdge` from
annodue (the struct was otherwise already mapped).

Header-only; no behavioral changes. The per-racer lap/checkpoint progress
updater (`0x47ffb0`) and a few sibling helpers are undefined functions that need
a Ghidra `Create Function` pass first — left for a follow-up.