### PR TITLE
swrConfig: name the video/audio/force-feedback settings menu builders

### DIFF
--- a/src/Swr/swrConfig.h
+++ b/src/Swr/swrConfig.h
@@ -35,6 +35,14 @@
 #define swrConfig_BuildForceFeedbackMenu_ADDR (0x0040ef40)
 #define swrConfig_RefreshForceFeedbackMenu_ADDR (0x0040c100)
 
+// Input-mapping screens (joystick/mouse/keyboard rebinding); RefreshMappingMenu populates the
+// binding rows for device 0=joystick/1=mouse/2=keyboard via swrConfig_SetMappingRowText.
+#define swrConfig_BuildJoystickMenu_ADDR (0x0040c7a0)
+#define swrConfig_BuildMouseMenu_ADDR (0x0040d2c0)
+#define swrConfig_BuildKeyboardMenu_ADDR (0x0040dd10)
+#define swrConfig_RefreshMappingMenu_ADDR (0x0040b740)
+#define swrConfig_SetMappingRowText_ADDR (0x0040c670)
+
 int swrConfig_WriteMappings(char* dirname);
 
 void swrConfig_ControlToString(unsigned int controlId, char* pDest);
@@ -63,5 +71,11 @@ void swrConfig_BuildAudioMenu(swrUI_unk* page);
 void swrConfig_RefreshAudioMenu(swrUI_unk* page);
 void swrConfig_BuildForceFeedbackMenu(swrUI_unk* page);
 void swrConfig_RefreshForceFeedbackMenu(swrUI_unk* page);
+
+void swrConfig_BuildJoystickMenu(swrUI_unk* page);
+void swrConfig_BuildMouseMenu(swrUI_unk* page);
+void swrConfig_BuildKeyboardMenu(swrUI_unk* page);
+void swrConfig_RefreshMappingMenu(int deviceIndex, swrUI_unk* page);
+void swrConfig_SetMappingRowText(int deviceIndex, swrUI_unk* page, int rowId, int control, int param5, int param6, int param7);
 
 #endif // SWRCONFIG_H

--- a/src/Swr/swrConfig.h
+++ b/src/Swr/swrConfig.h
@@ -26,6 +26,15 @@
 #define swrConfig_Puts_ADDR (0x004879a0)
 #define swrConfig_Printf_ADDR (0x004879f0)
 
+// Settings-menu UI: Build* constructs the page widgets (called from swrUI_BuildMenuPages),
+// Refresh* syncs those widgets from the current config globals.
+#define swrConfig_BuildVideoMenu_ADDR (0x0040e6a0)
+#define swrConfig_RefreshVideoMenu_ADDR (0x0040bbf0)
+#define swrConfig_BuildAudioMenu_ADDR (0x0040ea70)
+#define swrConfig_RefreshAudioMenu_ADDR (0x0040bc80)
+#define swrConfig_BuildForceFeedbackMenu_ADDR (0x0040ef40)
+#define swrConfig_RefreshForceFeedbackMenu_ADDR (0x0040c100)
+
 int swrConfig_WriteMappings(char* dirname);
 
 void swrConfig_ControlToString(unsigned int controlId, char* pDest);
@@ -47,5 +56,12 @@ int swrConfig_ReadAudioConfig(char* dirname);
 
 size_t swrConfig_Puts(char* string);
 size_t swrConfig_Printf(char* format, ...);
+
+void swrConfig_BuildVideoMenu(swrUI_unk* page);
+void swrConfig_RefreshVideoMenu(swrUI_unk* page);
+void swrConfig_BuildAudioMenu(swrUI_unk* page);
+void swrConfig_RefreshAudioMenu(swrUI_unk* page);
+void swrConfig_BuildForceFeedbackMenu(swrUI_unk* page);
+void swrConfig_RefreshForceFeedbackMenu(swrUI_unk* page);
 
 #endif // SWRCONFIG_H


### PR DESCRIPTION
Names the 6 swrConfig functions that build + refresh the Video / Audio / Force-Feedback settings screens (called from `swrUI_BuildMenuPages`). Header-only (`_ADDR` + prototypes).

- `swrConfig_BuildVideoMenu` / `RefreshVideoMenu`
- `swrConfig_BuildAudioMenu` / `RefreshAudioMenu`
- `swrConfig_BuildForceFeedbackMenu` / `RefreshForceFeedbackMenu`

`Build*` constructs the page widgets (3-patch title, nav/default/restore/OK buttons, the option checkboxes + radio groups); `Refresh*` syncs them from the config globals. Verified against `BuildMenuPages` window-id pairing + the page contents.