### PR TITLE
Add window mode selector (windowed / borderless / fullscreen)

### DIFF
--- a/dinput_hook/game_deltas/Window_delta.c
+++ b/dinput_hook/game_deltas/Window_delta.c
@@ -1,4 +1,5 @@
 #include "Window_delta.h"
+#include "window_mode.h"
 
 #include <stdio.h>
 #include <Windows.h>
@@ -140,25 +141,63 @@ const static int glfw_key_to_dik[] = {
     [GLFW_KEY_MENU] = DIK_RMENU,
 };
 
+int g_window_mode = WINDOW_MODE_WINDOWED;
+
+// Geometry of the last normal windowed state, restored when switching back to windowed.
 static int prev_window_x = 0;
 static int prev_window_y = 0;
 static int prev_window_width = 0;
 static int prev_window_height = 0;
 
+void set_window_mode(int mode) {
+    GLFWwindow *window = glfwGetCurrentContext();
+    if (!window)
+        return;
+
+    // Remember the windowed geometry before leaving a normal windowed state, so it can be
+    // restored later. Don't capture while borderless/fullscreen - that would clobber it.
+    const bool is_fullscreen = glfwGetWindowMonitor(window) != NULL;
+    const bool is_decorated = glfwGetWindowAttrib(window, GLFW_DECORATED);
+    if (!is_fullscreen && is_decorated) {
+        glfwGetWindowPos(window, &prev_window_x, &prev_window_y);
+        glfwGetWindowSize(window, &prev_window_width, &prev_window_height);
+    }
+
+    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+    const GLFWvidmode *vidmode = glfwGetVideoMode(monitor);
+
+    switch (mode) {
+        case WINDOW_MODE_WINDOWED: {
+            const int w = prev_window_width > 0 ? prev_window_width : 1280;
+            const int h = prev_window_height > 0 ? prev_window_height : 720;
+            const int x = prev_window_width > 0 ? prev_window_x : (vidmode->width - w) / 2;
+            const int y = prev_window_height > 0 ? prev_window_y : (vidmode->height - h) / 2;
+            glfwSetWindowAttrib(window, GLFW_DECORATED, GLFW_TRUE);
+            glfwSetWindowMonitor(window, NULL, x, y, w, h, 0);
+            break;
+        }
+        case WINDOW_MODE_BORDERLESS:
+            glfwSetWindowAttrib(window, GLFW_DECORATED, GLFW_FALSE);
+            glfwSetWindowMonitor(window, NULL, 0, 0, vidmode->width, vidmode->height, 0);
+            break;
+        case WINDOW_MODE_FULLSCREEN:
+            glfwSetWindowMonitor(window, monitor, 0, 0, vidmode->width, vidmode->height,
+                                 vidmode->refreshRate);
+            break;
+        default:
+            return;
+    }
+
+    g_window_mode = mode;
+}
+
 static void key_callback(GLFWwindow *window, int key, int scancode, int action, int mods) {
     if (key == GLFW_KEY_ENTER && action == GLFW_PRESS && mods & GLFW_MOD_ALT) {
-        bool fullscreen = glfwGetWindowMonitor(window);
-        if (!fullscreen) {
-            glfwGetWindowPos(window, &prev_window_x, &prev_window_y);
-            glfwGetWindowSize(window, &prev_window_width, &prev_window_height);
-            GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-            const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-            glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height,
-                                 mode->refreshRate);
-        } else {
-            glfwSetWindowMonitor(window, NULL, prev_window_x, prev_window_y, prev_window_width,
-                                 prev_window_height, 0);
-        }
+        // Alt+Enter toggles windowed <-> exclusive fullscreen; borderless is reachable from
+        // the debug menu dropdown.
+        set_window_mode(g_window_mode == WINDOW_MODE_FULLSCREEN ? WINDOW_MODE_WINDOWED
+                                                                : WINDOW_MODE_FULLSCREEN);
+        save_window_mode_setting();
         return;
     }
 

--- a/dinput_hook/game_deltas/window_mode.h
+++ b/dinput_hook/game_deltas/window_mode.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Window display modes selectable from the debug menu dropdown (and Alt+Enter).
+enum WindowMode {
+    WINDOW_MODE_WINDOWED = 0,  // decorated, resizable window
+    WINDOW_MODE_BORDERLESS = 1,// undecorated window filling the primary monitor
+    WINDOW_MODE_FULLSCREEN = 2,// exclusive fullscreen on the primary monitor
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Source of truth for the current window mode (one of WindowMode). Defined in Window_delta.c.
+extern int g_window_mode;
+
+// Applies `mode` to the GLFW window and updates g_window_mode. Safe to call once the
+// GLFW window/context exists. Does not persist the choice (see save_window_mode_setting).
+void set_window_mode(int mode);
+
+// Persists the current window mode to SW_RACER_RE.ini. Implemented in imgui_utils.cpp.
+void save_window_mode_setting(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -15,6 +15,7 @@
 #include "texture_replacement.h"
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
+#include "game_deltas/window_mode.h"
 
 extern "C" {
 #include <globals.h>
@@ -82,6 +83,14 @@ void read_settings_ini() {
     }
 
     imgui_state.enable_fog = GetPrivateProfileIntW(L"settings", L"enable_fog", 1, ini_path.c_str());
+
+    g_window_mode = GetPrivateProfileIntW(L"settings", L"window_mode", WINDOW_MODE_WINDOWED,
+                                          ini_path.c_str());
+    if (g_window_mode < WINDOW_MODE_WINDOWED || g_window_mode > WINDOW_MODE_FULLSCREEN)
+        g_window_mode = WINDOW_MODE_WINDOWED;
+    // The window starts as a maximized windowed window, so only apply non-windowed modes here.
+    if (g_window_mode != WINDOW_MODE_WINDOWED)
+        set_window_mode(g_window_mode);
 }
 
 void save_settings_ini() {
@@ -91,6 +100,13 @@ void save_settings_ini() {
                                std::to_wstring(imgui_state.anisotropy).c_str(), ini_path.c_str());
     WritePrivateProfileStringW(L"settings", L"enable_fog", imgui_state.enable_fog ? L"1" : L"0",
                                ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"window_mode",
+                               std::to_wstring(g_window_mode).c_str(), ini_path.c_str());
+}
+
+// Called from the (C) window key callbacks so Alt+Enter persists the chosen mode too.
+extern "C" void save_window_mode_setting(void) {
+    save_settings_ini();
 }
 
 const char *swrModel_NodeTypeStr(uint32_t nodeType) {
@@ -332,6 +348,14 @@ void opengl_render_imgui() {
             save_settings_ini();
         }
         if (ImGui::Checkbox("Enable fog", &imgui_state.enable_fog)) {
+            save_settings_ini();
+        }
+
+        static const char *window_mode_items[] = {"Windowed", "Borderless", "Fullscreen"};
+        int window_mode = g_window_mode;
+        if (ImGui::Combo("Window mode", &window_mode, window_mode_items,
+                         IM_ARRAYSIZE(window_mode_items))) {
+            set_window_mode(window_mode);
             save_settings_ini();
         }
         ImGui::TreePop();

--- a/dinput_hook/renderer_utils.cpp
+++ b/dinput_hook/renderer_utils.cpp
@@ -20,6 +20,7 @@
 #include "gltf_utils.h"
 #include "renderer_hook.h"
 #include "shaders_utils.h"
+#include "game_deltas/window_mode.h"
 
 extern "C" {
 #include <Platform/std3D.h>
@@ -1456,11 +1457,6 @@ static void renderer_viewFromTransforms(rdMatrix44 *view_mat, rdVector3 *positio
 
 static int glfw_key_to_dik[349];
 
-static int prev_window_x = 0;
-static int prev_window_y = 0;
-static int prev_window_width = 0;
-static int prev_window_height = 0;
-
 rdVector3 debugCameraPos = {2.0, 56.003, 4.026};
 rdVector3 cameraFront = {-0.99, 0, 0.0};
 rdVector3 cameraUp = {0, 1, 0};
@@ -1540,18 +1536,11 @@ static void debug_scene_key_callback(GLFWwindow *window, int key, int scancode, 
     }
 
     if (key == GLFW_KEY_ENTER && action == GLFW_PRESS && mods & GLFW_MOD_ALT) {
-        bool fullscreen = glfwGetWindowMonitor(window);
-        if (!fullscreen) {
-            glfwGetWindowPos(window, &prev_window_x, &prev_window_y);
-            glfwGetWindowSize(window, &prev_window_width, &prev_window_height);
-            GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-            const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-            glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height,
-                                 mode->refreshRate);
-        } else {
-            glfwSetWindowMonitor(window, NULL, prev_window_x, prev_window_y, prev_window_width,
-                                 prev_window_height, 0);
-        }
+        // Alt+Enter toggles windowed <-> exclusive fullscreen; borderless is reachable from
+        // the debug menu dropdown.
+        set_window_mode(g_window_mode == WINDOW_MODE_FULLSCREEN ? WINDOW_MODE_WINDOWED
+                                                                : WINDOW_MODE_FULLSCREEN);
+        save_window_mode_setting();
         return;
     }
 


### PR DESCRIPTION
## Summary

Adds a **Window mode** dropdown to the debug menu (under *graphics settings*) so players can switch between **Windowed**, **Borderless windowed**, and **Fullscreen** at runtime. The selection persists to `SW_RACER_RE.ini` and is reapplied on the next launch.

Previously the only display toggle was Alt+Enter (windowed ↔ exclusive fullscreen); borderless windowed wasn't reachable.

## Changes

- **New `dinput_hook/game_deltas/window_mode.h`** — `WindowMode` enum plus a small C/C++-safe API (`set_window_mode`, `g_window_mode`, `save_window_mode_setting`).
- **`Window_delta.c`** — implements `set_window_mode()` (the GLFW work + a single copy of the windowed-geometry capture/restore). Alt+Enter routes through it.
  - *Windowed*: `GLFW_DECORATED` on, restore last windowed pos/size (fallback 1280×720 centered).
  - *Borderless*: `GLFW_DECORATED` off, `glfwSetWindowMonitor(NULL, …)` sized to the monitor — windowed, no mode switch.
  - *Fullscreen*: `glfwSetWindowMonitor(monitor, …)` — exclusive (unchanged behavior).
- **`renderer_utils.cpp`** — the free-cam debug scene's Alt+Enter now routes through the shared function; removed its duplicate `prev_window_*` statics.
- **`imgui_utils.cpp`** — the dropdown widget, plus ini load/save and startup apply.

## Behavior notes

- Alt+Enter keeps its meaning (Windowed ↔ Fullscreen) and now keeps the dropdown in sync; borderless is dropdown-only.
- Default `Windowed` preserves the current maximized-on-startup behavior — non-windowed modes are only applied at startup if previously saved.

## Testing

- Builds and links cleanly with the WinLibs GCC 13.2 hook toolchain (`dinput.dll`).
- Runtime in-game verification of the three modes + persistence across restart is still recommended (not yet run).