### PR TITLE
feat: 100-lap races + 1hr+ race timer

### DIFF
--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -1,14 +1,22 @@
 #include <macros.h>
+#include <cstring>
+#include <cstdio>
 #include "swrObjJdge_delta.h"
 
 extern "C" {
 #include <Swr/swrObj.h>
+#include <Swr/swrRace.h>
+#include <Swr/swrText.h>
+#include <Swr/swrSprite.h>
 #include <globals.h>
 
 extern FILE* hook_log;
 }
 
 #include "../hook_helper.h"
+
+extern "C" void hook_function(const char *function_name, uint32_t original_address,
+                              uint8_t *hook_address);
 
 int fixup_invalid_node_ptrs(swrModel_Node *&node) {
     if (!node)
@@ -46,8 +54,11 @@ int fixup_invalid_node_ptrs(swrModel_Node *&node) {
 // TODO hack: this is a workaround for a crash when loading custom tracks. sometimes the scene graph
 //  contains nodes with invalid child pointers, this happens after playing a vanilla track and
 //  afterwards a custom track. can be reproduced playing "Spice Mine Run" and then "Bowsers Castle 1".
+static void reset_lap_tracking(swrScore *scores); // 100-lap support, defined below
+
 unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore *scores) {
     const unsigned int x = hook_call_original(swrObjJdge_InitTrack, judge, scores);
+    reset_lap_tracking(scores);
     const int num_removed_nodes = fixup_invalid_node_ptrs(swrViewport_array[0].model_root_node);
     if (num_removed_nodes != 0)
     {
@@ -55,4 +66,347 @@ unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore *scores) {
         fflush(hook_log);
     }
     return x;
+}
+
+// --- 100-lap support -------------------------------------------------------------------------
+// swrObjJdge_F2 (0x0045ea30) accumulates each frame's elapsed time into a fixed 5-element array
+// swrScore::results_P1_Lap1..Lap5 (offsets 0x60..0x70), indexed *directly* by the current lap
+// counter swrScore::results_P1_Lap (offset 0x78, read as an int). The vanilla menu caps laps at
+// 5, so the index never exceeds 4. With more than 5 laps the index walks off the end of the
+// array and corrupts the score struct -- total_time (0x74) at lap index 5, the lap counter
+// itself (0x78) at lap index 6, then obj_test_ptr (0x84) at lap index 9 -> crash -- within a
+// handful of laps. This is the real "hardcoded 5-lap" limit (the menu wrap is only cosmetic).
+//
+// Fix: de-index every access to that array inside F2 so it always uses the first slot
+// (Lap1, [esi+0x60]). The lap counter (0x78) and total race time (0x74) are left untouched, so
+// lap counting, the finish check (lap+1 == num_laps at judge+0x1c8) and the "n / N" HUD all work
+// natively for any lap count. Per-lap split data is no longer kept in the score; instead
+// swrObjJdge_F2_delta (below) reconstructs each lap's time from the running total at every lap
+// boundary, the in-race "LAP TIME" reads are pointed at the live current/last-lap slots (the two
+// swrRace_InRaceTimer sites in the table), and the on-track results screen is replaced with a
+// best/worst/average summary (swrRace_InRaceEndStatistics_delta). Total time + lap counting are
+// unaffected.
+//
+// Most sites are a 4-byte SIB-indexed memory operand ([esi + reg*4 + 0x60], plus one
+// +num_laps*4+0x5c at the finish check). The de-indexed form is 3 bytes, padded with a NOP, so
+// instruction boundaries are preserved and no trampoline is needed. We verify the original bytes
+// before patching so a mismatched / already-patched / future binary is skipped, never corrupted.
+void swrObjJdge_PatchLapTimeOverflow() {
+    struct LapTimeSite {
+        uint32_t address;
+        uint8_t original[4];
+        uint8_t patched[4];
+    };
+
+    static const LapTimeSite sites[] = {
+        {0x0045ebc6, {0x8d, 0x44, 0x8e, 0x60}, {0x8d, 0x46, 0x60, 0x90}}, // lea eax,[esi+0x60]
+        {0x0045ebe4, {0xd9, 0x44, 0x86, 0x60}, {0xd9, 0x46, 0x60, 0x90}}, // fld dword [esi+0x60]
+        {0x0045ebee, {0x8d, 0x4c, 0x86, 0x60}, {0x8d, 0x4e, 0x60, 0x90}}, // lea ecx,[esi+0x60]
+        {0x0045ec49, {0xd9, 0x44, 0x96, 0x5c}, {0xd9, 0x46, 0x60, 0x90}}, // fld dword [esi+0x60] (was +num_laps*4+0x5c)
+        {0x0045ed5f, {0x89, 0x5c, 0x86, 0x60}, {0x89, 0x5e, 0x60, 0x90}}, // mov [esi+0x60],ebx
+        {0x0045eda8, {0x8d, 0x44, 0x8e, 0x60}, {0x8d, 0x46, 0x60, 0x90}}, // lea eax,[esi+0x60]
+        {0x0045edb3, {0xd9, 0x44, 0x96, 0x60}, {0xd9, 0x46, 0x60, 0x90}}, // fld dword [esi+0x60]
+        {0x0045edbd, {0x8d, 0x4c, 0x96, 0x60}, {0x8d, 0x4e, 0x60, 0x90}}, // lea ecx,[esi+0x60]
+
+        // swrRace_InRaceTimer (0x00460950) in-race "LAP TIME" reads, indexed by current lap:
+        // point the current-lap read at Lap1 (slot 0, where F2 now writes the live accumulator) and
+        // the just-completed-lap read at Lap2 (slot 1, which swrObjJdge_F2_delta fills with the last
+        // lap's time) so the readout ticks and the lap-complete flash shows the real last-lap time
+        // instead of 00.000 / out-of-bounds garbage.
+        {0x00460aec, {0xd9, 0x44, 0x85, 0x60}, {0xd9, 0x45, 0x60, 0x90}}, // fld [ebp+0x60] (current lap)
+        {0x00460af6, {0xd9, 0x44, 0x85, 0x5c}, {0xd9, 0x45, 0x64, 0x90}}, // fld [ebp+0x64] (last lap)
+    };
+
+    int patched = 0;
+    const int total = (int) (sizeof(sites) / sizeof(sites[0]));
+    for (const LapTimeSite &site: sites) {
+        uint8_t *code = (uint8_t *) site.address;
+        if (std::memcmp(code, site.original, 4) != 0) {
+            if (std::memcmp(code, site.patched, 4) == 0)
+                continue; // already patched
+            fprintf(hook_log,
+                    "[swrObjJdge_PatchLapTimeOverflow] unexpected bytes at %p; aborting patch. "
+                    ">5 laps will corrupt memory / crash.\n",
+                    (void *) code);
+            fflush(hook_log);
+            return;
+        }
+
+        DWORD old_protect = 0;
+        VirtualProtect(code, 4, PAGE_EXECUTE_READWRITE, &old_protect);
+        std::memcpy(code, site.patched, 4);
+        VirtualProtect(code, 4, old_protect, &old_protect);
+        patched++;
+    }
+
+    fprintf(hook_log,
+            "[swrObjJdge_PatchLapTimeOverflow] de-indexed %d/%d lap-time sites; >5 laps now safe.\n",
+            patched, total);
+    fflush(hook_log);
+}
+
+// --- 1hr+ race-time support ------------------------------------------------------------------
+// swrObjJdge_F2 caps the running race time (and each lap slot) at 3000.0s == 50:00 every frame:
+//   if (total >= 3000.0f) total = 3000.0f;   // at 0x0045ed94 (total) and 0x0045edc8 (lap slot)
+// using a shared threshold constant 3000.0f at 0x004ad264 (referenced only by these two compares).
+// So the in-game timer pins at 50:00.000 and a longer race shows ~50:00.0xx. Raise the threshold
+// and both clamp values to 24h so the time keeps accumulating; the time formatter
+// (swrText_CreateTimeEntryPrecise) already prints minutes unbounded (MM:SS.mmm, e.g. 72:34.567),
+// so every total-time readout (in-race timer, results summary, hangar results) follows.
+void swrObjJdge_PatchRaceTimeCap() {
+    const float kCap = 86400.0f; // 24h; effectively no cap for any real race, keeps ms precision
+    uint8_t cap_bytes[4];
+    std::memcpy(cap_bytes, &kCap, 4);
+
+    static const uint8_t old_3000[4] = {0x00, 0x80, 0x3b, 0x45}; // 3000.0f
+
+    struct CapSite {
+        uint32_t address;
+        bool executable; // .text immediate vs .rdata constant
+    };
+    static const CapSite sites[] = {
+        {0x004ad264, false}, // shared threshold constant (.rdata), used by both fcom compares
+        {0x0045ed97, true},  // total_time clamp immediate: mov [esi+0x74], 3000.0f
+        {0x0045edca, true},  // lap-slot clamp immediate:  mov [ecx], 3000.0f
+    };
+
+    int patched = 0;
+    const int total = (int) (sizeof(sites) / sizeof(sites[0]));
+    for (const CapSite &site: sites) {
+        uint8_t *p = (uint8_t *) site.address;
+        if (std::memcmp(p, old_3000, 4) != 0) {
+            if (std::memcmp(p, cap_bytes, 4) == 0)
+                continue; // already patched
+            fprintf(hook_log,
+                    "[swrObjJdge_PatchRaceTimeCap] unexpected bytes at %p; skipping (timer stays "
+                    "capped at 50:00).\n",
+                    (void *) p);
+            fflush(hook_log);
+            return;
+        }
+
+        DWORD old_protect = 0;
+        VirtualProtect(p, 4, PAGE_EXECUTE_READWRITE, &old_protect);
+        std::memcpy(p, cap_bytes, 4);
+        VirtualProtect(p, 4, old_protect, &old_protect);
+        patched++;
+    }
+
+    fprintf(hook_log,
+            "[swrObjJdge_PatchRaceTimeCap] raised race-time cap %d/%d sites (50:00 -> 24h).\n",
+            patched, total);
+    fflush(hook_log);
+}
+
+// --- hours in time displays ------------------------------------------------------------------
+// The stock time formatters (swrText_CreateTimeEntry @0x00450670 -> centiseconds, and
+// swrText_CreateTimeEntryPrecise @0x00450760 -> milliseconds) split the time only into
+// minutes:seconds.fraction, with the minutes field unbounded -- so a 1h12m race renders as
+// "72:34.567". Reimplement both to break out an hours field once the time reaches an hour
+// ("1:12:34.567"). Under one hour the output is byte-for-byte the vanilla layout, so lap times,
+// records and short totals are unchanged. The time arrives as the 3rd argument, a float passed as
+// its raw bits (callers pass *(int*)&seconds); screenText is the leading ~format-code prefix.
+static void format_time_with_hours(int x, int y, int time_bits, int r, int g, int b, int a,
+                                   char *screenText, int frac_scale, int frac_digits) {
+    float t;
+    std::memcpy(&t, &time_bits, sizeof(t));
+    if (t < 0.0f)
+        t = 0.0f;
+
+    int total_sec = (int) t;
+    int frac = (int) ((t - (float) total_sec) * (float) frac_scale);
+    if (frac >= frac_scale) { // guard against float edge cases, matching the stock carry
+        frac -= frac_scale;
+        total_sec++;
+    }
+    const int h = total_sec / 3600;
+    const int m = (total_sec / 60) % 60;
+    const int s = total_sec % 60;
+
+    const char *prefix = screenText ? screenText : "";
+    char body[96];
+    if (h > 0)
+        snprintf(body, sizeof(body), "%s%d:%02d:%02d.%0*d", prefix, h, m, s, frac_digits, frac);
+    else if (m > 0)
+        snprintf(body, sizeof(body), "%s%d:%02d.%0*d", prefix, m, s, frac_digits, frac);
+    else
+        snprintf(body, sizeof(body), "%s%02d.%0*d", prefix, s, frac_digits, frac);
+
+    swrText_CreateTextEntry1(x, y, r, g, b, a, body);
+}
+
+void swrText_CreateTimeEntry_delta(int x, int y, int unused, int r, int g, int b, int a,
+                                   char *screenText) {
+    format_time_with_hours(x, y, unused, r, g, b, a, screenText, 100, 2); // centiseconds
+}
+
+void swrText_CreateTimeEntryPrecise_delta(int x, int y, int unused, int r, int g, int b, int a,
+                                          char *screenText) {
+    format_time_with_hours(x, y, unused, r, g, b, a, screenText, 1000, 3); // milliseconds
+}
+
+// Registers the hour-aware time formatter replacements. Done here (rather than renderer_hook.cpp)
+// because the swrText declarations + _ADDR macros are already C-linkage-visible in this file.
+// Must run during hook registration, before init_hooks() applies the detours.
+void swrObjJdge_RegisterTimeFormatHooks() {
+    hook_function("swrText_CreateTimeEntry", (uint32_t) swrText_CreateTimeEntry,
+                  (uint8_t *) swrText_CreateTimeEntry_ADDR);
+    hook_replace(swrText_CreateTimeEntry, swrText_CreateTimeEntry_delta);
+    hook_function("swrText_CreateTimeEntryPrecise", (uint32_t) swrText_CreateTimeEntryPrecise,
+                  (uint8_t *) swrText_CreateTimeEntryPrecise_ADDR);
+    hook_replace(swrText_CreateTimeEntryPrecise, swrText_CreateTimeEntryPrecise_delta);
+}
+
+// --- 100-lap lap-time tracking + summary -----------------------------------------------------
+// Because the de-index collapses the score's 5-slot per-lap array, we reconstruct each lap's time
+// from the racer's running total_time (swrScore+0x74) at every lap boundary. This needs no per-lap
+// storage in the score -- only a running best / worst (+ their lap numbers) per racer, plus the
+// last completed lap time (mirrored into the score's Lap2 slot so the patched in-race readout can
+// show it). swrScore field offsets:
+#define SCORE_STRIDE     0x88
+#define SCORE_POSITION   0x5c // short
+#define SCORE_LAP1       0x60 // float, slot 0 (F2's live current-lap accumulator after de-index)
+#define SCORE_LAP2       0x64 // float, slot 1 (we mirror the last completed lap time here)
+#define SCORE_TOTAL_TIME 0x74 // float
+#define SCORE_CUR_LAP    0x78 // int, completed-lap count for this racer
+#define JDGE_NUM_RACERS  0x1ac
+#define JDGE_NUM_LAPS    0x1c8
+
+#define LAP_RACER_MAX 24
+
+static const char *g_lapScores = nullptr; // == DAT_00e28960 (scores base), captured at InitTrack
+static float g_bestLap[LAP_RACER_MAX];
+static int g_bestLapNum[LAP_RACER_MAX];
+static float g_worstLap[LAP_RACER_MAX];
+static int g_worstLapNum[LAP_RACER_MAX];
+static float g_lastLap[LAP_RACER_MAX];
+static float g_prevTotal[LAP_RACER_MAX];
+static int g_prevLap[LAP_RACER_MAX];
+static bool g_lapFinished[LAP_RACER_MAX];
+
+static void reset_lap_tracking(swrScore *scores) {
+    g_lapScores = (const char *) scores;
+    for (int i = 0; i < LAP_RACER_MAX; i++) {
+        g_bestLap[i] = 1.0e9f;
+        g_bestLapNum[i] = 0;
+        g_worstLap[i] = 0.0f;
+        g_worstLapNum[i] = 0;
+        g_lastLap[i] = 0.0f;
+        g_prevTotal[i] = 0.0f;
+        g_prevLap[i] = 0;
+        g_lapFinished[i] = false;
+    }
+}
+
+static inline int float_bits(float f) {
+    int i;
+    std::memcpy(&i, &f, sizeof(i));
+    return i;
+}
+
+// Wraps swrObjJdge_F2: runs the (de-indexed, crash-safe) original, then reconstructs per-lap times
+// from each racer's total_time so we can report best / worst / average for any lap count.
+void swrObjJdge_F2_delta(swrObjJdge *jdge) {
+    hook_call_original(swrObjJdge_F2, jdge);
+
+    if (!g_lapScores)
+        return;
+
+    int numRacers = *(int *) ((char *) jdge + JDGE_NUM_RACERS);
+    const int numLaps = *(int *) ((char *) jdge + JDGE_NUM_LAPS);
+    if (numRacers > LAP_RACER_MAX)
+        numRacers = LAP_RACER_MAX;
+
+    for (int r = 0; r < numRacers; r++) {
+        char *sc = (char *) g_lapScores + r * SCORE_STRIDE;
+        const int lap = *(int *) (sc + SCORE_CUR_LAP);
+        const float total = *(float *) (sc + SCORE_TOTAL_TIME);
+
+        if (lap > g_prevLap[r]) {
+            const float lapTime = total - g_prevTotal[r];
+            const int lapNum = g_prevLap[r] + 1; // 1-based number of the lap that just finished
+            if (lapTime > 0.0f) {
+                g_lastLap[r] = lapTime;
+                if (lapTime < g_bestLap[r]) {
+                    g_bestLap[r] = lapTime;
+                    g_bestLapNum[r] = lapNum;
+                }
+                if (lapTime > g_worstLap[r]) {
+                    g_worstLap[r] = lapTime;
+                    g_worstLapNum[r] = lapNum;
+                }
+            }
+            g_prevTotal[r] = total;
+            g_prevLap[r] = lap;
+        }
+
+        if (!g_lapFinished[r] && lap < numLaps) {
+            // Mirror the last completed lap time into slot 1 so the patched in-race "LAP TIME"
+            // flash (which now reads slot 1) shows it instead of garbage.
+            *(float *) (sc + SCORE_LAP2) = g_lastLap[r];
+        } else if (!g_lapFinished[r] && numLaps > 0 && lap >= numLaps) {
+            // On finish, overwrite the de-indexed lap slots so the records save in
+            // swrRace_ResultsMenu (min over Lap1..Lap_n) records the real best lap rather than the
+            // de-indexed 0.0; the sentinel in Lap2 makes its min loop stop after Lap1.
+            g_lapFinished[r] = true;
+            if (g_bestLapNum[r] > 0) {
+                *(float *) (sc + SCORE_LAP1) = g_bestLap[r];
+                *(float *) (sc + SCORE_LAP2) = -1.0f;
+            }
+        }
+    }
+}
+
+// On-track end-of-race results. The vanilla screen stacks one row per lap upward from a fixed
+// baseline and reads the 5-slot array by absolute lap, so for >5 laps it runs off the top of the
+// screen and reads past the array. Since the de-index also means there is no per-lap row data to
+// show, replace it with a compact best / worst / average / total / position summary.
+void swrRace_InRaceEndStatistics_delta(void *jdge, void *score) {
+    if (!g_lapScores) {
+        hook_call_original(swrRace_InRaceEndStatistics, jdge, score);
+        return;
+    }
+
+    const int numLaps = *(int *) ((char *) jdge + JDGE_NUM_LAPS);
+
+    // Hide the per-racer pod portrait sprites the vanilla screen would manage.
+    for (int i = 0; i < 0x13; i++)
+        swrSprite_SetVisible((short) i, 0);
+
+    const int r = (int) (((char *) score - g_lapScores) / SCORE_STRIDE);
+    const float total = *(float *) ((char *) score + SCORE_TOTAL_TIME);
+    const int pos = *(short *) ((char *) score + SCORE_POSITION);
+    char buf[64];
+
+    swrText_CreateTextEntry1(0xa0, 0x14, -1, -1, -1, -1, swrText_Translate((char *) "~cResults"));
+
+    int y = 0x3c;
+    const int label_x = 0x46, time_x = 0x96, lapn_x = 0xd2;
+
+    if (r >= 0 && r < LAP_RACER_MAX && g_bestLapNum[r] > 0) {
+        const float avg = (numLaps > 0) ? total / (float) numLaps : 0.0f;
+
+        swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Best");
+        swrText_CreateTimeEntryFormat(time_x, y, float_bits(g_bestLap[r]), -1, -1, -1, -1, 1);
+        snprintf(buf, sizeof(buf), "Lap %d", g_bestLapNum[r]);
+        swrText_CreateTextEntry1(lapn_x, y, -1, -1, -1, -1, buf);
+        y += 0x10;
+
+        swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Worst");
+        swrText_CreateTimeEntryFormat(time_x, y, float_bits(g_worstLap[r]), -1, -1, -1, -1, 1);
+        snprintf(buf, sizeof(buf), "Lap %d", g_worstLapNum[r]);
+        swrText_CreateTextEntry1(lapn_x, y, -1, -1, -1, -1, buf);
+        y += 0x10;
+
+        swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Average");
+        swrText_CreateTimeEntryFormat(time_x, y, float_bits(avg), -1, -1, -1, -1, 1);
+        y += 0x10;
+    }
+
+    swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Total");
+    swrText_CreateTimeEntryFormat(time_x, y, float_bits(total), -1, -1, -1, -1, 1);
+    y += 0x14;
+
+    snprintf(buf, sizeof(buf), "~cFinished %d laps - position %d", numLaps, pos);
+    swrText_CreateTextEntry1(0xa0, y, -1, -1, -1, -1, buf);
 }

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -206,13 +206,12 @@ void swrObjJdge_PatchRaceTimeCap() {
 // ("1:12:34.567"). Under one hour the output is byte-for-byte the vanilla layout, so lap times,
 // records and short totals are unchanged. The time arrives as the 3rd argument, a float passed as
 // its raw bits (callers pass *(int*)&seconds); screenText is the leading ~format-code prefix.
-static void format_time_with_hours(int x, int y, int time_bits, int r, int g, int b, int a,
-                                   char *screenText, int frac_scale, int frac_digits) {
-    float t;
-    std::memcpy(&t, &time_bits, sizeof(t));
+// Formats a time (seconds) into out as H:MM:SS.frac (>=1h), M:SS.frac (>=1m) or SS.frac, with
+// frac_digits of a frac_scale-th fraction (100 = centiseconds, 1000 = milliseconds). The hours
+// field only appears past an hour; under an hour the layout matches stock exactly.
+static void format_time_str(float t, int frac_scale, int frac_digits, char *out, int out_size) {
     if (t < 0.0f)
         t = 0.0f;
-
     int total_sec = (int) t;
     int frac = (int) ((t - (float) total_sec) * (float) frac_scale);
     if (frac >= frac_scale) { // guard against float edge cases, matching the stock carry
@@ -222,16 +221,22 @@ static void format_time_with_hours(int x, int y, int time_bits, int r, int g, in
     const int h = total_sec / 3600;
     const int m = (total_sec / 60) % 60;
     const int s = total_sec % 60;
-
-    const char *prefix = screenText ? screenText : "";
-    char body[96];
     if (h > 0)
-        snprintf(body, sizeof(body), "%s%d:%02d:%02d.%0*d", prefix, h, m, s, frac_digits, frac);
+        snprintf(out, out_size, "%d:%02d:%02d.%0*d", h, m, s, frac_digits, frac);
     else if (m > 0)
-        snprintf(body, sizeof(body), "%s%d:%02d.%0*d", prefix, m, s, frac_digits, frac);
+        snprintf(out, out_size, "%d:%02d.%0*d", m, s, frac_digits, frac);
     else
-        snprintf(body, sizeof(body), "%s%02d.%0*d", prefix, s, frac_digits, frac);
+        snprintf(out, out_size, "%02d.%0*d", s, frac_digits, frac);
+}
 
+static void format_time_with_hours(int x, int y, int time_bits, int r, int g, int b, int a,
+                                   char *screenText, int frac_scale, int frac_digits) {
+    float t;
+    std::memcpy(&t, &time_bits, sizeof(t));
+    char tstr[32];
+    format_time_str(t, frac_scale, frac_digits, tstr, sizeof(tstr));
+    char body[96];
+    snprintf(body, sizeof(body), "%s%s", screenText ? screenText : "", tstr);
     swrText_CreateTextEntry1(x, y, r, g, b, a, body);
 }
 
@@ -283,6 +288,9 @@ static float g_lastLap[LAP_RACER_MAX];
 static float g_prevTotal[LAP_RACER_MAX];
 static int g_prevLap[LAP_RACER_MAX];
 static bool g_lapFinished[LAP_RACER_MAX];
+// First laps' times, kept so the <=5-lap vanilla results screen (which reads the 5-slot per-lap
+// array that the de-index collapsed) can be refilled with the correct per-lap times.
+static float g_lapTimes[LAP_RACER_MAX][8];
 
 static void reset_lap_tracking(swrScore *scores) {
     g_lapScores = (const char *) scores;
@@ -295,13 +303,9 @@ static void reset_lap_tracking(swrScore *scores) {
         g_prevTotal[i] = 0.0f;
         g_prevLap[i] = 0;
         g_lapFinished[i] = false;
+        for (int j = 0; j < 8; j++)
+            g_lapTimes[i][j] = 0.0f;
     }
-}
-
-static inline int float_bits(float f) {
-    int i;
-    std::memcpy(&i, &f, sizeof(i));
-    return i;
 }
 
 // Wraps swrObjJdge_F2: runs the (de-indexed, crash-safe) original, then reconstructs per-lap times
@@ -324,8 +328,11 @@ void swrObjJdge_F2_delta(swrObjJdge *jdge) {
 
         if (lap > g_prevLap[r]) {
             const float lapTime = total - g_prevTotal[r];
-            const int lapNum = g_prevLap[r] + 1; // 1-based number of the lap that just finished
+            const int completedIdx = g_prevLap[r]; // 0-based index of the lap that just finished
+            const int lapNum = completedIdx + 1;   // 1-based number for display
             if (lapTime > 0.0f) {
+                if (completedIdx < 8)
+                    g_lapTimes[r][completedIdx] = lapTime; // for the <=5 vanilla results refill
                 g_lastLap[r] = lapTime;
                 if (lapTime < g_bestLap[r]) {
                     g_bestLap[r] = lapTime;
@@ -357,10 +364,11 @@ void swrObjJdge_F2_delta(swrObjJdge *jdge) {
     }
 }
 
-// On-track end-of-race results. The vanilla screen stacks one row per lap upward from a fixed
-// baseline and reads the 5-slot array by absolute lap, so for >5 laps it runs off the top of the
-// screen and reads past the array. Since the de-index also means there is no per-lap row data to
-// show, replace it with a compact best / worst / average / total / position summary.
+// On-track end-of-race results. For <=5 laps the score's 5 per-lap slots fit, so refill them from
+// the reconstructed lap times (the de-index dropped per-lap storage) and defer to the original
+// screen -- it looks exactly like vanilla. For >5 laps a per-lap list can't fit (the vanilla layout
+// stacks one row per lap off the top of the screen), so show a compact best/worst/average/total
+// summary in the same left-label / time-column style.
 void swrRace_InRaceEndStatistics_delta(void *jdge, void *score) {
     if (!g_lapScores) {
         hook_call_original(swrRace_InRaceEndStatistics, jdge, score);
@@ -368,44 +376,66 @@ void swrRace_InRaceEndStatistics_delta(void *jdge, void *score) {
     }
 
     const int numLaps = *(int *) ((char *) jdge + JDGE_NUM_LAPS);
+    const int r = (int) (((char *) score - g_lapScores) / SCORE_STRIDE);
 
-    // Hide the per-racer pod portrait sprites the vanilla screen would manage.
+    if (numLaps <= 5) {
+        if (r >= 0 && r < LAP_RACER_MAX) {
+            for (int i = 0; i < numLaps && i < 8; i++)
+                *(float *) ((char *) score + SCORE_LAP1 + i * 4) = g_lapTimes[r][i];
+        }
+        hook_call_original(swrRace_InRaceEndStatistics, jdge, score);
+        return;
+    }
+
+    // >5 laps: hide the per-racer pod portrait sprites the vanilla screen would manage, then draw
+    // the summary. Times are formatted here (hour-aware) and drawn left-aligned so they sit in a
+    // clean column instead of right-aligning back over the labels.
     for (int i = 0; i < 0x13; i++)
         swrSprite_SetVisible((short) i, 0);
 
-    const int r = (int) (((char *) score - g_lapScores) / SCORE_STRIDE);
     const float total = *(float *) ((char *) score + SCORE_TOTAL_TIME);
     const int pos = *(short *) ((char *) score + SCORE_POSITION);
-    char buf[64];
+    char buf[96];
+    char tstr[32];
 
     swrText_CreateTextEntry1(0xa0, 0x14, -1, -1, -1, -1, swrText_Translate((char *) "~cResults"));
 
-    int y = 0x3c;
-    const int label_x = 0x46, time_x = 0x96, lapn_x = 0xd2;
+    const int label_x = 0x2d; // 45
+    const int time_x = 0x82;  // 130
+    const int lapn_x = 0xd2;  // 210
+    int y = 0x48;             // 72
 
     if (r >= 0 && r < LAP_RACER_MAX && g_bestLapNum[r] > 0) {
         const float avg = (numLaps > 0) ? total / (float) numLaps : 0.0f;
 
-        swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Best");
-        swrText_CreateTimeEntryFormat(time_x, y, float_bits(g_bestLap[r]), -1, -1, -1, -1, 1);
-        snprintf(buf, sizeof(buf), "Lap %d", g_bestLapNum[r]);
+        swrText_CreateTextEntry1(label_x, y, -1, -1, 0, -1, (char *) "~f4~sBest");
+        format_time_str(g_bestLap[r], 1000, 3, tstr, sizeof(tstr));
+        snprintf(buf, sizeof(buf), "~f1~s%s", tstr);
+        swrText_CreateTextEntry1(time_x, y, -1, -1, -1, -1, buf);
+        snprintf(buf, sizeof(buf), "~f1~sLap %d", g_bestLapNum[r]);
         swrText_CreateTextEntry1(lapn_x, y, -1, -1, -1, -1, buf);
-        y += 0x10;
+        y += 0xe;
 
-        swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Worst");
-        swrText_CreateTimeEntryFormat(time_x, y, float_bits(g_worstLap[r]), -1, -1, -1, -1, 1);
-        snprintf(buf, sizeof(buf), "Lap %d", g_worstLapNum[r]);
+        swrText_CreateTextEntry1(label_x, y, -1, -1, 0, -1, (char *) "~f4~sWorst");
+        format_time_str(g_worstLap[r], 1000, 3, tstr, sizeof(tstr));
+        snprintf(buf, sizeof(buf), "~f1~s%s", tstr);
+        swrText_CreateTextEntry1(time_x, y, -1, -1, -1, -1, buf);
+        snprintf(buf, sizeof(buf), "~f1~sLap %d", g_worstLapNum[r]);
         swrText_CreateTextEntry1(lapn_x, y, -1, -1, -1, -1, buf);
-        y += 0x10;
+        y += 0xe;
 
-        swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Average");
-        swrText_CreateTimeEntryFormat(time_x, y, float_bits(avg), -1, -1, -1, -1, 1);
-        y += 0x10;
+        swrText_CreateTextEntry1(label_x, y, -1, -1, 0, -1, (char *) "~f4~sAverage");
+        format_time_str(avg, 1000, 3, tstr, sizeof(tstr));
+        snprintf(buf, sizeof(buf), "~f1~s%s", tstr);
+        swrText_CreateTextEntry1(time_x, y, -1, -1, -1, -1, buf);
+        y += 0xe;
     }
 
-    swrText_CreateTextEntry1(label_x, y, -1, -1, -1, -1, (char *) "Total");
-    swrText_CreateTimeEntryFormat(time_x, y, float_bits(total), -1, -1, -1, -1, 1);
-    y += 0x14;
+    swrText_CreateTextEntry1(label_x, y, -1, -1, 0, -1, (char *) "~f4~sTotal");
+    format_time_str(total, 1000, 3, tstr, sizeof(tstr));
+    snprintf(buf, sizeof(buf), "~f1~s%s", tstr);
+    swrText_CreateTextEntry1(time_x, y, -1, -1, -1, -1, buf);
+    y += 0x16;
 
     snprintf(buf, sizeof(buf), "~cFinished %d laps - position %d", numLaps, pos);
     swrText_CreateTextEntry1(0xa0, y, -1, -1, -1, -1, buf);

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -250,18 +250,6 @@ void swrText_CreateTimeEntryPrecise_delta(int x, int y, int unused, int r, int g
     format_time_with_hours(x, y, unused, r, g, b, a, screenText, 1000, 3); // milliseconds
 }
 
-// Registers the hour-aware time formatter replacements. Done here (rather than renderer_hook.cpp)
-// because the swrText declarations + _ADDR macros are already C-linkage-visible in this file.
-// Must run during hook registration, before init_hooks() applies the detours.
-void swrObjJdge_RegisterTimeFormatHooks() {
-    hook_function("swrText_CreateTimeEntry", (uint32_t) swrText_CreateTimeEntry,
-                  (uint8_t *) swrText_CreateTimeEntry_ADDR);
-    hook_replace(swrText_CreateTimeEntry, swrText_CreateTimeEntry_delta);
-    hook_function("swrText_CreateTimeEntryPrecise", (uint32_t) swrText_CreateTimeEntryPrecise,
-                  (uint8_t *) swrText_CreateTimeEntryPrecise_ADDR);
-    hook_replace(swrText_CreateTimeEntryPrecise, swrText_CreateTimeEntryPrecise_delta);
-}
-
 // --- 100-lap lap-time tracking + summary -----------------------------------------------------
 // Because the de-index collapses the score's 5-slot per-lap array, we reconstruct each lap's time
 // from the racer's running total_time (swrScore+0x74) at every lap boundary. This needs no per-lap
@@ -278,6 +266,10 @@ void swrObjJdge_RegisterTimeFormatHooks() {
 #define JDGE_NUM_LAPS    0x1c8
 
 #define LAP_RACER_MAX 24
+// The vanilla on-track results screen has exactly 5 per-lap rows (the score's 5-slot per-lap
+// array). g_lapTimes only feeds that screen, and only on the <=5-lap path, so it needs no more
+// than these 5 slots -- a >5-lap race uses the best/worst/avg summary instead and never reads it.
+#define VANILLA_RESULTS_LAPS 5
 
 static const char *g_lapScores = nullptr; // == DAT_00e28960 (scores base), captured at InitTrack
 static float g_bestLap[LAP_RACER_MAX];
@@ -288,9 +280,9 @@ static float g_lastLap[LAP_RACER_MAX];
 static float g_prevTotal[LAP_RACER_MAX];
 static int g_prevLap[LAP_RACER_MAX];
 static bool g_lapFinished[LAP_RACER_MAX];
-// First laps' times, kept so the <=5-lap vanilla results screen (which reads the 5-slot per-lap
-// array that the de-index collapsed) can be refilled with the correct per-lap times.
-static float g_lapTimes[LAP_RACER_MAX][8];
+// Per-lap times for the first VANILLA_RESULTS_LAPS laps, kept so the <=5-lap vanilla results screen
+// (which reads the 5-slot per-lap array the de-index collapsed) can be refilled with real times.
+static float g_lapTimes[LAP_RACER_MAX][VANILLA_RESULTS_LAPS];
 
 static void reset_lap_tracking(swrScore *scores) {
     g_lapScores = (const char *) scores;
@@ -303,7 +295,7 @@ static void reset_lap_tracking(swrScore *scores) {
         g_prevTotal[i] = 0.0f;
         g_prevLap[i] = 0;
         g_lapFinished[i] = false;
-        for (int j = 0; j < 8; j++)
+        for (int j = 0; j < VANILLA_RESULTS_LAPS; j++)
             g_lapTimes[i][j] = 0.0f;
     }
 }
@@ -331,7 +323,7 @@ void swrObjJdge_F2_delta(swrObjJdge *jdge) {
             const int completedIdx = g_prevLap[r]; // 0-based index of the lap that just finished
             const int lapNum = completedIdx + 1;   // 1-based number for display
             if (lapTime > 0.0f) {
-                if (completedIdx < 8)
+                if (completedIdx < VANILLA_RESULTS_LAPS)
                     g_lapTimes[r][completedIdx] = lapTime; // for the <=5 vanilla results refill
                 g_lastLap[r] = lapTime;
                 if (lapTime < g_bestLap[r]) {
@@ -380,18 +372,23 @@ void swrRace_InRaceEndStatistics_delta(void *jdge, void *score) {
 
     if (numLaps <= 5) {
         if (r >= 0 && r < LAP_RACER_MAX) {
-            for (int i = 0; i < numLaps && i < 8; i++)
+            for (int i = 0; i < numLaps && i < VANILLA_RESULTS_LAPS; i++)
                 *(float *) ((char *) score + SCORE_LAP1 + i * 4) = g_lapTimes[r][i];
         }
         hook_call_original(swrRace_InRaceEndStatistics, jdge, score);
         return;
     }
 
-    // >5 laps: hide the per-racer pod portrait sprites the vanilla screen would manage, then draw
-    // the summary. Times are formatted here (hour-aware) and drawn left-aligned so they sit in a
-    // clean column instead of right-aligning back over the labels.
-    for (int i = 0; i < 0x13; i++)
-        swrSprite_SetVisible((short) i, 0);
+    // >5 laps: hide the results-screen sprites the vanilla screen would lay out, then draw the
+    // summary. These are UI sprites, not racers: the original swrRace_InRaceEndStatistics
+    // (0x00462320) single-player branch hides sprite IDs 0..0x12 (loop `while (i < 0x13)`) -- the
+    // per-lap row sprites it would otherwise show. We mirror that exact range so none show through
+    // our summary. (The vanilla 2-player splitscreen branches instead clear 0xf..0x12 / 0x13..0x16;
+    // the >5-lap summary path only runs single-player.) Times are formatted here (hour-aware) and
+    // drawn left-aligned so they sit in a clean column instead of right-aligning over the labels.
+    const short kResultsScreenSprites = 0x13; // == original single-player sprite-hide loop bound
+    for (short i = 0; i < kResultsScreenSprites; i++)
+        swrSprite_SetVisible(i, 0);
 
     const float total = *(float *) ((char *) score + SCORE_TOTAL_TIME);
     const int pos = *(short *) ((char *) score + SCORE_POSITION);

--- a/dinput_hook/game_deltas/swrObjJdge_delta.h
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.h
@@ -17,7 +17,6 @@ void swrObjJdge_PatchRaceTimeCap();
 // the time reaches an hour; identical to stock under one hour. Cover all total-time readouts.
 void swrText_CreateTimeEntry_delta(int x, int y, int unused, int r, int g, int b, int a, char *screenText);
 void swrText_CreateTimeEntryPrecise_delta(int x, int y, int unused, int r, int g, int b, int a, char *screenText);
-void swrObjJdge_RegisterTimeFormatHooks();
 
 // 100-lap support: reconstructs per-lap times from the running total (de-index drops per-lap
 // storage) to report best/worst/average for any lap count.

--- a/dinput_hook/game_deltas/swrObjJdge_delta.h
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.h
@@ -3,3 +3,26 @@
 #include "types.h"
 
 unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore * scores);
+
+// 100-lap support: de-index swrObjJdge_F2's fixed 5-element per-lap split-time array
+// (swrScore::results_P1_Lap1..Lap5) so lap counts above 5 stop corrupting the score struct.
+// Applied as a verified in-place byte patch at startup. See swrObjJdge_delta.cpp.
+void swrObjJdge_PatchLapTimeOverflow();
+
+// 1hr+ race-time support: raises swrObjJdge_F2's 50:00 (3000.0s) race-time / lap-time clamp to 24h
+// so the in-game timer and every total-time readout can show past one hour. Verified byte patch.
+void swrObjJdge_PatchRaceTimeCap();
+
+// 1hr+ race-time support: time formatters reimplemented to show an hours field (H:MM:SS.frac) once
+// the time reaches an hour; identical to stock under one hour. Cover all total-time readouts.
+void swrText_CreateTimeEntry_delta(int x, int y, int unused, int r, int g, int b, int a, char *screenText);
+void swrText_CreateTimeEntryPrecise_delta(int x, int y, int unused, int r, int g, int b, int a, char *screenText);
+void swrObjJdge_RegisterTimeFormatHooks();
+
+// 100-lap support: reconstructs per-lap times from the running total (de-index drops per-lap
+// storage) to report best/worst/average for any lap count.
+void swrObjJdge_F2_delta(swrObjJdge *jdge);
+
+// 100-lap support: replaces the on-track per-lap results list (which can't fit >5 rows) with a
+// best/worst/average/total/position summary.
+void swrRace_InRaceEndStatistics_delta(void *jdge, void *score);

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -1249,7 +1249,9 @@ LAB_0043b9b4:
                             break;
                         }
                         case 2: {
-                            hang->numLaps++;
+                            // 100-lap mod: coarse stepping so high lap counts stay reachable.
+                            // Fine control (1-5) is preserved for standard races; +5 beyond that.
+                            hang->numLaps += hang->numLaps < 5 ? 1 : 5;
                             break;
                         }
                         case 3: {
@@ -1294,7 +1296,7 @@ LAB_0043b9b4:
                             break;
                         }
                         case 2: {
-                            hang->numLaps--;
+                            hang->numLaps -= hang->numLaps <= 5 ? 1 : 5;
                             break;
                         }
                         case 3: {
@@ -1331,9 +1333,9 @@ LAB_0043b9b4:
             }
 
             if (hang->numLaps < 1) {
-                hang->numLaps = 5;
+                hang->numLaps = 100;
             }
-            if (hang->numLaps > 5) {
+            if (hang->numLaps > 100) {
                 hang->numLaps = 1;
             }
             if (hang->AISpeed < 1) {

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -1252,8 +1252,12 @@ LAB_0043b9b4:
                             // High-lap mod: coarse stepping so big lap counts stay reachable. Fine
                             // control (1-5) is preserved for standard races; +5 beyond that. Cap is
                             // 125 because numLaps is a signed char (>127 would overflow); the race
-                            // engine itself (int judge->num_laps) handles far more.
-                            hang->numLaps += hang->numLaps < 5 ? 1 : 5;
+                            // engine itself (int judge->num_laps) handles far more. Compute the next
+                            // value in an int and wrap to 1 explicitly: 125 + 5 would overflow the
+                            // char to negative before the >125 guard below could catch it, leaving
+                            // forward-wrap stuck (the <1 guard would bounce it back to 125).
+                            int nextLaps = (int) hang->numLaps + (hang->numLaps < 5 ? 1 : 5);
+                            hang->numLaps = (char) (nextLaps > 125 ? 1 : nextLaps);
                             break;
                         }
                         case 3: {

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -1249,8 +1249,10 @@ LAB_0043b9b4:
                             break;
                         }
                         case 2: {
-                            // 100-lap mod: coarse stepping so high lap counts stay reachable.
-                            // Fine control (1-5) is preserved for standard races; +5 beyond that.
+                            // High-lap mod: coarse stepping so big lap counts stay reachable. Fine
+                            // control (1-5) is preserved for standard races; +5 beyond that. Cap is
+                            // 125 because numLaps is a signed char (>127 would overflow); the race
+                            // engine itself (int judge->num_laps) handles far more.
                             hang->numLaps += hang->numLaps < 5 ? 1 : 5;
                             break;
                         }
@@ -1333,9 +1335,9 @@ LAB_0043b9b4:
             }
 
             if (hang->numLaps < 1) {
-                hang->numLaps = 100;
+                hang->numLaps = 125;
             }
-            if (hang->numLaps > 100) {
+            if (hang->numLaps > 125) {
                 hang->numLaps = 1;
             }
             if (hang->AISpeed < 1) {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1162,6 +1162,24 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) swrObjJdge_InitTrack_ADDR);
     hook_replace(swrObjJdge_InitTrack, swrObjJdge_InitTrack_delta);
 
+    // 100-lap support: de-index swrObjJdge_F2's fixed 5-slot per-lap split-time array so lap
+    // counts above 5 no longer corrupt the score struct (the real hardcoded 5-lap limit). The
+    // hangar menu cap was also raised to 100 in tracks_delta.c.
+    swrObjJdge_PatchLapTimeOverflow();
+
+    // 1hr+ race-time support: raise the 50:00 race-time clamp so the timer can show past one hour,
+    // and replace the time formatters with hour-aware versions (H:MM:SS.frac).
+    swrObjJdge_PatchRaceTimeCap();
+    swrObjJdge_RegisterTimeFormatHooks();
+
+    // 100-lap support: wrap swrObjJdge_F2 to reconstruct per-lap times (best/worst/average) and
+    // replace the on-track per-lap results list with a summary that fits any lap count.
+    hook_function("swrObjJdge_F2", (uint32_t) swrObjJdge_F2, (uint8_t *) swrObjJdge_F2_ADDR);
+    hook_replace(swrObjJdge_F2, swrObjJdge_F2_delta);
+    hook_function("swrRace_InRaceEndStatistics", (uint32_t) swrRace_InRaceEndStatistics,
+                  (uint8_t *) swrRace_InRaceEndStatistics_ADDR);
+    hook_replace(swrRace_InRaceEndStatistics, swrRace_InRaceEndStatistics_delta);
+
     hook_function("swrRace_CourseSelectionMenu", (uint32_t) swrRace_CourseSelectionMenu_ADDR,
                   (uint8_t *) swrRace_CourseSelectionMenu_delta);
     hook_function("swrRace_CourseInfoMenu", (uint32_t) swrRace_CourseInfoMenu_ADDR,

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -67,6 +67,7 @@ extern "C" {
 #include <Swr/swrRender.h>
 #include <Swr/swrSpline.h>
 #include <Swr/swrSprite.h>
+#include <Swr/swrText.h>
 #include <Swr/swrUI.h>
 #include <Swr/swrViewport.h>
 #include <Swr/swrViewport.h>
@@ -1170,7 +1171,12 @@ extern "C" void init_renderer_hooks() {
     // 1hr+ race-time support: raise the 50:00 race-time clamp so the timer can show past one hour,
     // and replace the time formatters with hour-aware versions (H:MM:SS.frac).
     swrObjJdge_PatchRaceTimeCap();
-    swrObjJdge_RegisterTimeFormatHooks();
+    hook_function("swrText_CreateTimeEntry", (uint32_t) swrText_CreateTimeEntry,
+                  (uint8_t *) swrText_CreateTimeEntry_ADDR);
+    hook_replace(swrText_CreateTimeEntry, swrText_CreateTimeEntry_delta);
+    hook_function("swrText_CreateTimeEntryPrecise", (uint32_t) swrText_CreateTimeEntryPrecise,
+                  (uint8_t *) swrText_CreateTimeEntryPrecise_ADDR);
+    hook_replace(swrText_CreateTimeEntryPrecise, swrText_CreateTimeEntryPrecise_delta);
 
     // 100-lap support: wrap swrObjJdge_F2 to reconstruct per-lap times (best/worst/average) and
     // replace the on-track per-lap results list with a summary that fits any lap count.


### PR DESCRIPTION
Lifts the vanilla 5-lap cap (menu now goes to 125) and fixes the in-game timer maxing out at 50:00. All in the `dinput_hook` delta layer - no decomp/header changes.

What's going on:
- The real 5-lap limit isn't the menu - it's `swrObjJdge_F2` indexing a fixed 5-slot per-lap-time array (`swrScore::results_P1_Lap1..5`) by the current lap with no bounds check, so >5 laps walk off the end and corrupt the score struct (crash within ~6-9 laps). Fixed with a verified in-place byte patch that de-indexes those accesses.
- Per-lap times are reconstructed from the running total so best/worst/average still work for any count. `<=5`-lap races keep the exact vanilla results screen; `>5` shows a compact best/worst/avg/total summary (a per-lap list can't fit on screen).
- The 50:00 timer was a hard `3000.0s` clamp in `F2` - raised to 24h, and the time formatters now break out an hours field (`H:MM:SS`) past an hour. Identical to stock under an hour.
- Menu cap is 125 because `numLaps` is a signed char; the engine's int `num_laps` handles far more, so going higher just needs decoupling the menu value from the char.

Verified in-game: 100-lap race counts/finishes correctly, timer reads past 1hr, results screen looks right for both <=5 and >5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)