### PR TITLE
swrSound: map streamed music controller + per-track SFX tables

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -97,6 +97,12 @@ swrSound_criticalSection 0x004b7e7e CRITICAL_SECTION
 
 swrModel_GlobalAnimationSpeed 0x004B7FA8 float
 
+# Streamed music + per-track ambient SFX tables. See swrSound.h (swrSound_SelectTrackMusic /
+# swrSound_UpdateEngineAudio) and the swrSfxCue struct in types.h.
+swrMusicTrackTable 0x004b8750 int16_t[8][3]
+swrMusicPlanetIntroTable 0x004b8780 int16_t[8]
+swrSfxPreloadSets 0x004b8fa8 swrSfxCue*[24]
+
 swrSprite_SpriteCount 0x004b91b8 int
 swrSprite_unk_x 0x004b91bc float = 16.0
 swrSprite_unk_y 0x004b91c0 float = 155.0

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -51,8 +51,14 @@
 #define swrSound_WasSfxRecentlyPlayed_ADDR (0x004273e0)
 #define swrSound_PlaySfxThrottled_ADDR (0x00427410)
 #define swrSound_MarkSfxPlayed_ADDR (0x00427530)
+
+// Streamed in-race / menu music controller (channel 7). See the grouped prototypes below.
+#define swrSound_SetMusicFade_ADDR (0x004277f0)
+#define swrSound_UpdateMusic_ADDR (0x00427880)
 #define swrSound_UpdateEngineAudio_ADDR (0x00427b20)
+#define swrSound_ResetMusic_ADDR (0x00427d70)
 #define swrSound_PreloadSoundSet_ADDR (0x00427d90)
+#define swrSound_SelectTrackMusic_ADDR (0x00427ea0)
 #define swrSound_PreloadRacerSounds_ADDR (0x00427f10)
 #define swrSound_PreloadSfx_ADDR (0x00427fb0)
 
@@ -172,6 +178,15 @@ int swrSound_PushRecentSfx(short soundId);
 int swrSound_WasSfxRecentlyPlayed(int soundId);
 // Record the play time/category so later calls can apply the cooldown + recent-played checks.
 void swrSound_MarkSfxPlayed(int category, int variant, int soundId, int param4);
+
+// Streamed music controller (channel 7). swrSound_SelectTrackMusic picks the per-track theme
+// from swrMusicTrackTable[planet][subtrack] (subtrack 3 special-cased) into the queued-music
+// global; swrSound_UpdateMusic cross-fades current -> queued each frame; swrSound_SetMusicFade
+// sets the fade mode (0 stop / 1 arm / 2,3 fade up/down); swrSound_ResetMusic clears the queue.
+void swrSound_SelectTrackMusic(int planet, int subtrack, int restore);
+void swrSound_UpdateMusic(void);
+void swrSound_SetMusicFade(int mode);
+void swrSound_ResetMusic(void);
 
 // Per-frame engine/surface SFX: select and play loop sounds keyed by speed.
 void swrSound_UpdateEngineAudio(int param1, int param2, float* param3);

--- a/src/types.h
+++ b/src/types.h
@@ -1161,6 +1161,19 @@ extern "C"
         IA3dSource* source; // 0x48
     } swrSoundDescriptor; // sizeof(0x4c)
 
+    // One per-track ambient-SFX cue (0xc bytes). swrSfxPreloadSets[planet*3 + subtrack] points
+    // to a list of these, terminated by an entry with startProgress < 0. swrSound_UpdateEngineAudio
+    // plays soundId on channel 6 while the racer's lap progress is inside [startProgress,
+    // endProgress] (volume ramped across the range; start > end wraps the start/finish line).
+    typedef struct swrSfxCue
+    {
+        float startProgress; // 0x00 lap-progress range start (0..1)
+        float endProgress; // 0x04 lap-progress range end (0..1)
+        int16_t soundId; // 0x08 bank index, or < 0 to skip
+        uint8_t flags; // 0x0a bit0 = periodic random retrigger (else continuous loop)
+        uint8_t unk0b; // 0x0b
+    } swrSfxCue; // sizeof(0xc)
+
     typedef int (*swrUI_unk_F1)(struct swrUI_unk* self, int param_2, void* param_3, int param_4);
     typedef int (*swrUI_unk_F2)(struct swrUI_unk* self, unsigned int param_2, void* param_3, struct swrUI_unk* ui2);
 


### PR DESCRIPTION
Maps the streamed-music side of swrSound (sits next to the already-merged playback layer):

- **Functions** (`swrSound.h`): `swrSound_SelectTrackMusic` (picks the per-track theme), `swrSound_UpdateMusic` (per-frame cross-fade on channel 7), `swrSound_SetMusicFade`, `swrSound_ResetMusic`.
- **Data tables** (`data_symbols.syms`): `swrMusicTrackTable` (`int16_t[8][3]`, per-track in-race theme), `swrMusicPlanetIntroTable` (`int16_t[8]`, per-planet intro), `swrSfxPreloadSets` (per-track ambient-cue lists).
- **Struct** (`types.h`): `swrSfxCue` for the ambient-cue entries.

Note: per-track ambient SFX turn out to be placed by **lap-progress range** (`swrSound_UpdateEngineAudio` plays a cue while progress is in `[start,end]`), not world position.

Validated: `globals.h` regenerates cleanly, `types.h` syntax-checks, `sizeof(swrSfxCue)==0xc`.