### PR TITLE
swrText: name the in-race overlay draw-queue + timed-message helpers

### DIFF
--- a/src/Swr/swrText.h
+++ b/src/Swr/swrText.h
@@ -29,8 +29,19 @@
 #define swrText_SetupGlyph_ADDR (0x0042edc0)
 #define swrText_DrawGlyph_ADDR (0x0042eeb0)
 
+// In-race overlay: per-frame draw queues (minimap dots + 2 text-entry lists)
+// and the transient centered-message system.
+#define resetOverlayDrawQueues_ADDR (0x0044fcc0)
+#define swrText_ShowTimedMessage_ADDR (0x0044fce0)
+#define swrText_UpdateTimedMessage_ADDR (0x0044fd50)
+#define swrText_RenderEntries1_ADDR (0x00450100)
+#define swrText_RenderEntries2_ADDR (0x004501f0)
+
 #define DrawTextEntries_ADDR (0x00450280)
 #define DrawTextEntries2_ADDR (0x004502B0)
+
+#define swrText_ClearEntryClipRects_ADDR (0x004502f0)
+#define swrText_SetEntryClipRect_ADDR (0x00450310)
 
 #define swrText_CreateEntry_ADDR (0x004503e0)
 
@@ -81,8 +92,18 @@ void swrText_SetupGlyph(char c);
 // Emit the current glyph's quads at (x, y); style 'o' outline / 's' shadow / 'f' bold.
 void swrText_DrawGlyph(short x, short y, char style);
 
+// In-race overlay draw queues + transient centered message.
+void resetOverlayDrawQueues(void);                       // clear minimap + both text-entry queues
+void swrText_ShowTimedMessage(char* text, float duration); // stage a centered message with a display TTL
+void swrText_UpdateTimedMessage(void);                   // render + fade the staged message, tick its timer
+void swrText_RenderEntries1(void);                       // render text-entry list 1 (inner of DrawTextEntries)
+void swrText_RenderEntries2(void);                       // render text-entry list 2 (inner of DrawTextEntries2)
+
 void DrawTextEntries();
 void DrawTextEntries2();
+// Per-entry clip rect (text-entry list 1).
+void swrText_ClearEntryClipRects(void);
+void swrText_SetEntryClipRect(int* rect);
 
 void swrText_CreateEntry(short x, short y, char r, char g, char b, char a, char* screenText, int formatInt, int isEntry2);
 


### PR DESCRIPTION
7 in-race text-overlay helpers (header-only, inert):
- `resetOverlayDrawQueues` — clears the minimap + both text-entry queues each frame.
- `swrText_RenderEntries1` / `swrText_RenderEntries2` — the inner renderers behind the existing `DrawTextEntries` / `DrawTextEntries2`.
- `swrText_ShowTimedMessage` / `swrText_UpdateTimedMessage` — stage + render/fade a transient centered message (with a display TTL).
- `swrText_SetEntryClipRect` / `swrText_ClearEntryClipRects` — per-entry clip rect for text-entry list 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)