### PR TITLE
Fix hang/cursor stutter when closing via the window X

### DIFF
--- a/dinput_hook/game_deltas/Window_delta.c
+++ b/dinput_hook/game_deltas/Window_delta.c
@@ -394,6 +394,18 @@ int Window_Main_delta(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLin
 #endif
     }
 
+    // Closing via the window's X sets glfwWindowShouldClose and drops out of the loop here.
+    // The GLFW window bypasses the original Window_msg_main_handler, so its WM_DESTROY ->
+    // Main_Shutdown() path never runs. Without this the process unwinds out of WinMain and the
+    // OS has to forcibly reclaim the GL context, sound and (still-acquired) input devices, which
+    // stalls the system briefly and never saves the profile. Run the same graceful teardown the
+    // in-game "Quit Game" option does (Main_Shutdown saves the profile, stops sound and releases
+    // input/display in order) so the X button closes as cleanly as the menu quit.
+    Main_Shutdown();
+    // Terminate immediately, exactly like the in-game "Quit Game" (Main_Shutdown(); exit(0);).
+    // Returning instead would unwind back through WinMain and run the DLL's graceful GL/GLFW +
+    // C++ static-destructor teardown, which adds a noticeable ~1s delay after shutdown.
+    ExitProcess(0);
     return 0;
 }
 


### PR DESCRIPTION
Closing the game with the window **X** briefly hung the system and stuttered the cursor; closing via the in-game **Quit Game** was instant. The X path also silently skipped the profile save.

**Cause:** the GLFW window in `Window_Main_delta` bypasses the original `Window_msg_main_handler`, so its `WM_DESTROY -> Main_Shutdown()` path never ran. On X-close the loop just exited and the process unwound with no graceful teardown, leaving the OS to forcibly reclaim the GL context, sound, and the still-acquired input devices.

**Fix:** when the loop exits, do exactly what the in-game quit does — `Main_Shutdown()` (saves the profile, stops sound, releases input/display in order) then `ExitProcess(0)`. `ExitProcess` skips the ~1s graceful GL/GLFW + C++ static-destructor unwind that a plain `return` would trigger, so the X now closes as instantly as the menu quit.

`Main_Shutdown` is reverse-hooked, so the call reaches the original `0x004240d0` rather than the reimpl stub.

Tested locally: cursor stutter/hang gone, close is instant, profile saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)