### PR TITLE
swrSound: name the mixer-voice struct fields + the 3 voice arrays

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1012,6 +1012,12 @@ rdMatrix44_ringBuffer 0x00e37c00 rdMatrix44[0xbff]
 
 rdModel_CurrentViewport 0x00e67c04 swrViewport*
 
+# 8-voice mixer. swrSound_Update reconciles requested -> live each frame and
+# snapshots live -> backup when the audio output changes. See swrSound struct.
+swrSound_voicesBackup 0x00e67c20 swrSound[8]
+swrSound_voicesLive 0x00e67e40 swrSound[8]
+swrSound_voicesRequested 0x00e68060 swrSound[8]
+
 texture_buffer 0x00e93860 void*[1700] # texture pointers
 
 assetBufferUnknownStats1 0x00E981E0 int

--- a/src/types.h
+++ b/src/types.h
@@ -1111,24 +1111,29 @@ extern "C"
         char unk[0x1abbc0];
     } swr_unk3; // sizeof(0x1abbc0). See FUN_00408e40
 
+    // One mixer voice (0x44 bytes). There are 8 voices; the live A3D-backed state
+    // is mirrored at DAT_00e67e40 and the requested state at DAT_00e68060 (source
+    // field = DAT_00e68080). playASoundImpl fills a free voice; swrSound_Update
+    // reconciles requested -> live each frame. See swrSound_ResetChannel.
     typedef struct swrSound
     {
-        int unk0;
-        int id;
-        int unk;
-        int unk1;
-        int unk2;
-        float pitch;
-        int unk4;
-        short unk5;
-        short unk51;
-        IA3dSource* source;
-        char unk6[8];
-        rdVector3 pos;
-        int unk7;
-        float maxDist;
-        float minDist;
-    } swrSound; // sizeof(0x44) in [8] ?. See DAT_00e68080
+        int activeSoundId; // 0x00 currently-playing id (-1 = free, -2 = pending start)
+        int id; // 0x04 requested sound id (bank entry index)
+        int unk08; // 0x08 nonzero drives positional velocity/doppler; AcquireSource context
+        int startFrame; // 0x0c frame counter (DAT_00e22a30) when the play was requested
+        int priority; // 0x10 voice-steal priority (default 8; lowest is stolen first)
+        float pitch; // 0x14
+        int volume; // 0x18 computed gain, fed to swrSound_SetGain
+        short pan; // 0x1c -999 = 3D positional (use pos), otherwise a pan value
+        short unk51; // 0x1e
+        IA3dSource* source; // 0x20
+        int unk24; // 0x24
+        int dedicatedSource; // 0x28 set when the acquired source != the bank entry's shared one
+        rdVector3 pos; // 0x2c
+        rdVector3* trackedPos; // 0x38 live position to follow each frame, or NULL for static
+        float maxDist; // 0x3c
+        float minDist; // 0x40
+    } swrSound; // sizeof(0x44)
 
     typedef int (*swrUI_unk_F1)(struct swrUI_unk* self, int param_2, void* param_3, int param_4);
     typedef int (*swrUI_unk_F2)(struct swrUI_unk* self, unsigned int param_2, void* param_3, struct swrUI_unk* ui2);


### PR DESCRIPTION
`swrSound` is the per-voice channel struct (0x44). Filled in the field names + named the voice arrays, all verified in Ghidra (no game/build needed beyond a compile check).

**types.h `swrSound` fields** (verified against `playASoundImpl`, which fills a requested voice, and `swrSound_Update`, which reconciles requested -> live each frame):
- `+0x00 activeSoundId` (-1 free, -2 pending), `+0x0c startFrame`, `+0x10 priority` (voice-steal, default 8), `+0x18 volume`, `+0x1c pan` (`-999` = 3D positional), `+0x28 dedicatedSource`, `+0x38 trackedPos` (`rdVector3*` followed each frame).
- pitch/source/pos/min/maxDist were already correct; `+0x08` and `+0x1e` left `unk` (genuinely ambiguous). Size preserved at 0x44 (`_Static_assert` checked).

**data_symbols.syms** — the three contiguous 8-voice arrays the mixer uses:
- `swrSound_voicesBackup` @0xe67c20, `swrSound_voicesLive` @0xe67e40, `swrSound_voicesRequested` @0xe68060 — each `swrSound[8]` (contiguous: each + 0x220 = the next).

Build-checked: `types.h` compiles, the `sizeof`/offset asserts hold, and the regenerated `globals.h` compiles clean. Names are my best read from the decomp — happy to match whatever you call these on your end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)