### PR TITLE
Name swrCamera_unk fields + swrRace_InitFrameTimer + spectator-cam table

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -234,6 +234,8 @@ fogColorInt16 0x004C3B88 int16_t[4]
 fogStartInt16 0x004C3B90 int16_t # between 0 (near) and 1000 (far)
 fogEndInt16 0x004C3B94 int16_t # between 0 (near) and 1000 (far)
 
+swrObjcMan_SpectatorCamModes 0x004c3ef0 int16_t[7] # auto-cycle spectator cam: mode = table[rand % 7]
+
 numEnabledLights 0x00004C3BA0 int[12]
 
 rdMatrixStack34_modified 0x004c3c0c int

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1339,6 +1339,13 @@ bool swrRace_LapCompletion(void* engineData, int param_2)
     HANG("TODO");
 }
 
+// 0x004804c0
+void swrRace_InitFrameTimer(void)
+{
+    // See swe1r-decomp
+    HANG("TODO");
+}
+
 // 0x00480540
 void swrRace_IncrementFrameTimer(void)
 {

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -155,6 +155,8 @@
 
 #define swrRace_UpdateRaceProgress_ADDR (0x0047ffb0)
 
+#define swrRace_InitFrameTimer_ADDR (0x004804c0)
+
 #define swrRace_IncrementFrameTimer_ADDR (0x00480540)
 
 // Save / profile persistence (player tournament data -> .\data\player\tgfd.dat).
@@ -392,6 +394,10 @@ bool swrRace_LapCompletion(void* engineData, int param_2);
 void swrRace_UpdateRaceProgress(void* engineData, int param_2, int incrementLap, int offTrackTick);
 
 void swrRace_IncrementFrameTimer(void);
+
+// 0x004804c0. Resets the frame timer / delta-time state (sibling of IncrementFrameTimer):
+// sets the fixed-step default and samples the initial system time.
+void swrRace_InitFrameTimer(void);
 
 // Save / profile persistence.
 // Boot entry: load tgfd.dat; on failure rebuild defaults and write a fresh file.

--- a/src/types.h
+++ b/src/types.h
@@ -1089,17 +1089,22 @@ extern "C"
         swrRace* obj_test_ptr;
     } swrScore; // sizeof(0x88)
 
-    typedef struct swrCamera_unk
+    typedef struct swrCamera_unk // viewport/camera state; unkCameraArray[32] @ 0x004b91c4, stride 0x7c
     {
-        char unk[4]; // 0x0
-        int unk1; // 0x4
-        rdVector3* unk2; // 0x8
-        float unk3; // 0xc
-        float unk31; // 0x10
-        rdMatrix44 unk4; // 0x14
-        char unk5[24];
-        rdVector4 unk6; // 0x6c
-    } swrCamera_unk; // sizeof(0x7c). At 0x04b91c4 ?
+        unsigned char flags; // 0x0. bit 0x2 = active/render this frame
+        char unk01[3]; // 0x1
+        short behaviorType; // 0x4. 0 = inactive; 2/3/4 = extract transform + apply offset
+        short sourceType; // 0x6. 0 = copy rdMatrix44, 1 = rdMatrix_SetTransform44, else FUN_00428c40
+        void* matrixSource; // 0x8. source matrix / swrTranslationRotation
+        short offsetMode; // 0xc. offset source kind (0 or 1)
+        short unk0e; // 0xe
+        void* offsetSource; // 0x10. second source (offset / parent)
+        rdMatrix44 transform; // 0x14. computed view matrix (written by swrViewport_UpdateCameras)
+        rdVector3 posOffset; // 0x54. local offset rotated into matrix space
+        rdVector3 rotationYPR; // 0x60. yaw/pitch/roll applied via rdMatrix_SetRotation44
+        rdVector3 localOffset; // 0x6c. offset added to translation
+        float unk78; // 0x78
+    } swrCamera_unk; // sizeof(0x7c). At 0x004b91c4
 
     typedef struct swr_unk1 // == RdModel3
     {


### PR DESCRIPTION
Small RE-naming pass on the camera/viewport + frame-timer area, from reverse-engineering a community camera mod.

- **`swrCamera_unk`** (`types.h`): filled in the fields of the per-viewport camera state (`unkCameraArray`, stride `0x7c`) from `swrViewport_UpdateCameras` — `flags`/`behaviorType`/`sourceType`/`matrixSource`/`offsetSource`, the `transform` matrix @`0x14`, and the `posOffset`/`rotationYPR`/`localOffset` vectors. Size unchanged (`0x7c`, statically asserted locally).
- **`swrRace_InitFrameTimer`** (`swrRace.h`/`.c`): named `FUN_004804c0` (the frame-timer init, sibling of `swrRace_IncrementFrameTimer`) with `_ADDR` + prototype + reverse-hook stub. Left as a stub for now — happy to use a different name if your DB already has one.
- **`swrObjcMan_SpectatorCamModes`** (`data_symbols.syms`): registered the auto-cycle spectator-cam mode table at `0x4c3ef0` (`int16_t[7]`).

Builds clean (WinLibs GCC 13.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
