### PR TITLE
types: name the galaxy-map planet table + swrPlanetInfo struct

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1269,3 +1269,9 @@ swrWeather_particlePositions 0x00e99860 rdVector3[80]
 swrWeather_particleScreenPositions 0x00e9a000 rdVector2[80]
 swrWeather_particleSpriteIds 0x00e9a280 int[80]
 swrWeather_particleStates 0x00e9a960 char[80]
+
+# Galaxy-map planet data (8 planets). Populated by swrObjHang_Init, consumed by DrawHoloPlanet.
+# Sun/moon sprite pool (@0x00e293c4) + sun/moon and preview-model node arrays are identified but
+# left for a follow-up (their exact element struct / count want more verification).
+swrPlanetTable 0x00e98f40 swrPlanetInfo[8]
+swrPlanetHoloModelNodes 0x00e299f4 void*[8]

--- a/src/types.h
+++ b/src/types.h
@@ -3065,6 +3065,21 @@ extern "C"
         uint8_t unused;
     } TrackInfo; // sizeof(0xc)
 
+    // Galaxy-map planet entry (0x5c bytes). The 8 entries at swrPlanetTable are populated by
+    // swrObjHang_Init (names via swrText_Translate; sun/moon ranges; rotation state randomized) and
+    // consumed by DrawHoloPlanet. The sun/moon sprite range indexes a separate per-sprite pool.
+    typedef struct swrPlanetInfo
+    {
+        int sunMoonSpriteStart; // 0x00 first index into the sun/moon sprite pool for this planet
+        int sunMoonSpriteEnd; // 0x04 last index (inclusive); start > end => none (e.g. Oovo IV)
+        float orientationAngle; // 0x08 fixed per-planet tilt set at init; rotates the planet model AND its sun/moon; not animated
+        float spinAngle; // 0x0c live planet-model rotation, advanced by spinSpeed each frame
+        float spinSpeed; // 0x10
+        float unk14; // 0x14 advanced by unk18 each frame but never applied to a transform (appears unused)
+        float unk18; // 0x18
+        char name[0x40]; // 0x1c display name (swrText_Translate'd, e.g. "Tatooine")
+    } swrPlanetInfo; // sizeof(0x5c)
+
     typedef struct SmushImageInfo
     {
         uint8_t* data; // format rgb565


### PR DESCRIPTION
Names the previously-unnamed galaxy-map planet data:

- **`swrPlanetInfo`** struct (`0x5c`) in `types.h` — sun/moon sprite range, billboard spin angle/speed pairs, and display `name` (@+0x1c).
- **`swrPlanetTable`** `swrPlanetInfo[8]` @`0x00e98f40` and **`swrPlanetHoloModelNodes`** `void*[8]` @`0x00e299f4` in `data_symbols.syms`.

Populated by `swrObjHang_Init` (names via `swrText_Translate`; sun/moon ranges; spin state randomized) and consumed by `DrawHoloPlanet`. Planet index order: 0 Tatooine, 1 Ando Prim, 2 Aquilaris, 3 Ord Ibann, 4 Baroonda, 5 Mon Gazza, 6 Oovo IV, 7 Malastare.

The sun/moon sprite pool (@`0x00e293c4`) + sun/moon and track-preview node arrays are identified but left for a follow-up (their element struct/count want more verification).

Validated: `globals.h` regenerates + `types.h` compiles clean; `sizeof(swrPlanetInfo)==0x5c`, `name` @ `0x1c`.