### PR TITLE
Map swrMain boot + per-frame loop spine

### DIFF
--- a/src/Main/swrMain.h
+++ b/src/Main/swrMain.h
@@ -8,10 +8,35 @@
 
 #define Main_ParseCmdLine_ADDR (0x00424430)
 
+// Boot init tail (called from Main_Startup).
+#define Main_StartupSoundAndControl_ADDR (0x00411361)
+#define Main_InitAudioInput_ADDR (0x004112e1)
+
+// Per-frame loop helpers (driven by swrMain2_GuiAdvance).
+#define swrMain_ProcessDebugKeys_ADDR (0x004104f0)
+#define swrMain_UpdateNetworkTick_ADDR (0x0041c1d0)
+#define swrMain_RunFrame_ADDR (0x00445980)
+
 int Main_Startup(char* cmdline);
 void Main_Shutdown(void);
 
 void Main_ShutdownError(void);
 int Main_ParseCmdLine(char* cmdline);
+
+// Start the audio and input services: swrSound_Startup + swrControl_Startup.
+void Main_StartupSoundAndControl(void);
+// Init the sound critical section, then start the audio/input services. Tail of Main_Startup.
+int Main_InitAudioInput(void);
+
+// Per-frame core tick: phase 1 (== 1 or 0) updates the world (swrModel_UpdateAnimations,
+// swrEvent_CallAllF0..F3, swrViewport_UpdateCameras, gated by the pause state); phase 2
+// (== 2 or 0) renders (HUD occlusion sample + swrPlayerHUD_RenderAllViewports). flags == 0
+// in the render phase also draws the extra full-screen pass.
+void swrMain_RunFrame(short flags, short phase);
+// Per-frame debug/cheat hotkey handler (FPS toggle, unlock-all, force-feedback/mouse/joystick
+// toggles, the Mars Guo / Bullseye racer swaps).
+void swrMain_ProcessDebugKeys(void);
+// Per-frame network update pacer (gated by Main_nut_delay_ms; drives swrMultiplayer_InRace).
+void swrMain_UpdateNetworkTick(void);
 
 #endif // SWR_MAIN_H

--- a/src/Swr/swrMultiplayer.h
+++ b/src/Swr/swrMultiplayer.h
@@ -16,6 +16,10 @@
 
 #define swrMultiplayer_SetSessionDesc_ADDR (0x00486e60)
 
+// Per-frame: drain and dispatch all queued incoming network packets
+// (sithMulti_HandleIncomingPacket loop). Called from swrMain2_GuiAdvance.
+#define swrMultiplayer_PumpPackets_ADDR (0x0041b7f0)
+
 void swrMultiplayer_SetInMultiplayer(int bInMultiplayer);
 
 int swrMultiplayer_IsMultiplayerEnabled(void);
@@ -35,5 +39,8 @@ void swrMultiplayer_SetLastGame(char* str);
 // int __cdecl stdComm_GetSessionSettings(StdCommSessionSettings* pSettings)
 
 unsigned int swrMultiplayer_SetSessionDesc(int unused, void* param_2);
+
+// Drain and dispatch all queued incoming network packets; returns the count handled.
+int swrMultiplayer_PumpPackets(void);
 
 #endif // SWRMULTIPLAYER_H

--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -98,6 +98,8 @@ FUN_004206b0
 
 #define swrUI_ClearAllSprites_ADDR (0x00417060)
 
+#define swrUI_Initialize_ADDR (0x00410fd0)
+
 #define swrUI_replaceAllocatedStr_ADDR (0x004174e0)
 
 #define swrUI_GetByValue_ADDR (0x0041b5e0)
@@ -204,5 +206,9 @@ void swrUI_LoadUIElements(void);
 void swrUI_LoadWindowUIElements(void);
 void swrUI_LoadPartsUIElements(void);
 void swrUI_LoadSelectionsUIElements(void);
+
+// Initialize the UI system: allocate the element hash table, zero the element arrays, install
+// the default element proc, and run the one-time CPU-speed calibration loop. Called at boot.
+int swrUI_Initialize(void);
 
 #endif // SWRUI_H


### PR DESCRIPTION
Names 7 functions in the game's top-level driver, across 3 headers:

swrMain.h:
- swrMain_RunFrame(flags, phase): the core per-frame tick - phase 1 updates the world (swrModel_UpdateAnimations, swrEvent_CallAllF0..F3, swrViewport_UpdateCameras, pause-gated); phase 2 renders the viewports.
- swrMain_ProcessDebugKeys: per-frame debug/cheat hotkey handler.
- swrMain_UpdateNetworkTick: per-frame network update pacer.
- Main_InitAudioInput / Main_StartupSoundAndControl: boot init tail.

swrMultiplayer.h:
- swrMultiplayer_PumpPackets: drain/dispatch queued incoming packets.

swrUI.h:
- swrUI_Initialize: UI system init (element hash table + default proc + CPU-speed calibration).

These are the helpers driven by swrMain2_GuiAdvance (the master frame fn) and Main_Startup. Header-only change.