### PR TITLE
swrViewport: move SetCameraIndex/UpdateCameras prototypes to their own header

### DIFF
--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -152,10 +152,6 @@ void swrModel_AnimationSetSpeed(swrModel_Animation* anim, float speed);
 void swrModel_AnimationTransitionToTime(swrModel_Animation* anim, float time, float transition_speed);
 void swrModel_AnimationSetLoopTransitionSpeed(swrModel_Animation* anim, float transition_speed);
 
-void swrViewport_SetCameraIndex(short a1, swrViewport* mesh);
-
-void swrViewport_UpdateCameras();
-
 swrModel_MeshMaterial* swrModel_NodeFindFirstMeshMaterial(swrModel_Node* node);
 void swrModel_MeshMaterialSetColors(swrModel_MeshMaterial* a1, int16_t a2, int16_t a3, int16_t a4, int16_t a5_G, int16_t a6, int16_t a7);
 void swrModel_NodeSetColorsOnAllMaterials(swrModel_Node* a1_pJdge0x10, int a2, int a3, int a4, int a5_G, int a6, int a7);

--- a/src/Swr/swrViewport.h
+++ b/src/Swr/swrViewport.h
@@ -33,6 +33,9 @@
 #define swrViewport_SetRootNodeForAllViewports_ADDR (0x00483fc0)
 #define swrViewport_SetNodeFlagsForAllViewports_ADDR (0x00483ff0)
 
+void swrViewport_SetCameraIndex(short a1, swrViewport* mesh);
+void swrViewport_UpdateCameras();
+
 // Projects a world (or camera-relative) point to screen pixels for the given viewport.
 // Outputs go to outScreenX / outScreenY (set to -1000.0 if off the projection rect),
 // outZ and outDepth. pointIsCameraRelative == 0 means worldPos is absolute world space


### PR DESCRIPTION
`swrViewport_SetCameraIndex` and `swrViewport_UpdateCameras` had their `_ADDR` defines in swrViewport.h but their prototypes over in swrModel.h. Moved the two prototypes to swrViewport.h so they sit with their defines.

Besides being the right home, this fixes a real snag in `ImportHeaderInfos.py`: it only pairs a prototype with `_ADDR` names it has *already* seen while reading the concatenated `master_header.h`. swrModel.h is concatenated before swrViewport.h, so these two prototypes were read before their addresses existed and got silently dropped -- which aborts the whole import with `addresses != prototypes`. With them co-located, the import runs clean.

No signature change (`short a1, swrViewport* mesh` / `void`), just relocated.
