### PR TITLE
stdConffile: reimplement the config-file parser

### DIFF
--- a/src/General/stdConffile.c
+++ b/src/General/stdConffile.c
@@ -1,6 +1,9 @@
 #include "stdConffile.h"
 
+#include "globals.h"
 #include <macros.h>
+
+#include <string.h>
 
 // 0x004877b0 TODO: Crashes on release build, works on debug
 int stdConffile_Open(const char* pFilename)
@@ -11,53 +14,204 @@ int stdConffile_Open(const char* pFilename)
 // 0x004877d0
 int stdConffile_OpenWrite(char* pFilename)
 {
-    HANG("TODO");
+    if (stdConffile_writeFile != NULL)
+        return 0;
+
+    stdConffile_writeFile = (*stdPlatform_hostServices_ptr->fileOpen)(pFilename, "wb");
+    if (stdConffile_writeFile == NULL)
+    {
+        stdConffile_writeFile = NULL;
+        return 0;
+    }
+    strncpy(stdConffile_aWriteFilename, pFilename, 0x7f);
+    stdConffile_aWriteFilename[0x7f] = '\0';
+    return 1;
 }
 
 // 0x00487830
 int stdConffile_OpenMode(const char* pFilename, const char* openMode)
 {
-    HANG("TODO");
+    if (stdConffile_bOpen != 0)
+        stdConffile_PushStack();
+
+    // "none" opens a conffile context with no backing file (in-memory only)
+    if (strcmp(pFilename, "none") == 0)
+    {
+        stdConffile_openFile = NULL;
+    }
+    else
+    {
+        stdConffile_openFile = (*stdPlatform_hostServices_ptr->fileOpen)(pFilename, openMode);
+        if (stdConffile_openFile == NULL)
+        {
+            stdConffile_openFile = NULL;
+            if (stdConffile_bOpen != 0)
+                stdConffile_PopStack();
+            return 0;
+        }
+    }
+
+    stdConffile_g_aLine = (*stdPlatform_hostServices_ptr->alloc)(0x1000);
+    strncpy(stdConffile_pFilename, pFilename, 0x7f);
+    stdConffile_pFilename[0x7f] = '\0';
+    stdConffile_linenum = 0;
+    stdConffile_bOpen = 1;
+    return 1;
 }
 
 // 0x00487900
 void stdConffile_Close(void)
 {
-    HANG("TODO");
+    if (stdConffile_bOpen != 0)
+    {
+        if (stdConffile_openFile != NULL)
+            (*stdPlatform_hostServices_ptr->fileClose)(stdConffile_openFile);
+        stdConffile_openFile = NULL;
+        (*stdPlatform_hostServices_ptr->free)(stdConffile_g_aLine);
+        if (stdConffile_stackLevel != 0)
+        {
+            stdConffile_PopStack();
+            return;
+        }
+        stdConffile_bOpen = 0;
+    }
 }
 
 // 0x00487960
 void stdConffile_CloseWrite(void)
 {
-    HANG("TODO");
+    if (stdConffile_writeFile != NULL)
+    {
+        (*stdPlatform_hostServices_ptr->fileClose)(stdConffile_writeFile);
+        stdConffile_writeFile = NULL;
+        strncpy(stdConffile_aWriteFilename, "NOT_OPEN", 0x7f);
+        stdConffile_aWriteFilename[0x7f] = '\0';
+    }
 }
 
 // 0x00487a50
 int stdConffile_ReadArgsFromStr(char* pStr)
 {
-    HANG("TODO");
+    int n = 0;
+    stdConffile_g_entry.numArgs = 0;
+
+    char* tok = strtok(pStr, ", \t\n\r");
+    if (tok == NULL)
+    {
+        stdConffile_g_entry.numArgs = 0;
+        return 0;
+    }
+
+    do
+    {
+        if (n >= 512)
+            return 1;
+
+        char* eq = strchr(tok, '=');
+        if (eq == NULL)
+        {
+            stdConffile_g_entry.aArgs[n].argName = tok;
+            stdConffile_g_entry.aArgs[n].argValue = tok;
+        }
+        else
+        {
+            *eq = '\0';
+            stdConffile_g_entry.aArgs[n].argName = tok;
+            stdConffile_g_entry.aArgs[n].argValue = eq + 1;
+        }
+        n++;
+        tok = strtok(NULL, ", \t\n\r");
+    } while (tok != NULL);
+
+    stdConffile_g_entry.numArgs = n;
+    return 0;
 }
 
 // 0x00487ae0
-int stdConffile_ReadArgs()
+int stdConffile_ReadArgs(void)
 {
-    HANG("TODO");
+    if (stdConffile_ReadLine() == 0)
+        return 0;
+
+    while (stdConffile_ReadArgsFromStr(stdConffile_g_aLine) == 0)
+    {
+        if (stdConffile_g_entry.numArgs != 0)
+            return 1;
+        if (stdConffile_ReadLine() == 0)
+            return 0;
+    }
+    return 0;
 }
 
 // 0x00487b20
 int stdConffile_ReadLine(void)
 {
-    HANG("TODO");
+    bool done = false;
+    size_t remaining = 0xfff;
+    char* str = stdConffile_g_aLine;
+
+    do
+    {
+        if (remaining == 0)
+            return 1;
+
+        if ((*stdPlatform_hostServices_ptr->fileGets)(stdConffile_openFile, str, remaining) == NULL)
+            return 0;
+
+        stdConffile_linenum++;
+
+        char first = *str;
+        if (first != ';' && first != '#' && first != '\n' && first != '\r')
+        {
+            char* comment = strchr(str, '#');
+            if (comment != NULL)
+                *comment = '\0';
+            strlwr(str);
+
+            size_t len = strlen(stdConffile_g_aLine);
+            if (stdConffile_g_aLine[len - 2] == '\\')
+            {
+                // trailing backslash: continuation, keep reading over the backslash
+                remaining = 0x1000 - len;
+                str = stdConffile_g_aLine + (len - 2);
+            }
+            else
+            {
+                done = true;
+                if (stdConffile_g_aLine[len - 1] == '\r' || stdConffile_g_aLine[len - 1] == '\n')
+                    stdConffile_g_aLine[len - 1] = '\0';
+            }
+        }
+
+        if (done)
+            return 1;
+    } while (true);
 }
 
 // 0x00487c00
 void stdConffile_PushStack(void)
 {
-    HANG("TODO");
+    strcpy(stdConffile_aFilenameStack[stdConffile_stackLevel], stdConffile_pFilename);
+    stdConffile_linenumStack[stdConffile_stackLevel] = stdConffile_linenum;
+    stdConffile_linenum = 0;
+    stdConffile_apBufferStack[stdConffile_stackLevel] = stdConffile_g_aLine;
+    stdConffile_openFileStack[stdConffile_stackLevel] = stdConffile_openFile;
+    stdConffile_openFile = NULL;
+    stdConffile_aEntryStack[stdConffile_stackLevel] = stdConffile_g_entry;
+    stdConffile_stackLevel++;
 }
 
 // 0x00487c90
 void stdConffile_PopStack(void)
 {
-    HANG("TODO");
+    if (stdConffile_stackLevel != 0)
+    {
+        int level = stdConffile_stackLevel - 1;
+        strcpy(stdConffile_pFilename, stdConffile_aFilenameStack[level]);
+        stdConffile_stackLevel = level;
+        stdConffile_openFile = stdConffile_openFileStack[level];
+        stdConffile_linenum = stdConffile_linenumStack[level];
+        stdConffile_g_aLine = stdConffile_apBufferStack[level];
+        stdConffile_g_entry = stdConffile_aEntryStack[level];
+    }
 }


### PR DESCRIPTION
Reimplements the conffile parser/tokenizer that sits beneath `swrConfig` (and the various loaders that read `.cfg`/`.tab` files).

- **Open/Close** (read + write) -- read-open honours the `"none"` sentinel (in-memory context, no backing file) and pushes/pops the include stack when already open; write-open uses `"wb"`.
- **`ReadLine`** -- skips `;`/`#` comment lines, strips trailing `#` comments, lowercases, and handles trailing-backslash line continuation.
- **`ReadArgsFromStr`** / **`ReadArgs`** -- `strtok` key=value splitter (`", \t\n\r"` delimited) into `stdConffile_g_entry`.
- **`PushStack`/`PopStack`** -- the nested-include stack (saves/restores filename, line number, buffer, file handle, and the whole entry).

No new globals (all `stdConffile_*` state was already named). Verified with the project flags (both `-Werror` gates); disasm confirms the string literals (`none`/`wb`/`", \t\n\r"`), the `strtok`/`strchr`/`strlwr` calls, and the 4100-byte `g_entry` `rep movsl` copy in push/pop.

One small intentional divergence: `ReadArgsFromStr` caps at the `aArgs[512]` capacity; the original's pointer bound allowed one slot past the array (a harmless off-by-one never reached by real conf files).