### PR TITLE
swrObjHang: map the hangar front-end (menus + shop)

### DIFF
--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -13,6 +13,15 @@
 
 #define DrawTracks_ADDR (0x004360e0)
 
+// hangar front-end per-screen update handlers (dispatched by swrObjHang_F0 on swrObjHang_STATE)
+#define swrObjHang_UpdateLegalScreen_ADDR (0x00434ec0)
+#define swrObjHang_UpdateSplashScreen_ADDR (0x00435240)
+#define swrObjHang_UpdateEnterName_ADDR (0x004367c0)
+#define swrObjHang_UpdateMainMenu_ADDR (0x00436860)
+#define swrObjHang_UpdateWattoShop_ADDR (0x004376c0)
+#define swrObjHang_UpdateLookAtVehicle_ADDR (0x00437f70)
+#define swrObjHang_UpdateJunkyard_ADDR (0x0043abc0)
+
 #define GetRequiredPlaceToProceed_ADDR (0x00440a00)
 #define isTrackUnlocked_ADDR (0x00440a20)
 #define isTrackPlayable_ADDR (0x00440aa0)
@@ -164,6 +173,15 @@ void swrObjHang_SetHangar2(swrObjHang* hang);
 void swrObjHang_SetUnused(void);
 
 void DrawTracks(swrObjHang* hang, char param_2);
+
+// hangar front-end per-screen update handlers (dispatched by swrObjHang_F0 on swrObjHang_STATE):
+void swrObjHang_UpdateLegalScreen(swrObjHang* hang);
+void swrObjHang_UpdateSplashScreen(swrObjHang* hang);
+void swrObjHang_UpdateEnterName(swrObjHang* hang);
+void swrObjHang_UpdateMainMenu(swrObjHang* hang);
+void swrObjHang_UpdateWattoShop(swrObjHang* hang);     // parts / pit-droid shop
+void swrObjHang_UpdateLookAtVehicle(swrObjHang* hang); // view-pod 3D screen
+void swrObjHang_UpdateJunkyard(swrObjHang* hang);      // used-parts screen
 
 char GetRequiredPlaceToProceed(char circuitIdx, char trackIdx);
 int isTrackUnlocked(char circuitId, char trackId);

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -29,6 +29,14 @@
 #define swrObjHang_NavigateMenu_ADDR (0x0045bde0)
 #define swrObjHang_FocusMenuItem_ADDR (0x0045bee0)
 
+// hangar transition/cutscene state handlers (swrObjHang_STATE 14-18) + screen loader; best-effort
+#define swrObjHang_UpdateLoadScreen_ADDR (0x00434ea0)
+#define swrObjHang_UpdateVehicleSelectIntro_ADDR (0x0043c6f0)
+#define swrObjHang_UpdateTauntScene_ADDR (0x0043ca30)
+#define swrObjHang_UpdatePlanetSelectIntro_ADDR (0x0043ceb0)
+#define swrObjHang_UpdateResultsIntro_ADDR (0x0043d4e0)
+#define swrObjHang_LoadScreen_ADDR (0x00457410)
+
 #define GetRequiredPlaceToProceed_ADDR (0x00440a00)
 #define isTrackUnlocked_ADDR (0x00440a20)
 #define isTrackPlayable_ADDR (0x00440aa0)
@@ -201,6 +209,20 @@ int swrObjHang_IsCameraMoving(swrObjHang* hang);
 void swrObjHang_NavigateMenu(swrObjHang* hang, short dir, int param_3);
 // Focuses a specific menu item (sets the camera index and queues the next state).
 void swrObjHang_FocusMenuItem(swrObjHang* hang, int itemIndex, swrObjHang_STATE nextState, int param_4);
+
+// hangar transition/cutscene state handlers (swrObjHang_STATE 14-18) + screen loader (best-effort):
+// Reloads the current hangar screen scene; plays the planet cinematic on first visit.
+void swrObjHang_LoadScreen(swrObjHang* hang, int param_2, int param_3);
+// State 14: (re)loads the screen via swrObjHang_LoadScreen.
+void swrObjHang_UpdateLoadScreen(swrObjHang* hang);
+// State 15: opponent taunt scene (pilot voice lines).
+void swrObjHang_UpdateTauntScene(swrObjHang* hang);
+// State 16: camera fly-through into planet selection.
+void swrObjHang_UpdatePlanetSelectIntro(swrObjHang* hang);
+// State 17: camera transition into the post-race results.
+void swrObjHang_UpdateResultsIntro(void);
+// State 18: holo-planet + camera cutscene into vehicle selection.
+void swrObjHang_UpdateVehicleSelectIntro(swrObjHang* hang);
 
 char GetRequiredPlaceToProceed(char circuitIdx, char trackIdx);
 int isTrackUnlocked(char circuitId, char trackId);

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -22,6 +22,13 @@
 #define swrObjHang_UpdateLookAtVehicle_ADDR (0x00437f70)
 #define swrObjHang_UpdateJunkyard_ADDR (0x0043abc0)
 
+// hangar menu navigation + shop (parts/truguts)
+#define swrObjHang_UpdateScreenTransition_ADDR (0x0043da90)
+#define swrObjHang_SwapSelectedPart_ADDR (0x00440800)
+#define swrObjHang_IsCameraMoving_ADDR (0x00440b50)
+#define swrObjHang_NavigateMenu_ADDR (0x0045bde0)
+#define swrObjHang_FocusMenuItem_ADDR (0x0045bee0)
+
 #define GetRequiredPlaceToProceed_ADDR (0x00440a00)
 #define isTrackUnlocked_ADDR (0x00440a20)
 #define isTrackPlayable_ADDR (0x00440aa0)
@@ -182,6 +189,18 @@ void swrObjHang_UpdateMainMenu(swrObjHang* hang);
 void swrObjHang_UpdateWattoShop(swrObjHang* hang);     // parts / pit-droid shop
 void swrObjHang_UpdateLookAtVehicle(swrObjHang* hang); // view-pod 3D screen
 void swrObjHang_UpdateJunkyard(swrObjHang* hang);      // used-parts screen
+
+// hangar menu navigation + shop (parts/truguts):
+// Pans the camera into a screen, then commits the queued state transition; returns 1 when done.
+int swrObjHang_UpdateScreenTransition(swrObjHang* hang, int param_2, int param_3);
+// Swaps the selected part between the pod and the junkyard inventory (models + truguts).
+void swrObjHang_SwapSelectedPart(swrObjHang* hang);
+// Whether the hangar camera is still moving toward its target menu position.
+int swrObjHang_IsCameraMoving(swrObjHang* hang);
+// Moves the menu selection/camera to the adjacent valid item in the current room.
+void swrObjHang_NavigateMenu(swrObjHang* hang, short dir, int param_3);
+// Focuses a specific menu item (sets the camera index and queues the next state).
+void swrObjHang_FocusMenuItem(swrObjHang* hang, int itemIndex, swrObjHang_STATE nextState, int param_4);
 
 char GetRequiredPlaceToProceed(char circuitIdx, char trackIdx);
 int isTrackUnlocked(char circuitId, char trackId);


### PR DESCRIPTION
Names 12 functions in the hangar/front-end (`swrObjHang`, annodue's "Hang"
entity) — everything between races. Declared in `src/Swr/swrObj.h`. The struct
was already mapped; `swrObjHang_F0` is a switch over the `swrObjHang_STATE` enum
that dispatches each state to its screen handler, so the screen names come
straight from the enum (not guesswork).

### Screen handlers (state → handler)
`UpdateLegalScreen`, `UpdateSplashScreen`, `UpdateEnterName`, `UpdateMainMenu`,
`UpdateWattoShop` (parts/pit-droid shop), `UpdateLookAtVehicle`, `UpdateJunkyard`
(used-parts). SELECT_* / POST_RACE_INFO dispatch to the already-named `swrRace_*`
menu callbacks.

### Menu navigation + shop economy
`UpdateScreenTransition` (camera-pan + commit state change), `SwapSelectedPart`
(the buy/swap transaction — swaps part data + scene models + truguts),
`IsCameraMoving`, `NavigateMenu`, `FocusMenuItem`.

Header-only; no behavioral changes. The state 14–18 transition cutscenes (pilot
taunts, intro fly-throughs) and deeper shop sub-helpers are left for a follow-up
(best named with runtime observation).