### PR TITLE
swrConfig: reimplement video/audio/force config read/write

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,14 +19,14 @@ BreakBeforeBraces: Custom
 BraceWrapping:
     AfterEnum: true
     AfterClass: true
-    AfterControlStatement: true
+    AfterControlStatement: false
     AfterFunction: true
     AfterNamespace: true
     AfterStruct: true
     AfterUnion: true
     AfterExternBlock: true
-    BeforeCatch: true
-    BeforeElse: true
+    BeforeCatch: false
+    BeforeElse: false
     IndentBraces: false
     SplitEmptyFunction: false
     SplitEmptyRecord: false

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -48,6 +48,9 @@ swrConfig_currentInputDeviceType 0x004b2030 swrConfig_DEVICE
 
 swrTextFmtString1 0x004b2304 char[4] = "%s\0\0"
 
+swrConfig_FORCE_ENABLED 0x004b2910 int
+swrControl_forceFeedbackAvailable 0x004b2914 int
+
 swrConfig_joystick_enabled 0x004b2944 int = 1
 swrConfig_keyboard_enabled 0x004b2948 int = 1
 joystick_detected 0x004b294c int = 1
@@ -84,6 +87,7 @@ swrUI_unk_ptr 0x004b5d74 swrUI_unk*
 Main_nut_delay_ms 0x004b6718 int = 32
 Main_hiRes_sound 0x004b6d14 int = 1
 Main_doppler_sound 0x004b6d18 int = 0
+Main_sound_reflections 0x004b6d1c int
 Main_sound 0x004b6d20 int = 1
 Main_sound_gain_adjust 0x004b6d24 float
 swrRace_voices_enabled 0x004b6d28 int = 1
@@ -399,6 +403,7 @@ swrSound_Initted 0x004eb450 int
 
 swrSound_Ready 0x004eb458 int
 swrRace_music_enabled 0x004eb45c int
+Main_sound_reverb 0x004eb460 int
 
 swrSoundHashTable 0x004eb464 tHashTable*
 

--- a/src/Swr/swrConfig.c
+++ b/src/Swr/swrConfig.c
@@ -164,42 +164,38 @@ int swrConfig_ReadVideoConfig(char* config_type)
     char pathname[256];
 
     sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", config_type, "video.cfg");
-    if (stdConffile_Open(pathname) == 0)
-    {
+    if (stdConffile_Open(pathname) == 0) {
         stdConffile_Close();
         return -1;
     }
 
-    while (stdConffile_ReadArgs() != 0)
-    {
+    while (stdConffile_ReadArgs() != 0) {
         if (strcmp(stdConffile_g_entry.aArgs[0].argName, "end.") == 0)
             break;
 
-        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "VIDEO") == 0)
-        {
+        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "VIDEO") == 0) {
             char* name = stdConffile_g_entry.aArgs[1].argName;
             char* value = stdConffile_g_entry.aArgs[1].argValue;
 
-            if (strcmpi(name, "REFLECTIONS") == 0)
+            if (strcmpi(name, "REFLECTIONS") == 0) {
                 swrConfig_VIDEO_REFLECTIONS = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "ZEFFECTS") == 0)
+            } else if (strcmpi(name, "ZEFFECTS") == 0) {
                 swrConfig_VIDEO_ZEFFECTS = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "DYNAMIC_LIGHTING") == 0)
+            } else if (strcmpi(name, "DYNAMIC_LIGHTING") == 0) {
                 swrConfig_VIDEO_DYNAMIC_LIGHTING = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "VSYNC") == 0)
+            } else if (strcmpi(name, "VSYNC") == 0) {
                 swrConfig_VIDEO_VSYNC = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "LENSFLARE") == 0)
+            } else if (strcmpi(name, "LENSFLARE") == 0) {
                 swrConfig_VIDEO_LENSFLARE = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "ENGINEEXHAUST") == 0)
+            } else if (strcmpi(name, "ENGINEEXHAUST") == 0) {
                 swrConfig_VIDEO_ENGINEEXHAUST = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "TEXTURE_RES") == 0)
+            } else if (strcmpi(name, "TEXTURE_RES") == 0) {
                 swrConfig_VIDEO_TEXTURE_RES = atoi(value);
-            else if (strcmpi(name, "MODEL_DETAIL") == 0)
+            } else if (strcmpi(name, "MODEL_DETAIL") == 0) {
                 swrConfig_VIDEO_MODEL_DETAIL = atoi(value);
-            else if (strcmpi(name, "DRAWDISTANCE") == 0)
+            } else if (strcmpi(name, "DRAWDISTANCE") == 0) {
                 swrConfig_VIDEO_DRAWDISTANCE = atoi(value);
-            else
-            {
+            } else {
                 stdConffile_Close();
                 return 0;
             }
@@ -219,17 +215,16 @@ void swrConfig_AssignForceValues(void)
 // 0x0040ab60
 void swrConfig_SetDefaultForce(void)
 {
-    int iVar1;
-    int* piVar2;
-    int* piVar3;
+    int count;
+    int* src;
+    int* dst;
 
-    piVar2 = swrConfig_defaultForceConfig;
-    piVar3 = &swrConfig_FORCE_STRENGTH;
-    for (iVar1 = 8; iVar1 != 0; iVar1 = iVar1 + -1)
-    {
-        *piVar3 = *piVar2;
-        piVar2 = piVar2 + 1;
-        piVar3 = piVar3 + 1;
+    src = swrConfig_defaultForceConfig;
+    dst = &swrConfig_FORCE_STRENGTH;
+    for (count = 8; count != 0; count--) {
+        *dst = *src;
+        src++;
+        dst++;
     }
     swrConfig_AssignForceValues();
 }
@@ -246,69 +241,54 @@ int swrConfig_WriteForceFeedbackConfig(char* filename)
 
     sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", filename, "force.cfg");
     open_status = stdConffile_OpenWrite(pathname);
-    if (open_status == 0)
-    {
+    if (open_status == 0) {
         stdConffile_CloseWrite();
         return 0xffffffff;
     }
     sprintf(prefix, "FORCEFEEDBACK");
     printf_status = swrConfig_Printf("\n\n####### %s SETTINGS\n\n", prefix);
-    if (printf_status == 0)
-    {
+    if (printf_status == 0) {
         sprintf(config_name, "STRENGTH=%i", swrConfig_FORCE_STRENGTH);
         printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-        if (printf_status == 0)
-        {
+        if (printf_status == 0) {
             sprintf(config_name, "AUTOCENTER=%i", swrConfig_FORCE_AUTOCENTER);
             printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-            if (printf_status == 0)
-            {
+            if (printf_status == 0) {
                 sprintf(config_name, "COLLISIONS=%i", swrConfig_FORCE_COLLISIONS);
                 printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                if (printf_status == 0)
-                {
+                if (printf_status == 0) {
                     sprintf(config_name, "DAMAGE=%i", swrConfig_FORCE_DAMAGE);
                     printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                    if (printf_status == 0)
-                    {
+                    if (printf_status == 0) {
                         sprintf(config_name, "TERRAIN=%i", swrConfig_FORCE_TERRAIN);
                         printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                        if (printf_status == 0)
-                        {
+                        if (printf_status == 0) {
                             sprintf(config_name, "PODACTIONS=%i", swrConfig_FORCE_PODACTIONS);
                             printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                            if (printf_status == 0)
-                            {
+                            if (printf_status == 0) {
                                 str_bool = "ON";
-                                if (swrConfig_FORCE_GFORCES == 0)
-                                {
+                                if (swrConfig_FORCE_GFORCES == 0) {
                                     str_bool = "OFF";
                                 }
                                 sprintf(config_name, "GFORCES=%s", str_bool);
                                 printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                                if (printf_status == 0)
-                                {
+                                if (printf_status == 0) {
                                     str_bool = "ON";
-                                    if (swrConfig_FORCE_ENGINERUMBLE == 0)
-                                    {
+                                    if (swrConfig_FORCE_ENGINERUMBLE == 0) {
                                         str_bool = "OFF";
                                     }
                                     sprintf(config_name, "ENGINERUMBLE=%s", str_bool);
                                     printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                                    if (printf_status == 0)
-                                    {
+                                    if (printf_status == 0) {
                                         str_bool = "TRUE";
-                                        if (swrConfig_FORCE_ENABLED == 0)
-                                        {
+                                        if (swrConfig_FORCE_ENABLED == 0) {
                                             str_bool = "FALSE";
                                         }
                                         sprintf(config_name, "ENABLED=%s", str_bool);
                                         printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                                        if (printf_status == 0)
-                                        {
+                                        if (printf_status == 0) {
                                             printf_status = swrConfig_Puts("\nend.\n");
-                                            if (printf_status == 0)
-                                            {
+                                            if (printf_status == 0) {
                                                 stdConffile_CloseWrite();
                                                 return 1;
                                             }
@@ -332,47 +312,42 @@ int swrConfig_ReadForceFeedbackConfig(char* config_type)
     char pathname[256];
 
     sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", config_type, "force.cfg");
-    if (stdConffile_Open(pathname) == 0)
-    {
+    if (stdConffile_Open(pathname) == 0) {
         stdConffile_Close();
         return -1;
     }
 
-    while (stdConffile_ReadArgs() != 0)
-    {
+    while (stdConffile_ReadArgs() != 0) {
         if (strcmp(stdConffile_g_entry.aArgs[0].argName, "end.") == 0)
             break;
 
-        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "FORCEFEEDBACK") == 0)
-        {
+        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "FORCEFEEDBACK") == 0) {
             char* name = stdConffile_g_entry.aArgs[1].argName;
             char* value = stdConffile_g_entry.aArgs[1].argValue;
 
-            if (strcmpi(name, "STRENGTH") == 0)
+            if (strcmpi(name, "STRENGTH") == 0) {
                 swrConfig_FORCE_STRENGTH = atoi(value);
-            else if (strcmpi(name, "AUTOCENTER") == 0)
+            } else if (strcmpi(name, "AUTOCENTER") == 0) {
                 swrConfig_FORCE_AUTOCENTER = atoi(value);
-            else if (strcmpi(name, "COLLISIONS") == 0)
+            } else if (strcmpi(name, "COLLISIONS") == 0) {
                 swrConfig_FORCE_COLLISIONS = atoi(value);
-            else if (strcmpi(name, "DAMAGE") == 0)
+            } else if (strcmpi(name, "DAMAGE") == 0) {
                 swrConfig_FORCE_DAMAGE = atoi(value);
-            else if (strcmpi(name, "TERRAIN") == 0)
+            } else if (strcmpi(name, "TERRAIN") == 0) {
                 swrConfig_FORCE_TERRAIN = atoi(value);
-            else if (strcmpi(name, "PODACTIONS") == 0)
+            } else if (strcmpi(name, "PODACTIONS") == 0) {
                 swrConfig_FORCE_PODACTIONS = atoi(value);
-            else if (strcmpi(name, "GFORCES") == 0)
+            } else if (strcmpi(name, "GFORCES") == 0) {
                 swrConfig_FORCE_GFORCES = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "ENGINERUMBLE") == 0)
+            } else if (strcmpi(name, "ENGINERUMBLE") == 0) {
                 swrConfig_FORCE_ENGINERUMBLE = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "ENABLED") == 0)
-            {
-                if (Main_force_feedback != 0 && swrControl_forceFeedbackAvailable != 0 && strcmpi(value, "TRUE") == 0)
+            } else if (strcmpi(name, "ENABLED") == 0) {
+                if (Main_force_feedback != 0 && swrControl_forceFeedbackAvailable != 0 && strcmpi(value, "TRUE") == 0) {
                     swrConfig_FORCE_ENABLED = 1;
-                else
+                } else {
                     swrConfig_FORCE_ENABLED = 0;
-            }
-            else
-            {
+                }
+            } else {
                 stdConffile_Close();
                 return 0;
             }
@@ -396,94 +371,74 @@ int swrConfig_WriteAudioConfig(char* dirname)
 
     sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", dirname, "audio.cfg");
     open_status = stdConffile_OpenWrite(pathname);
-    if (open_status == 0)
-    {
+    if (open_status == 0) {
         stdConffile_CloseWrite();
         return 0xffffffff;
     }
     sprintf(prefix, "AUDIO");
     printf_status = swrConfig_Printf("\n\n####### %s SETTINGS\n\n", prefix);
-    if (printf_status == 0)
-    {
+    if (printf_status == 0) {
         str_bool = "ON";
-        if (Main_sound == 0)
-        {
+        if (Main_sound == 0) {
             str_bool = "OFF";
         }
         sprintf(config_name, "SYS=%s", str_bool);
         printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-        if (printf_status == 0)
-        {
+        if (printf_status == 0) {
             str_bool = "ON";
-            if (Main_hiRes_sound == 0)
-            {
+            if (Main_hiRes_sound == 0) {
                 str_bool = "OFF";
             }
             sprintf(config_name, "HIRES=%s", str_bool);
             printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-            if (printf_status == 0)
-            {
+            if (printf_status == 0) {
                 str_bool = "ON";
-                if (Sound_enabled_3d == 0)
-                {
+                if (Sound_enabled_3d == 0) {
                     str_bool = "OFF";
                 }
                 sprintf(config_name, "3D=%s", str_bool);
                 printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                if (printf_status == 0)
-                {
+                if (printf_status == 0) {
                     str_bool = "ON";
-                    if (Main_doppler_sound == 0)
-                    {
+                    if (Main_doppler_sound == 0) {
                         str_bool = "OFF";
                     }
                     sprintf(config_name, "DOPPLER=%s", str_bool);
                     printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                    if (printf_status == 0)
-                    {
+                    if (printf_status == 0) {
                         str_bool = "ON";
-                        if (Main_sound_reflections == 0)
-                        {
+                        if (Main_sound_reflections == 0) {
                             str_bool = "OFF";
                         }
                         sprintf(config_name, "REFLECTIONS=%s", str_bool);
                         printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                        if (printf_status == 0)
-                        {
+                        if (printf_status == 0) {
                             sprintf(config_name, "GAINMATCH=%0.2f", (double) Main_sound_gain_adjust);
                             printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                            if (printf_status == 0)
-                            {
+                            if (printf_status == 0) {
                                 str_bool = "ON";
-                                if (swrRace_voices_enabled == 0)
-                                {
+                                if (swrRace_voices_enabled == 0) {
                                     str_bool = "OFF";
                                 }
                                 sprintf(config_name, "VOICE=%s", str_bool);
                                 printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                                if (printf_status == 0)
-                                {
+                                if (printf_status == 0) {
                                     str_bool = "ON";
-                                    if (swrRace_music_enabled == 0)
-                                    {
+                                    if (swrRace_music_enabled == 0) {
                                         str_bool = "OFF";
                                     }
                                     sprintf(config_name, "MUSIC=%s", str_bool);
                                     printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                                    if (printf_status == 0)
-                                    {
+                                    if (printf_status == 0) {
                                         str_bool = "ON";
-                                        if (Main_sound_reverb == 0)
-                                        {
+                                        if (Main_sound_reverb == 0) {
                                             str_bool = "OFF";
                                         }
                                         sprintf(config_name, "REVERB=%s", str_bool);
                                         printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
-                                        if (printf_status == 0)
-                                        {
+                                        if (printf_status == 0) {
                                             printf_status = swrConfig_Puts("\nend.\n");
-                                            if (printf_status == 0)
-                                            {
+                                            if (printf_status == 0) {
                                                 stdConffile_CloseWrite();
                                                 return 1;
                                             }
@@ -510,39 +465,35 @@ int swrConfig_ReadAudioConfig(char* dirname)
         return 1;
 
     sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", dirname, "audio.cfg");
-    if (stdConffile_Open(pathname) == 0)
-    {
+    if (stdConffile_Open(pathname) == 0) {
         stdConffile_Close();
         return -1;
     }
 
-    while (stdConffile_ReadArgs() != 0)
-    {
+    while (stdConffile_ReadArgs() != 0) {
         if (strcmp(stdConffile_g_entry.aArgs[0].argName, "end.") == 0)
             break;
 
-        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "AUDIO") == 0)
-        {
+        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "AUDIO") == 0) {
             char* name = stdConffile_g_entry.aArgs[1].argName;
             char* value = stdConffile_g_entry.aArgs[1].argValue;
 
-            if (strcmpi(name, "HIRES") == 0)
+            if (strcmpi(name, "HIRES") == 0) {
                 Main_hiRes_sound = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "SYS") == 0)
+            } else if (strcmpi(name, "SYS") == 0) {
                 Main_sound = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "3D") == 0)
+            } else if (strcmpi(name, "3D") == 0) {
                 Sound_enabled_3d = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "DOPPLER") == 0)
+            } else if (strcmpi(name, "DOPPLER") == 0) {
                 Main_doppler_sound = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "GAINMATCH") == 0)
-            {
+            } else if (strcmpi(name, "GAINMATCH") == 0) {
                 Main_sound_gain_adjust = (float) atof(value);
                 swrSound_SetMainGain(Main_sound_gain_adjust);
-            }
-            else if (strcmpi(name, "VOICE") == 0)
+            } else if (strcmpi(name, "VOICE") == 0) {
                 swrRace_voices_enabled = strcmpi(value, "ON") == 0;
-            else if (strcmpi(name, "MUSIC") == 0)
+            } else if (strcmpi(name, "MUSIC") == 0) {
                 swrRace_music_enabled = strcmpi(value, "ON") == 0;
+            }
         }
     }
 

--- a/src/Swr/swrConfig.c
+++ b/src/Swr/swrConfig.c
@@ -5,6 +5,11 @@
 #include "globals.h"
 #include "macros.h"
 
+#include "swrSound.h"
+
+#include <string.h>
+#include <stdlib.h>
+
 // 0x00406080
 int swrConfig_WriteMappings(char* dirname)
 {
@@ -156,7 +161,52 @@ int swrConfig_WriteVideoConfig(char* dirname)
 // 0x00408b60
 int swrConfig_ReadVideoConfig(char* config_type)
 {
-    HANG("TODO");
+    char pathname[256];
+
+    sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", config_type, "video.cfg");
+    if (stdConffile_Open(pathname) == 0)
+    {
+        stdConffile_Close();
+        return -1;
+    }
+
+    while (stdConffile_ReadArgs() != 0)
+    {
+        if (strcmp(stdConffile_g_entry.aArgs[0].argName, "end.") == 0)
+            break;
+
+        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "VIDEO") == 0)
+        {
+            char* name = stdConffile_g_entry.aArgs[1].argName;
+            char* value = stdConffile_g_entry.aArgs[1].argValue;
+
+            if (strcmpi(name, "REFLECTIONS") == 0)
+                swrConfig_VIDEO_REFLECTIONS = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "ZEFFECTS") == 0)
+                swrConfig_VIDEO_ZEFFECTS = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "DYNAMIC_LIGHTING") == 0)
+                swrConfig_VIDEO_DYNAMIC_LIGHTING = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "VSYNC") == 0)
+                swrConfig_VIDEO_VSYNC = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "LENSFLARE") == 0)
+                swrConfig_VIDEO_LENSFLARE = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "ENGINEEXHAUST") == 0)
+                swrConfig_VIDEO_ENGINEEXHAUST = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "TEXTURE_RES") == 0)
+                swrConfig_VIDEO_TEXTURE_RES = atoi(value);
+            else if (strcmpi(name, "MODEL_DETAIL") == 0)
+                swrConfig_VIDEO_MODEL_DETAIL = atoi(value);
+            else if (strcmpi(name, "DRAWDISTANCE") == 0)
+                swrConfig_VIDEO_DRAWDISTANCE = atoi(value);
+            else
+            {
+                stdConffile_Close();
+                return 0;
+            }
+        }
+    }
+
+    stdConffile_Close();
     return 1;
 }
 
@@ -169,34 +219,335 @@ void swrConfig_AssignForceValues(void)
 // 0x0040ab60
 void swrConfig_SetDefaultForce(void)
 {
-    HANG("TODO");
+    int iVar1;
+    int* piVar2;
+    int* piVar3;
+
+    piVar2 = swrConfig_defaultForceConfig;
+    piVar3 = &swrConfig_FORCE_STRENGTH;
+    for (iVar1 = 8; iVar1 != 0; iVar1 = iVar1 + -1)
+    {
+        *piVar3 = *piVar2;
+        piVar2 = piVar2 + 1;
+        piVar3 = piVar3 + 1;
+    }
+    swrConfig_AssignForceValues();
 }
 
 // 0x0040ab80
 int swrConfig_WriteForceFeedbackConfig(char* filename)
 {
-    HANG("TODO");
+    int open_status;
+    size_t printf_status;
+    char* str_bool;
+    char config_name[32];
+    char prefix[32];
+    char pathname[256];
+
+    sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", filename, "force.cfg");
+    open_status = stdConffile_OpenWrite(pathname);
+    if (open_status == 0)
+    {
+        stdConffile_CloseWrite();
+        return 0xffffffff;
+    }
+    sprintf(prefix, "FORCEFEEDBACK");
+    printf_status = swrConfig_Printf("\n\n####### %s SETTINGS\n\n", prefix);
+    if (printf_status == 0)
+    {
+        sprintf(config_name, "STRENGTH=%i", swrConfig_FORCE_STRENGTH);
+        printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+        if (printf_status == 0)
+        {
+            sprintf(config_name, "AUTOCENTER=%i", swrConfig_FORCE_AUTOCENTER);
+            printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+            if (printf_status == 0)
+            {
+                sprintf(config_name, "COLLISIONS=%i", swrConfig_FORCE_COLLISIONS);
+                printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                if (printf_status == 0)
+                {
+                    sprintf(config_name, "DAMAGE=%i", swrConfig_FORCE_DAMAGE);
+                    printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                    if (printf_status == 0)
+                    {
+                        sprintf(config_name, "TERRAIN=%i", swrConfig_FORCE_TERRAIN);
+                        printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                        if (printf_status == 0)
+                        {
+                            sprintf(config_name, "PODACTIONS=%i", swrConfig_FORCE_PODACTIONS);
+                            printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                            if (printf_status == 0)
+                            {
+                                str_bool = "ON";
+                                if (swrConfig_FORCE_GFORCES == 0)
+                                {
+                                    str_bool = "OFF";
+                                }
+                                sprintf(config_name, "GFORCES=%s", str_bool);
+                                printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                                if (printf_status == 0)
+                                {
+                                    str_bool = "ON";
+                                    if (swrConfig_FORCE_ENGINERUMBLE == 0)
+                                    {
+                                        str_bool = "OFF";
+                                    }
+                                    sprintf(config_name, "ENGINERUMBLE=%s", str_bool);
+                                    printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                                    if (printf_status == 0)
+                                    {
+                                        str_bool = "TRUE";
+                                        if (swrConfig_FORCE_ENABLED == 0)
+                                        {
+                                            str_bool = "FALSE";
+                                        }
+                                        sprintf(config_name, "ENABLED=%s", str_bool);
+                                        printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                                        if (printf_status == 0)
+                                        {
+                                            printf_status = swrConfig_Puts("\nend.\n");
+                                            if (printf_status == 0)
+                                            {
+                                                stdConffile_CloseWrite();
+                                                return 1;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    stdConffile_CloseWrite();
+    return 0;
 }
 
 // 0x0040ae40
 int swrConfig_ReadForceFeedbackConfig(char* config_type)
 {
-    HANG("TODO");
+    char pathname[256];
+
+    sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", config_type, "force.cfg");
+    if (stdConffile_Open(pathname) == 0)
+    {
+        stdConffile_Close();
+        return -1;
+    }
+
+    while (stdConffile_ReadArgs() != 0)
+    {
+        if (strcmp(stdConffile_g_entry.aArgs[0].argName, "end.") == 0)
+            break;
+
+        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "FORCEFEEDBACK") == 0)
+        {
+            char* name = stdConffile_g_entry.aArgs[1].argName;
+            char* value = stdConffile_g_entry.aArgs[1].argValue;
+
+            if (strcmpi(name, "STRENGTH") == 0)
+                swrConfig_FORCE_STRENGTH = atoi(value);
+            else if (strcmpi(name, "AUTOCENTER") == 0)
+                swrConfig_FORCE_AUTOCENTER = atoi(value);
+            else if (strcmpi(name, "COLLISIONS") == 0)
+                swrConfig_FORCE_COLLISIONS = atoi(value);
+            else if (strcmpi(name, "DAMAGE") == 0)
+                swrConfig_FORCE_DAMAGE = atoi(value);
+            else if (strcmpi(name, "TERRAIN") == 0)
+                swrConfig_FORCE_TERRAIN = atoi(value);
+            else if (strcmpi(name, "PODACTIONS") == 0)
+                swrConfig_FORCE_PODACTIONS = atoi(value);
+            else if (strcmpi(name, "GFORCES") == 0)
+                swrConfig_FORCE_GFORCES = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "ENGINERUMBLE") == 0)
+                swrConfig_FORCE_ENGINERUMBLE = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "ENABLED") == 0)
+            {
+                if (Main_force_feedback != 0 && swrControl_forceFeedbackAvailable != 0 && strcmpi(value, "TRUE") == 0)
+                    swrConfig_FORCE_ENABLED = 1;
+                else
+                    swrConfig_FORCE_ENABLED = 0;
+            }
+            else
+            {
+                stdConffile_Close();
+                return 0;
+            }
+        }
+    }
+
+    stdConffile_Close();
+    swrConfig_AssignForceValues();
     return 1;
 }
 
 // 0x00422140
 int swrConfig_WriteAudioConfig(char* dirname)
 {
-    HANG("TODO");
-    return -1;
+    int open_status;
+    size_t printf_status;
+    char* str_bool;
+    char config_name[32];
+    char prefix[32];
+    char pathname[256];
+
+    sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", dirname, "audio.cfg");
+    open_status = stdConffile_OpenWrite(pathname);
+    if (open_status == 0)
+    {
+        stdConffile_CloseWrite();
+        return 0xffffffff;
+    }
+    sprintf(prefix, "AUDIO");
+    printf_status = swrConfig_Printf("\n\n####### %s SETTINGS\n\n", prefix);
+    if (printf_status == 0)
+    {
+        str_bool = "ON";
+        if (Main_sound == 0)
+        {
+            str_bool = "OFF";
+        }
+        sprintf(config_name, "SYS=%s", str_bool);
+        printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+        if (printf_status == 0)
+        {
+            str_bool = "ON";
+            if (Main_hiRes_sound == 0)
+            {
+                str_bool = "OFF";
+            }
+            sprintf(config_name, "HIRES=%s", str_bool);
+            printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+            if (printf_status == 0)
+            {
+                str_bool = "ON";
+                if (Sound_enabled_3d == 0)
+                {
+                    str_bool = "OFF";
+                }
+                sprintf(config_name, "3D=%s", str_bool);
+                printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                if (printf_status == 0)
+                {
+                    str_bool = "ON";
+                    if (Main_doppler_sound == 0)
+                    {
+                        str_bool = "OFF";
+                    }
+                    sprintf(config_name, "DOPPLER=%s", str_bool);
+                    printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                    if (printf_status == 0)
+                    {
+                        str_bool = "ON";
+                        if (Main_sound_reflections == 0)
+                        {
+                            str_bool = "OFF";
+                        }
+                        sprintf(config_name, "REFLECTIONS=%s", str_bool);
+                        printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                        if (printf_status == 0)
+                        {
+                            sprintf(config_name, "GAINMATCH=%0.2f", (double) Main_sound_gain_adjust);
+                            printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                            if (printf_status == 0)
+                            {
+                                str_bool = "ON";
+                                if (swrRace_voices_enabled == 0)
+                                {
+                                    str_bool = "OFF";
+                                }
+                                sprintf(config_name, "VOICE=%s", str_bool);
+                                printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                                if (printf_status == 0)
+                                {
+                                    str_bool = "ON";
+                                    if (swrRace_music_enabled == 0)
+                                    {
+                                        str_bool = "OFF";
+                                    }
+                                    sprintf(config_name, "MUSIC=%s", str_bool);
+                                    printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                                    if (printf_status == 0)
+                                    {
+                                        str_bool = "ON";
+                                        if (Main_sound_reverb == 0)
+                                        {
+                                            str_bool = "OFF";
+                                        }
+                                        sprintf(config_name, "REVERB=%s", str_bool);
+                                        printf_status = swrConfig_Printf("%-28s%-28s\n", prefix, config_name);
+                                        if (printf_status == 0)
+                                        {
+                                            printf_status = swrConfig_Puts("\nend.\n");
+                                            if (printf_status == 0)
+                                            {
+                                                stdConffile_CloseWrite();
+                                                return 1;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    stdConffile_CloseWrite();
+    return 0;
 }
 
 // 0x00422440
 int swrConfig_ReadAudioConfig(char* dirname)
 {
-    HANG("TODO");
-    return -1;
+    char pathname[256];
+
+    if (swrSound_Initted == 0)
+        return 1;
+
+    sprintf(pathname, "%s%s\\%s", ".\\data\\config\\", dirname, "audio.cfg");
+    if (stdConffile_Open(pathname) == 0)
+    {
+        stdConffile_Close();
+        return -1;
+    }
+
+    while (stdConffile_ReadArgs() != 0)
+    {
+        if (strcmp(stdConffile_g_entry.aArgs[0].argName, "end.") == 0)
+            break;
+
+        if (strcmpi(stdConffile_g_entry.aArgs[0].argName, "AUDIO") == 0)
+        {
+            char* name = stdConffile_g_entry.aArgs[1].argName;
+            char* value = stdConffile_g_entry.aArgs[1].argValue;
+
+            if (strcmpi(name, "HIRES") == 0)
+                Main_hiRes_sound = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "SYS") == 0)
+                Main_sound = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "3D") == 0)
+                Sound_enabled_3d = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "DOPPLER") == 0)
+                Main_doppler_sound = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "GAINMATCH") == 0)
+            {
+                Main_sound_gain_adjust = (float) atof(value);
+                swrSound_SetMainGain(Main_sound_gain_adjust);
+            }
+            else if (strcmpi(name, "VOICE") == 0)
+                swrRace_voices_enabled = strcmpi(value, "ON") == 0;
+            else if (strcmpi(name, "MUSIC") == 0)
+                swrRace_music_enabled = strcmpi(value, "ON") == 0;
+        }
+    }
+
+    stdConffile_Close();
+    return 1;
 }
 
 // 0x004879a0


### PR DESCRIPTION
Reimplements the settings-file serialization in `swrConfig` — fills in the `HANG` stubs to complete the video/audio/force read/write/defaults set that `WriteVideoConfig` already started.

**Functions:** `ReadVideoConfig`, `ReadAudioConfig`, `WriteAudioConfig`, `WriteForceFeedbackConfig`, `ReadForceFeedbackConfig`, `SetDefaultForce`.

**New globals they touch:**
- `swrConfig_FORCE_ENABLED` (0x4b2910) — the FF `ENABLED` setting; gates the `cifr_*` runtime
- `swrControl_forceFeedbackAvailable` (0x4b2914) — FF hardware-cap flag, cleared by `cifr_Init` when the joystick can't do FF
- `Main_sound_reflections` (0x4b6d1c), `Main_sound_reverb` (0x4eb460) — audio toggles (recovered from the `WriteAudioConfig` disasm since the decompile dropped the varargs)

Verified against the project flags (both `-Werror` gates pass); string constants, the `SetDefaultForce` copy loop, and the `GAINMATCH` float->double all match the disasm.

`WriteMappings` / `ControlToString` / `AssignForceValues` stay stubbed — they need the input-binding descriptor tables and the force-feedback gain block typed first, so they'll come in a follow-up. (`SetDefaultForce`/`ReadForceFeedbackConfig` call `AssignForceValues`, which stays a stub — fine for the dormant reverse-hook; the call site is correct.)

The two new FF global names are best-effort proposals — rename if your DB already has them.