### PR TITLE
swrUI: sub-namespace the front-end glue as swrUI_Front_*

### DIFF
--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -225,10 +225,10 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
         }
 
         sprintf(local_60, pMenuEntry);
-        // swrUI_TextMenu already offsets each entry by (rowIndex * lineHeight) from the
+        // swrUI_Front_TextMenu already offsets each entry by (rowIndex * lineHeight) from the
         // PosY base, so PosY must stay fixed here. Advancing it too applied the offset
         // twice and double-spaced the menu (every option dropped 20px instead of 10).
-        swrUI_TextMenu(hang, 60, PosY, 10, hang->mainMenuSelection, i, local_60);
+        swrUI_Front_TextMenu(hang, 60, PosY, 10, hang->mainMenuSelection, i, local_60);
     }
 
     for (uint8_t i = 0; i < hang->num_local_players; i++) {
@@ -716,7 +716,7 @@ void swrRace_CourseSelectionMenu_delta(void) {
         hang->track_index = -1;
     }
 
-    MenuAxisHorizontal(NULL, 55);
+    swrUI_Front_MenuAxisHorizontal(NULL, 55);
 
     uint8_t R, G, B;
     char *pTxtCircuit = NULL;
@@ -930,7 +930,7 @@ void swrRace_CourseInfoMenu_delta(swrObjHang *hang) {
         DAT_0050c430[11] = 0xff;
         DAT_0050c560 = 0;
 
-        if (BeatEverything1stPlace(hang)) {
+        if (swrUI_Front_BeatEverything1stPlace(hang)) {
             iVar6 = DAT_0050c560;
             DAT_0050c560 = DAT_0050c560 + 1;
             DAT_0050c430[iVar6] = 0;
@@ -963,7 +963,7 @@ LAB_0043b9b4:
     const uint8_t ReqPlaceToProcceed =
         GetRequiredPlaceToProceed(hang->circuitIdx, NumUnlockedTracks);
 
-    // PosY is the fixed base row; swrUI_TextMenu offsets each entry by (i * lineHeight),
+    // PosY is the fixed base row; swrUI_Front_TextMenu offsets each entry by (i * lineHeight),
     // so PosY must NOT be advanced per row -- doing so applied the offset twice and
     // double-spaced the race options. Multi-line entries still add explicit PosY+N offsets.
     int32_t PosY = 160;
@@ -978,7 +978,7 @@ LAB_0043b9b4:
             switch (DAT_0050c430[i]) {
                 case 0: {
                     pText = swrText_Translate(g_pTxtMirror);
-                    swrUI_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
                     if (hang->bMirror != 0) {
                         pText = swrText_Translate(g_pTxtOn);
                         uVar13 = (int8_t) DAT_0050c550;
@@ -1000,18 +1000,18 @@ LAB_0043b9b4:
                         pText = swrText_Translate(g_pTxtWinnerTakesAll);
                     }
 
-                    swrUI_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i,
                                    swrText_Translate(g_pTxtWinnings));
-                    swrUI_TextMenu(hang, 85, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 85, PosY, 10, DAT_0050c550, i, pText);
 
-                    swrUI_TextMenu(hang, 45, PosY + 10, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 45, PosY + 10, 10, DAT_0050c550, i,
                                    swrText_Translate(g_pTxt1st));
-                    swrUI_TextMenu(hang, 45, PosY + 20, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 45, PosY + 20, 10, DAT_0050c550, i,
                                    swrText_Translate(g_pTxt2nd));
-                    swrUI_TextMenu(hang, 45, PosY + 30, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 45, PosY + 30, 10, DAT_0050c550, i,
                                    swrText_Translate(g_pTxt3rd));
                     if (ReqPlaceToProcceed == 4) {
-                        swrUI_TextMenu(hang, 45, PosY + 40, 10, DAT_0050c550, i,
+                        swrUI_Front_TextMenu(hang, 45, PosY + 40, 10, DAT_0050c550, i,
                                        swrText_Translate(g_pTxt4th));
                     }
 
@@ -1021,7 +1021,7 @@ LAB_0043b9b4:
                         fTruguts *= hang->winnings.truguts[hang->WinningsID - 1][j];
                         pText = swrText_Translate("~f0~r~s%d");
                         sprintf(local_40, pText, (int) fTruguts);
-                        swrUI_TextMenu(hang, 105, PosYIt, 10, DAT_0050c550, i, local_40);
+                        swrUI_Front_TextMenu(hang, 105, PosYIt, 10, DAT_0050c550, i, local_40);
                         PosYIt = PosYIt + 10;
                     }
 
@@ -1056,14 +1056,14 @@ LAB_0043b9b4:
 
                 LAB_0043bd30:
                     pText = swrText_Translate(pText);
-                    swrUI_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
                     pText = local_40;
                     uVar13 = DAT_0050c550;
                     goto LAB_0043be29;
                 }
                 case 5: {
                     pText = swrText_Translate(g_pTxtDemoMode);
-                    swrUI_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
                     if (hang->demo_mode != 0) {
                         pText = swrText_Translate(g_pTxtOn);
                         goto LAB_0043be20;
@@ -1084,14 +1084,14 @@ LAB_0043b9b4:
                 }
             }
             pText = swrText_Translate(pText);
-            swrUI_TextMenu(hang, 30, PosY, 10, (char) DAT_0050c550, i, pText);
+            swrUI_Front_TextMenu(hang, 30, PosY, 10, (char) DAT_0050c550, i, pText);
             pText = local_40;
 
         LAB_0043be20:
             uVar13 = DAT_0050c550;
 
         LAB_0043be29:
-            swrUI_TextMenu(hang, 85, PosY, 10, uVar13, i, pText);
+            swrUI_Front_TextMenu(hang, 85, PosY, 10, uVar13, i, pText);
         }
     }
 
@@ -1120,11 +1120,11 @@ LAB_0043b9b4:
         swrText_CreateTextEntry1(160, 37, 0, 0xff, 0, 0xff, local_40);
         FUN_0042de10(local_40, 0);
         FUN_0042de10(local_40, 0);
-        MenuAxisHorizontal(NULL, 38);
+        swrUI_Front_MenuAxisHorizontal(NULL, 38);
 
         if (hang->track_index < DEFAULT_NB_TRACKS) {
-            swrUI_DrawRecord(hang, 100, 55, 255.0, 0);
-            swrUI_DrawRecord(hang, 220, 55, 255.0, 3);
+            swrUI_Front_DrawRecord(hang, 100, 55, 255.0, 0);
+            swrUI_Front_DrawRecord(hang, 220, 55, 255.0, 3);
 
             // Record 3 Laps
             iVar6 = hang->bMirror + hang->track_index * 2;

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1146,14 +1146,14 @@ extern "C" void init_renderer_hooks() {
     // fileRead
     // fileClose
 
-    hook_function("HandleCircuits", (uint32_t) HandleCircuits_ADDR,
+    hook_function("swrUI_Front_HandleCircuits", (uint32_t) swrUI_Front_HandleCircuits_ADDR,
                   (uint8_t *) HandleCircuits_delta);
     hook_function("isTrackPlayable", (uint32_t) isTrackPlayable_ADDR,
                   (uint8_t *) isTrackPlayable_delta);
     hook_function("VerifySelectedTrack", (uint32_t) VerifySelectedTrack_ADDR,
                   (uint8_t *) VerifySelectedTrack_delta);
 
-    hook_function("swrUI_GetTrackNameFromId", (uint32_t) swrUI_GetTrackNameFromId_ADDR,
+    hook_function("swrUI_Front_GetTrackNameFromId", (uint32_t) swrUI_Front_GetTrackNameFromId_ADDR,
                   (uint8_t *) swrUI_GetTrackNameFromId_delta);
 
     hook_function("swrObjHang_InitTrackSprites", (uint32_t) swrObjHang_InitTrackSprites_ADDR,

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -313,39 +313,39 @@ swrUI_unk* swrUI_GetByValue(swrUI_unk* ui, int value)
 }
 
 // 0x00420930
-void swrUI_LoadTrackFromId(swrRace_TRACK trackId, char* buffer, size_t len)
+void swrUI_Front_LoadTrackFromId(swrRace_TRACK trackId, char* buffer, size_t len)
 {
     char* str;
-    str = swrUI_GetTrackNameFromId(trackId);
+    str = swrUI_Front_GetTrackNameFromId(trackId);
     snprintf(buffer, len, "%s", str);
 }
 
 // 0x0043b0b0
-void HandleCircuits(swrObjHang* hang)
+void swrUI_Front_HandleCircuits(swrObjHang* hang)
 {
     HANG("TODO");
 }
 
 // 0x0043fce0
-void swrUI_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText)
+void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText)
 {
     HANG("TODO");
 }
 
 // 0x00440150
-void MenuAxisHorizontal(void* pUnused, short posY)
+void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY)
 {
     HANG("TODO");
 }
 
 // 0x004403e0
-void swrUI_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5)
+void swrUI_Front_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5)
 {
     HANG("TODO");
 }
 
 // 0x00440620
-char* swrUI_GetTrackNameFromId(int trackId) // swrRace_TRACK
+char* swrUI_Front_GetTrackNameFromId(int trackId) // swrRace_TRACK
 {
     char* res = NULL;
     switch (trackId)
@@ -430,13 +430,13 @@ char* swrUI_GetTrackNameFromId(int trackId) // swrRace_TRACK
 }
 
 // 0x00440bc0
-bool BeatEverything1stPlace(swrObjHang* hang)
+bool swrUI_Front_BeatEverything1stPlace(swrObjHang* hang)
 {
     HANG("TODO");
 }
 
 // 0x00457C20
-void swrUI_LoadPlanetModels()
+void swrUI_Front_LoadPlanetModels()
 {
     swrModel_LoadModelIntoScene(MODELID_pln_tatooine_part, -1, INGAME_MODELID_pln_tatooine_part, 0);
     swrModel_LoadModelIntoScene(MODELID_pln_andoprime_part, -1, INGAME_MODELID_pln_andoprime_part, 0);
@@ -453,7 +453,7 @@ void swrUI_LoadPlanetModels()
 }
 
 // 0x00457CF0
-void swrUI_LoadMapPartModels()
+void swrUI_Front_LoadMapPartModels()
 {
     swrModel_LoadModelIntoScene(MODELID_map_tat1_part, -1, INGAME_MODELID_map_tat1_part, 0);
     swrModel_LoadModelIntoScene(MODELID_map_tat2_part, -1, INGAME_MODELID_map_tat2_part, 0);
@@ -483,7 +483,7 @@ void swrUI_LoadMapPartModels()
 }
 
 // 0x00457ed0
-void swrUI_LoadUIElements(void)
+void swrUI_Front_LoadUIElements(void)
 {
     swrSpriteTexture* tex;
     short id;
@@ -528,13 +528,13 @@ void swrUI_LoadUIElements(void)
 }
 
 // 0x00457fd0
-void swrUI_LoadWindowUIElements(void)
+void swrUI_Front_LoadWindowUIElements(void)
 {
     HANG("TODO");
 }
 
 // 0x004580e0
-void swrUI_LoadPartsUIElements(void)
+void swrUI_Front_LoadPartsUIElements(void)
 {
     swrSpriteTexture* tex;
     int id;
@@ -574,7 +574,7 @@ void swrUI_LoadPartsUIElements(void)
 }
 
 // 0x00458250
-void swrUI_LoadSelectionsUIElements(void)
+void swrUI_Front_LoadSelectionsUIElements(void)
 {
     swrSpriteTexture* tex;
     int id;

--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -214,19 +214,19 @@ FUN_004206b0
 #define swrUI_GetByValue_ADDR (0x0041b5e0)
 #define swrUI_ApplyFocusColor_ADDR (0x0041b630)
 #define swrUI_ProcessPendingClose_ADDR (0x0041b690)   // free a deferred element + completion callback (msg 0x64)
-#define swrUI_LoadTrackFromId_ADDR (0x00420930)
-#define HandleCircuits_ADDR (0x0043b0b0)
-#define swrUI_TextMenu_ADDR (0x0043fce0)
-#define MenuAxisHorizontal_ADDR (0x00440150)
-#define swrUI_DrawRecord_ADDR (0x004403e0)
-#define swrUI_GetTrackNameFromId_ADDR (0x00440620)
-#define BeatEverything1stPlace_ADDR (0x00440bc0)
-#define swrUI_LoadPlanetModels_ADDR (0x00457C20)
-#define swrUI_LoadMapPartModels_ADDR (0x00457CF0)
-#define swrUI_LoadUIElements_ADDR (0x00457ed0)
-#define swrUI_LoadWindowUIElements_ADDR (0x00457fd0)
-#define swrUI_LoadPartsUIElements_ADDR (0x004580e0)
-#define swrUI_LoadSelectionsUIElements_ADDR (0x00458250)
+#define swrUI_Front_LoadTrackFromId_ADDR (0x00420930)
+#define swrUI_Front_HandleCircuits_ADDR (0x0043b0b0)
+#define swrUI_Front_TextMenu_ADDR (0x0043fce0)
+#define swrUI_Front_MenuAxisHorizontal_ADDR (0x00440150)
+#define swrUI_Front_DrawRecord_ADDR (0x004403e0)
+#define swrUI_Front_GetTrackNameFromId_ADDR (0x00440620)
+#define swrUI_Front_BeatEverything1stPlace_ADDR (0x00440bc0)
+#define swrUI_Front_LoadPlanetModels_ADDR (0x00457C20)
+#define swrUI_Front_LoadMapPartModels_ADDR (0x00457CF0)
+#define swrUI_Front_LoadUIElements_ADDR (0x00457ed0)
+#define swrUI_Front_LoadWindowUIElements_ADDR (0x00457fd0)
+#define swrUI_Front_LoadPartsUIElements_ADDR (0x004580e0)
+#define swrUI_Front_LoadSelectionsUIElements_ADDR (0x00458250)
 
 // ---- swrUI_Menu_*: F2 page procs for the main-menu / settings screens (0x401-0x403) ----
 int swrUI_Menu_Main(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_unk* ui2);
@@ -397,26 +397,26 @@ char* swrUI_replaceAllocatedStr(char* str, char* mondo_text);
 
 swrUI_unk* swrUI_GetByValue(swrUI_unk* ui, int value);
 
-void swrUI_LoadTrackFromId(swrRace_TRACK trackId, char* buffer, size_t len);
+void swrUI_Front_LoadTrackFromId(swrRace_TRACK trackId, char* buffer, size_t len);
 
-void HandleCircuits(swrObjHang* hang);
+void swrUI_Front_HandleCircuits(swrObjHang* hang);
 
-void swrUI_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText);
+void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText);
 
-void MenuAxisHorizontal(void* pUnused, short posY);
+void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY);
 
-void swrUI_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5);
+void swrUI_Front_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5);
 
-char* swrUI_GetTrackNameFromId(int trackId);
+char* swrUI_Front_GetTrackNameFromId(int trackId);
 
-bool BeatEverything1stPlace(swrObjHang* hang);
+bool swrUI_Front_BeatEverything1stPlace(swrObjHang* hang);
 
-void swrUI_LoadPlanetModels();
-void swrUI_LoadMapPartModels();
-void swrUI_LoadUIElements(void);
-void swrUI_LoadWindowUIElements(void);
-void swrUI_LoadPartsUIElements(void);
-void swrUI_LoadSelectionsUIElements(void);
+void swrUI_Front_LoadPlanetModels();
+void swrUI_Front_LoadMapPartModels();
+void swrUI_Front_LoadUIElements(void);
+void swrUI_Front_LoadWindowUIElements(void);
+void swrUI_Front_LoadPartsUIElements(void);
+void swrUI_Front_LoadSelectionsUIElements(void);
 
 // Initialize the UI system: allocate the element hash table, zero the element arrays, install
 // the default element proc, and run the one-time CPU-speed calibration loop. Called at boot.


### PR DESCRIPTION
Follow-up to the `swrUI_Menu_*` rename in #72 -- this does the front-end glue half of the sub-namespacing we discussed.

The 13 functions in 0x43b-0x440 + 0x457 (`HandleCircuits`, `TextMenu`, `DrawRecord`, `GetTrackNameFromId`, `BeatEverything1stPlace`, `MenuAxisHorizontal`, `LoadTrackFromId`, and the `Load*Models`/`Load*UIElements` loaders) were `swrUI_`-prefixed but really drive the `swrObjHang` front-end -- most take `swrObjHang*` and they interleave with swrObjHang by address. Renamed them to `swrUI_Front_*` so the section reads as its own namespace. Core toolkit stays `swrUI_*`.

Touches swrUI.h (define + prototype), the swrUI.c reimpls, and the dinput_hook delta call sites in lockstep. Left the dinput_hook `_delta` wrappers alone (out of scope). Build-verified locally (links + hook table regenerates to the new symbols).

Heads-up: this and #72 both touch swrUI.h, so whichever lands second will need a trivial rebase.
