### PR TITLE
swrMultiplayer: name the multiplayer-menu UI cluster

### DIFF
--- a/src/Swr/swrMultiplayer.h
+++ b/src/Swr/swrMultiplayer.h
@@ -74,6 +74,26 @@
 // (sithMulti_HandleIncomingPacket loop). Called from swrMain2_GuiAdvance.
 #define swrMultiplayer_PumpPackets_ADDR (0x0041b7f0)
 
+// Multiplayer menu UI: the host/join/race-setup screen builders + their helpers.
+#define swrMultiplayer_GetSessionName_ADDR (0x0041bd10)
+#define swrMultiplayer_SetRacerListDisplay_ADDR (0x0041bd90)
+#define swrMultiplayer_ResetRaceSettings_ADDR (0x0041c260)
+#define swrMultiplayer_BroadcastRaceSettings_ADDR (0x0041c2a0)
+#define swrMultiplayer_SendRacerSelection_ADDR (0x0041c390)
+#define swrMultiplayer_CreateSession_ADDR (0x0041c5c0)
+#define swrMultiplayer_FreeRacerSlot_ADDR (0x0041e7c0)
+#define swrMultiplayer_IsAvailable_ADDR (0x0041e9d0)
+#define swrMultiplayer_BuildSessionTypeUI_ADDR (0x0041ea20)
+#define swrMultiplayer_BuildJoinGameUI_ADDR (0x0041f0e0)
+#define swrMultiplayer_BuildRaceSetupUI_ADDR (0x0041f940)
+#define swrMultiplayer_BuildRacerListUI_ADDR (0x00420600)
+#define swrMultiplayer_ValidateGameFields_ADDR (0x00420730)
+#define swrMultiplayer_FillLastPlayerName_ADDR (0x00420a90)
+#define swrMultiplayer_FillDefaultGameName_ADDR (0x00420b80)
+#define swrMultiplayer_PopulateRacerList_ADDR (0x00420cc0)
+#define swrMultiplayer_JoinGame_ADDR (0x00420d90)
+#define swrMultiplayer_GetActivePlayerCount_ADDR (0x00420f90)
+
 void swrMultiplayer_SetInMultiplayer(int bInMultiplayer);
 
 int swrMultiplayer_IsMultiplayerEnabled(void);
@@ -212,5 +232,26 @@ unsigned int swrMultiplayer_SetSessionDesc(int unused, void* param_2);
 
 // Drain and dispatch all queued incoming network packets; returns the count handled.
 int swrMultiplayer_PumpPackets(void);
+
+// Multiplayer menu UI: host/join/race-setup screen builders + their helpers.
+int swrMultiplayer_IsAvailable(void);                               // can a session start? gates the MP menu entry
+unsigned int swrMultiplayer_CreateSession(wchar_t* a1, wchar_t* a2, wchar_t* a3, char* a4, int a5);
+char* swrMultiplayer_GetSessionName(void);
+void swrMultiplayer_SetRacerListDisplay(int enabled, int x, int y); // toggle racer-list overlay + free slot cache
+void swrMultiplayer_FreeRacerSlot(int slot);
+void swrMultiplayer_ResetRaceSettings(void);                        // reset racer ids + track (Boonta) / laps (3)
+void swrMultiplayer_BroadcastRaceSettings(void);                    // host -> all: track/laps/racers (msg 0x3a)
+void swrMultiplayer_SendRacerSelection(void);                       // client -> server: racer pick (msg 0x3b)
+int swrMultiplayer_GetActivePlayerCount(void);
+void swrMultiplayer_PopulateRacerList(void);                        // fill racer list with connected players
+void swrMultiplayer_JoinGame(swrUI_unk* page);                      // connect to the entered game
+int swrMultiplayer_ValidateGameFields(swrUI_unk* page, int id1, int id2, int id3); // fields non-empty -> enable OK
+void swrMultiplayer_FillLastPlayerName(swrUI_unk* field);
+void swrMultiplayer_FillDefaultGameName(swrUI_unk* field);
+// Screen builders (each registers its swrUI_Menu_Mp* page proc):
+int swrMultiplayer_BuildSessionTypeUI(void);   // window 0x186a5: Host / Join root
+int swrMultiplayer_BuildJoinGameUI(void);      // window 0x186ab
+int swrMultiplayer_BuildRaceSetupUI(void);     // window 0x186b8
+int swrMultiplayer_BuildRacerListUI(void);     // window 0x30d41
 
 #endif // SWRMULTIPLAYER_H


### PR DESCRIPTION
Names the 18 functions behind the multiplayer menu UI (the host/join/race-setup screens), carved + traced with the create_function tooling.

**Screen builders** (each registers its `swrUI_Menu_Mp*` page proc, matching the existing `swrMultiplayer_BuildCreateGameUI`):
`BuildSessionTypeUI` (Host/Join root, 0x186a5), `BuildJoinGameUI` (0x186ab), `BuildRaceSetupUI` (0x186b8), `BuildRacerListUI` (0x30d41).

**Helpers:** `IsAvailable` (gates the MP menu), `CreateSession`, `GetSessionName`, `SetRacerListDisplay`, `FreeRacerSlot`, `ResetRaceSettings`, `BroadcastRaceSettings` (host, sithMessage 0x3a), `SendRacerSelection` (client, 0x3b), `ValidateGameFields`, `FillLastPlayerName`, `FillDefaultGameName`, `PopulateRacerList`, `GetActivePlayerCount`, `JoinGame`.

Added as a thematic block to match this header's existing role-grouped layout (it's organized by function, not address-sorted, so I didn't reorder it). `CreateSession` (0x41c5c0) is my one lower-confidence name -- happy to adjust. Header-only.
