### PR TITLE
AI full LOD: optional debug toggle to render AI racers at full detail

### DIFF
--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -29,6 +29,9 @@ extern float cameraPitch;
 extern float cameraYaw;
 extern float cameraSpeed;
 
+// Defined in main.cpp: writes/reverts the AI full-LOD .text patches (gated by ai_full_lod).
+extern "C" void set_ai_full_lod(bool on);
+
 extern uint8_t replacedTries[323];// 323 MODELIDs
 extern std::map<int, ReplacementModel> replacement_map;
 extern const char *modelid_cstr[];
@@ -82,6 +85,10 @@ void read_settings_ini() {
     }
 
     imgui_state.enable_fog = GetPrivateProfileIntW(L"settings", L"enable_fog", 1, ini_path.c_str());
+
+    imgui_state.ai_full_lod =
+        GetPrivateProfileIntW(L"settings", L"ai_full_lod", 0, ini_path.c_str());
+    set_ai_full_lod(imgui_state.ai_full_lod);
 }
 
 void save_settings_ini() {
@@ -91,6 +98,8 @@ void save_settings_ini() {
                                std::to_wstring(imgui_state.anisotropy).c_str(), ini_path.c_str());
     WritePrivateProfileStringW(L"settings", L"enable_fog", imgui_state.enable_fog ? L"1" : L"0",
                                ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"ai_full_lod",
+                               imgui_state.ai_full_lod ? L"1" : L"0", ini_path.c_str());
 }
 
 const char *swrModel_NodeTypeStr(uint32_t nodeType) {
@@ -332,6 +341,10 @@ void opengl_render_imgui() {
             save_settings_ini();
         }
         if (ImGui::Checkbox("Enable fog", &imgui_state.enable_fog)) {
+            save_settings_ini();
+        }
+        if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
+            set_ai_full_lod(imgui_state.ai_full_lod);
             save_settings_ini();
         }
         ImGui::TreePop();

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -33,6 +33,7 @@ typedef struct ImGuiState {
     int msaa_samples = 1;
     int anisotropy = 8;
     bool enable_fog = true;
+    bool ai_full_lod = false;// force every racer (incl. AI) onto the full pod model (no LOD pop-in)
 
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;

--- a/dinput_hook/main.cpp
+++ b/dinput_hook/main.cpp
@@ -72,6 +72,45 @@ DWORD_PTR hookIAT(const char *libName, const char *API_Name, LPVOID newFun) {
 typedef HICON(WINAPI *NewLoadIconA)(HINSTANCE hInstance, LPCSTR lpIconName);
 NewLoadIconA ReCall;
 
+// Toggle the "AI full LOD" feature (debug-menu option ai_full_lod). Three .text patches are
+// applied together when enabled and reverted to the stock bytes when disabled. They take
+// effect on the next race load.
+//
+// 1) swrObjJdge_SpawnRacers @0x0046654d: JNZ 0x46655a -> NOP. Makes every racer (not just the
+//    local "Locl" human) load the full pod model + pilot instead of the low-detail "bot" model,
+//    so AI render at full detail with no whole-model LOD pop-in.
+// 2) swrRace_PoddAnimateVariousThings @0x004723ce: JG 0x472704 -> NOP. Always build the four
+//    cockpit/engine connector quads regardless of camera distance (otherwise far pods drop them
+//    and look like a bare cockpit "on the floor").
+// 3) swrRace_PoddAnimateVariousThings @0x00472577: JG 0x472740 -> NOP. Always build the finer
+//    energy-binder detail regardless of distance.
+//
+// Verified on the OpenGL renderer: full-detail AI with connectors intact, no cockpit detachment,
+// no >6-pod crash. Costs some (largely renderer-bound) FPS. NOTE: distant AI still follow the
+// track spline (vanilla AI LOD) and can show a slight "tiptoe"; a clean fix for that is tracked
+// separately and intentionally out of scope here.
+extern "C" void set_ai_full_lod(bool on) {
+    struct Patch {
+        uint32_t addr;
+        uint8_t len;
+        uint8_t original[6];// stock bytes (from Ghidra; the Steam EXE .text is encrypted on disk)
+    };
+    static const Patch patches[] = {
+        {0x0046654d, 2, {0x75, 0x0b}},                        // JNZ 0x0046655a
+        {0x004723ce, 6, {0x0f, 0x8f, 0x30, 0x03, 0x00, 0x00}},// JG 0x00472704
+        {0x00472577, 6, {0x0f, 0x8f, 0xc3, 0x01, 0x00, 0x00}},// JG 0x00472740
+    };
+    for (const Patch &p: patches) {
+        uint8_t bytes[6];
+        for (uint8_t i = 0; i < p.len; i++)
+            bytes[i] = on ? 0x90 /* NOP */ : p.original[i];
+        DWORD oldProtect;
+        VirtualProtect((LPVOID) p.addr, p.len, PAGE_EXECUTE_READWRITE, &oldProtect);
+        memcpy((LPVOID) p.addr, bytes, p.len);
+        VirtualProtect((LPVOID) p.addr, p.len, oldProtect, &oldProtect);
+    }
+}
+
 HICON __stdcall LoadIconHook(HINSTANCE hInstance, LPCSTR lpIconName) {
     // Main is ready. Patch the hooks and the function we are in to return properly
     fprintf(hook_log, "LoadIcon Hook called\n");


### PR DESCRIPTION
Adds an **"AI full LOD (no model pop-in)"** option to the debug menu (off by default, persisted to `SW_RACER_RE.ini`). When enabled it applies three small `.text` patches at the next race load, and reverts them cleanly when disabled:

- `swrObjJdge_SpawnRacers` `@0x0046654d` (`JNZ` → `NOP`): every racer loads the full pod model + pilot instead of the low-detail "bot" model, so AI render at full detail with no whole-model LOD pop-in.
- `swrRace_PoddAnimateVariousThings` `@0x004723ce` and `@0x00472577` (`JG` → `NOP`): the cockpit/engine connector cables and energy-binder detail build at any distance instead of being culled on far pods (otherwise distant full-LOD pods look like a bare cockpit).

`set_ai_full_lod()` in `main.cpp` applies/reverts the patches (stock bytes taken from Ghidra, since the Steam EXE `.text` is encrypted on disk); the checkbox and the ini load/save live in `imgui_utils`.

Tested in-game on the OpenGL renderer: full-detail AI with connectors intact, no cockpit detachment, no crash with a full grid. Minor (largely renderer-bound) FPS cost.

### Known follow-ups (out of scope here)
- Distant AI still follow the track spline (vanilla AI LOD) and can show a slight "tiptoe". A clean fix is entangled with the shared spline progress/lap tracking, so it's intentionally left for a separate change.
- AI pod shadows can render over the local player's pod.
