### PR TITLE
swrUI: name 6 widget constructors + the wrapped-text drawer

### DIFF
--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -70,6 +70,13 @@ FUN_004206b0
 #define swrUI_ShowConfirmDialog_ADDR (0x004145b0)
 #define swrUI_SetSize_ADDR (0x00414b40)
 #define swrUI_SetPos_ADDR (0x00414b60)
+// More widget constructors (swrUI_New* family; the trailing unk00_6 = widget class id):
+#define swrUI_NewScreenText_ADDR (0x00413340)
+#define swrUI_NewSpriteElement_ADDR (0x00413b90)
+#define swrUI_NewFramedText_ADDR (0x00413c50)
+#define swrUI_New3PatchBox_ADDR (0x00413fc0)
+#define swrUI_NewDialog_ADDR (0x004146c0)
+#define swrUI_DrawWrappedText_ADDR (0x00417fe0)
 // Mouse hit-test + dispatch + default element proc:
 #define swrUI_HitTest_ADDR (0x004150e0)
 #define swrUI_ProcessMouse_ADDR (0x00415400)
@@ -92,6 +99,18 @@ swrUI_unk* swrUI_NewButton(swrUI_unk* parent, int id, int font, char* text, int 
 void swrUI_ShowConfirmDialog(swrUI_unk* parent, int id1, int id2, void* unk, char* message, char* yesLabel, char* noLabel, int param8, int param9);
 void swrUI_SetSize(swrUI_unk* ui, int width, int height);
 void swrUI_SetPos(swrUI_unk* ui, int x, int y);
+// Class 3: a positioned/sized screen-text element (text applied via swrUI_RunCallbacksScreenText).
+swrUI_unk* swrUI_NewScreenText(swrUI_unk* parent, int id, int index, char* text, int unk5, int x, int y, int width, int height, int unk10, int flags, int sizeUnk);
+// Class 7: a sprite element bound to a rect with a user F2 callback (e.g. a clickable icon).
+swrUI_unk* swrUI_NewSpriteElement(swrUI_unk* parent, int id, int* rect, int spriteId, int spriteFlag, swrUI_unk_F2* f2, int sizeUnk);
+// Class 0xa: text framed by border sprites (0xfa3 left / 0xfa4 right).
+swrUI_unk* swrUI_NewFramedText(swrUI_unk* parent, int id, int index, char* text, int x, int y, int width, int height, int flags, int flags2);
+// Class 0xb: a 3-slice ("3-patch") sprite box; style (0x10000/0x20000/0x40000/0x80000) picks the sprite set.
+swrUI_unk* swrUI_New3PatchBox(swrUI_unk* parent, int id, int index, char* text, int x, int y, int width, int style, int center, int flags, int sizeUnk);
+// Modal dialog: title label + word-wrapped message + up to 3 buttons, screen-centered (x/y == -1 centers). swrUI_ShowConfirmDialog wraps this.
+swrUI_unk* swrUI_NewDialog(swrUI_unk* parent, int x, int y, char* title, char* message, char* button1, char* button2, char* button3, swrUI_unk_F2* f2);
+// Word-wrap a string to the element's bbox width and draw it line by line (splits on spaces).
+void swrUI_DrawWrappedText(swrUI_unk* ui, char* text, int flag);
 swrUI_unk* swrUI_HitTest(swrUI_unk* root, int cursor_x, int cursor_y);
 void swrUI_ProcessMouse(void);
 int swrUI_DefaultElementProc(swrUI_unk* ui, unsigned int msg, void* param, int param2);


### PR DESCRIPTION
Header-only mapping of the high-confidence members of the `swrUI_New*` widget-constructor family. Each was verified in Ghidra by its composition (`swrUI_New` + size/pos + sprites) and the `unk00_6` widget-class id it sets:

| Addr | Name | Class | What it builds |
|---|---|---|---|
| 0x413340 | `swrUI_NewScreenText` | 3 | positioned/sized screen-text element |
| 0x413b90 | `swrUI_NewSpriteElement` | 7 | a sprite bound to a rect with a user F2 callback |
| 0x413c50 | `swrUI_NewFramedText` | 0xa | text framed by border sprites (0xfa3/0xfa4) |
| 0x413fc0 | `swrUI_New3PatchBox` | 0xb | 3-slice sprite box (the "3-patch" box) |
| 0x4146c0 | `swrUI_NewDialog` | - | title + word-wrapped message + up to 3 buttons (what `swrUI_ShowConfirmDialog` wraps) |
| 0x417fe0 | `swrUI_DrawWrappedText` | - | word-wraps a string into the element bbox and draws it line by line |

Names are my best read from behavior — happy to match whatever you call these on your end.

**Deferred:** the class 5/6/9 constructors (0x413520 / 0x413a90 / 0x413430) and the rest of the ~120-fn UI region. Their widget types hinge on the F1 class-procs (0x416130 / 0x416370 / 0x416690), which aren't carved as functions in the DB yet (`CreateMissingFunctions.py`) — I'll map them once they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)