### PR TITLE
Dedup 0x408640: keep swrUI_UpdateProgressBar, drop DirectDraw_BlitProgressBar (#68)

### DIFF
--- a/dinput_hook/game_deltas/DirectX_delta.c
+++ b/dinput_hook/game_deltas/DirectX_delta.c
@@ -35,8 +35,9 @@ void DirectDraw_Shutdown_delta(void) {
     // nothing to do here
 }
 
-// 0x00408640
-void DirectDraw_BlitProgressBar_delta(int progress) {
+// 0x00408640 (canonical name swrUI_UpdateProgressBar; replaces the original blit
+// with the HD/widescreen progress bar)
+void swrUI_UpdateProgressBar_delta(int progress) {
     int w, h;
     glfwGetFramebufferSize(glfwGetCurrentContext(), &w, &h);
     glViewport(0, 0, w, h);

--- a/dinput_hook/game_deltas/DirectX_delta.h
+++ b/dinput_hook/game_deltas/DirectX_delta.h
@@ -4,7 +4,7 @@
 
 void DirectDraw_InitProgressBar_delta(void);
 void DirectDraw_Shutdown_delta(void);
-void DirectDraw_BlitProgressBar_delta(int progress);
+void swrUI_UpdateProgressBar_delta(int progress);
 
 void DirectDraw_LockZBuffer_delta(uint32_t *bytes_per_depth_value, LONG *pitch, LPVOID *data,
                                   float *near, float *far);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1069,8 +1069,8 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) DirectDraw_InitProgressBar_delta);
     hook_function("DirectDraw_Shutdown", (uint32_t) 0x00408620,
                   (uint8_t *) DirectDraw_Shutdown_delta);
-    hook_function("DirectDraw_BlitProgressBar", (uint32_t) 0x00408640,
-                  (uint8_t *) DirectDraw_BlitProgressBar_delta);
+    hook_function("swrUI_UpdateProgressBar", (uint32_t) swrUI_UpdateProgressBar_ADDR,
+                  (uint8_t *) swrUI_UpdateProgressBar_delta);
     hook_function("DirectDraw_LockZBuffer", (uint32_t) 0x00431C40,
                   (uint8_t *) DirectDraw_LockZBuffer_delta);
     hook_function("DirectDraw_UnlockZBuffer", (uint32_t) 0x00431cd0,

--- a/scripts/GenerateHooks.py
+++ b/scripts/GenerateHooks.py
@@ -72,7 +72,7 @@ hooks_blacklist = [
     # DirectDraw
     "DirectDraw_InitProgressBar",
     "DirectDraw_Shutdown",
-    "DirectDraw_BlitProgressBar",
+    "swrUI_UpdateProgressBar",  # 0x408640, force-hooked by the delta (was DirectDraw_BlitProgressBar)
     "DirectDraw_LockZBuffer",
     "DirectDraw_UnlockZBuffer",
     "Direct3d_SetFogMode",

--- a/src/Win95/DirectX.c
+++ b/src/Win95/DirectX.c
@@ -23,12 +23,6 @@ void DirectDraw_Shutdown(void)
     }
 }
 
-// 0x00408640
-void DirectDraw_BlitProgressBar(int progress)
-{
-    HANG("TODO");
-}
-
 // 0x00431C40
 void DirectDraw_LockZBuffer(uint32_t* bytes_per_depth_value, LONG* pitch, LPVOID* data, float* near_, float* far_)
 {

--- a/src/Win95/DirectX.h
+++ b/src/Win95/DirectX.h
@@ -5,7 +5,6 @@
 
 #define DirectDraw_InitProgressBar_ADDR (0x00408510)
 #define DirectDraw_Shutdown_ADDR (0x00408620)
-#define DirectDraw_BlitProgressBar_ADDR (0x00408640)
 
 #define DirectDraw_LockZBuffer_ADDR (0x00431C40)
 #define DirectDraw_UnlockZBuffer_ADDR (0x00431cd0)
@@ -46,7 +45,6 @@
 
 void DirectDraw_InitProgressBar(void);
 void DirectDraw_Shutdown(void);
-void DirectDraw_BlitProgressBar(int progress);
 
 void DirectDraw_LockZBuffer(uint32_t* bytes_per_depth_value, LONG* pitch, LPVOID* data, float* near, float* far);
 void DirectDraw_UnlockZBuffer(void);


### PR DESCRIPTION
The last duplicate from #68 (`0x408640`). Per your call, consolidating to `swrUI_UpdateProgressBar`.

Both reimpl bodies were identical `HANG("TODO")` stubs, so nothing is lost:
- **Removed `DirectDraw_BlitProgressBar`** — `_ADDR` + prototype in `DirectX.h`, the stub body in `DirectX.c`. No callers. This also drops a duplicate `// 0x00408640` reverse-hook annotation (swrUI.c keeps the only one).
- **Renamed the live delta** `DirectDraw_BlitProgressBar_delta → swrUI_UpdateProgressBar_delta` and pointed the hook at `swrUI_UpdateProgressBar_ADDR`. The HD/widescreen "energy binder" progress bar is the **same body at the same address** — behavior unchanged.
- **Retargeted the `GenerateHooks.py` force-hook blacklist** to the new name, so the delta stays the sole hook at `0x408640`. Verified: regenerating `hook_generated.c` produces no conflicting auto reverse-hook.

Resolves the remaining unchecked box on #68.

Note: I couldn't compile the `dinput_hook` side in my environment (the `modules/` deps), but it's a pure rename of an existing working delta + a header/stub removal — worth a quick build on your end to confirm the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)