### PR TITLE
swrObjJdge: reimplement F4 (race-judge sub-event dispatcher) + type the struct

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -48,6 +48,7 @@ swrConfig_currentInputDeviceType 0x004b2030 swrConfig_DEVICE
 
 swrTextFmtString1 0x004b2304 char[4] = "%s\0\0"
 
+swrControl_uiInputActive 0x004b2940 int
 swrConfig_joystick_enabled 0x004b2944 int = 1
 swrConfig_keyboard_enabled 0x004b2948 int = 1
 joystick_detected 0x004b294c int = 1
@@ -567,12 +568,19 @@ swrSpriteTexture_dial_gradient_rgb2 0x0050CA00 swrSpriteTexture*
 speedDialPosition1 0x0050CA04 float
 speedDialPosition2 0x0050CA08 float
 
+swrObjJdge_postRaceHudState 0x0050ca10 int
+
 numLocalPlayers 0x0050CA18 int
 
 debug_showSplineMarkers 0x0050ca24 int
 swrRace_IsInvincible 0x0050ca28 int
 
+swrObjJdge_localRacerId 0x0050ca30 int
 swrJdge_Cleared 0x0050ca34 int
+swrRace_demoMode 0x0050ca3c int
+swrObjJdge_demoHudCycleIndex 0x0050ca40 int
+swrObjJdge_demoHudCycled 0x0050ca44 int
+swrObjJdge_creditsScrollState 0x0050ca48 int
 
 specialActiveTrigger 0x0050CB48 swrModel_TriggerDescription*
 swrObjTrig_CurrentPlanetId 0x0050CB4C int
@@ -1275,6 +1283,9 @@ swrWeather_velocityX 0x004b9528 float
 swrWeather_velocityY 0x004b952c float
 swrWeather_stretchFactor 0x004b9530 float
 swrWeather_particleCap 0x004b9534 int
+
+swrPlayerHUD_lightStreakParam 0x004b9578 float
+
 swrWeather_particlePositions 0x00e99860 rdVector3[80]
 swrWeather_particleScreenPositions 0x00e9a000 rdVector2[80]
 swrWeather_particleSpriteIds 0x00e9a280 int[80]

--- a/src/Swr/swrEvent.c
+++ b/src/Swr/swrEvent.c
@@ -5,6 +5,8 @@
 
 #include "swrAssetBuffer.h"
 
+#include <macros.h>
+
 // 0x00447300
 void swrEvent_AllocateAndLoadObjs(int event, int count)
 {
@@ -296,4 +298,10 @@ void swrEvent_FreeObjs(int event)
             }
         }
     }
+}
+
+// 0x00450be0
+void swrEvent_Broadcast(int event, int* subEvents)
+{
+    HANG("TODO");
 }

--- a/src/Swr/swrEvent.h
+++ b/src/Swr/swrEvent.h
@@ -143,6 +143,8 @@ swrEventManager eventManagerMain[][9] = {
 
 #define swrEvent_GetItem_ADDR (0x00450b30)
 
+#define swrEvent_Broadcast_ADDR (0x00450be0)
+
 #define swrEvent_DispatchSubEvents_ADDR (0x00450c00)
 
 #define swrEvent_CallF4_ADDR (0x00450c50)
@@ -171,6 +173,10 @@ void* swrEvent_FindObjectById(int event, int id);
 int swrEvent_GetEventCount(int event);
 
 void* swrEvent_GetItem(int event, int index);
+
+// Broadcast a sub-event to every entity of the event type (wraps swrEvent_BroadcastFiltered with the
+// 'All!' wildcard); vestigial in the release build (builds the args then no-ops via swr_noop2).
+void swrEvent_Broadcast(int event, int* subEvents);
 
 void swrEvent_DispatchSubEvents(void* obj, int* subEvents); // int[2]
 

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -4,6 +4,8 @@
 #include "swrEvent.h"
 #include "swrSprite.h"
 #include "swrModel.h"
+#include "swrSound.h"
+#include "swrCam.h"
 
 #include <macros.h>
 
@@ -298,8 +300,148 @@ void swrObjJdge_F3(swrObjJdge* jdge)
 // 0x00463a50
 int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
 {
-    HANG("TODO");
-    return 0;
+    switch (*subEvents)
+    {
+    case 'Begn': // race start: latch the race config from the sub-event payload
+        swr_FastMode = 0;
+        swrRace_DebugFlag = 0;
+        swrControl_uiInputActive = 0;
+        swrJdge_Cleared = 0;
+        jdge->num_players = subEvents[2];
+        jdge->planetId = subEvents[3];
+        jdge->unk1b0_modelId = subEvents[4];
+        jdge->unk1b4_splineId = subEvents[5];
+        jdge->cam_splineId = subEvents[6];
+        jdge->planet_track_number = subEvents[7];
+        jdge->unk1cc_ms = (float) subEvents[8];
+        jdge->num_laps = subEvents[9];
+        jdge->best_lap_time_ms = *(float*) (p3 + 0x28);
+        jdge->recordLap3_ms = *(float*) (p3 + 0x2c);
+        jdge->unk1c4 = subEvents[0xc];
+        if (subEvents[0xd] == 1)
+            GameSettingFlags |= 0x4000;
+        else
+            GameSettingFlags &= ~0x4000;
+        jdge->flag &= ~0x80;
+        swrObjJdge_localRacerId = subEvents[0xe];
+        if (jdge->unk1cc_ms <= 0.0f)
+            jdge->flag &= ~0x20;
+        else
+            jdge->flag |= 0x20;
+        swrObjJdge_InitTrack(jdge, (swrScore*) subEvents[1]);
+        if (firstLocalPlayer == NULL)
+            jdge->flag |= 0x40;
+        else
+            jdge->flag &= ~0x40;
+        swrScene_SetObjectsLoaded();
+        jdge->flag = (jdge->flag & 0xfffffff4) | 4;
+        jdge->raceTimer_ms = 0.5f;
+        swrSprite_SetColor(-0x67, 0, 0, 0, 0xff);
+        swrObjJdge_postRaceHudState = 0;
+        swrSound_SelectPlanetIntroMusic(jdge->planetId);
+        swrObjJdge_UpdateViewportLayout(jdge, 2);
+        if (jdge->planetId == 3 && jdge->planet_track_number == 1)
+            swrPlayerHUD_lightStreakParam = 10000.0f;
+        if (swrRace_demoMode != 0)
+        {
+            swrObjJdge_demoHudCycleIndex++;
+            if (swrObjJdge_demoHudCycleIndex == 6)
+            {
+                swrObjJdge_demoHudCycleIndex = 1;
+                swrObjJdge_demoHudCycled = 1;
+            }
+            jdge->hud_mode = 4;
+            swrObjJdge_creditsScrollState = 0;
+        }
+        return 1;
+
+    case 'Load': // allocate-time reset of all per-race state
+        swrCam_CamState_InitMainMat4(1, 1, &jdge->unk64_mat, 0);
+        jdge->flag = 0;
+        jdge->raceTimer_ms = 0.0f;
+        jdge->unk30 = 0;
+        jdge->unk2c_spline = NULL;
+        jdge->unk64_mat.vA.x = 1.0f; jdge->unk64_mat.vA.y = 0.0f; jdge->unk64_mat.vA.z = 0.0f; jdge->unk64_mat.vA.w = 0.0f;
+        jdge->unk64_mat.vB.x = 0.0f; jdge->unk64_mat.vB.y = 1.0f; jdge->unk64_mat.vB.z = 0.0f; jdge->unk64_mat.vB.w = 0.0f;
+        jdge->unk64_mat.vC.x = 0.0f; jdge->unk64_mat.vC.y = 0.0f; jdge->unk64_mat.vC.z = 1.0f; jdge->unk64_mat.vC.w = 0.0f;
+        jdge->unk64_mat.vD.x = 0.0f; jdge->unk64_mat.vD.y = 0.0f; jdge->unk64_mat.vD.z = 0.0f; jdge->unk64_mat.vD.w = 1.0f;
+        for (int i = 0; i < 6; i++)
+            jdge->splineMarkers[i] = NULL;
+        jdge->unk28_model = NULL;
+        jdge->unk1d8 = 0;
+        jdge->unk1dc = 0;
+        jdge->unk12c = NULL;
+        jdge->unk134_mat.vD.x = 1.0f;
+        jdge->unk134_mat.vD.y = 0.0f;
+        jdge->unk134_mat.vD.z = 0.0f;
+        jdge->unk134_mat.vD.w = 0.0f;
+        jdge->unk174[0] = 0.0f; jdge->unk174[1] = 1.0f; jdge->unk174[2] = 0.0f; jdge->unk174[3] = 0.0f;
+        jdge->unk174[4] = 0.0f; jdge->unk174[5] = 0.0f; jdge->unk174[6] = 1.0f; jdge->unk174[7] = 0.0f;
+        jdge->unk174[8] = 0.0f; jdge->unk174[9] = 0.0f; jdge->unk174[10] = 0.0f;
+        jdge->unk1a0 = 1.0f;
+        jdge->cam_spline = NULL;
+        jdge->unk1a8 = 0;
+        jdge->unk1e0 = 0;
+        jdge->unk1e4 = 0.0f;
+        jdge->hud_mode = 2;
+        jdge->unk128[0] = 0; jdge->unk128[1] = 0; jdge->unk128[2] = 0; jdge->unk128[3] = 0;
+        // fall through: 'Load' and 'RSet' both re-sleep every Jdge entity
+    case 'RSet':
+    {
+        swr_noop2();
+        int ev[16];
+        ev[0] = 'Slep';
+        swrEvent_CallF4('Jdge', ev);
+        return 1;
+    }
+
+    case 'Join': // if we are the session host, broadcast the master-claim event
+        if ((jdge->flag & 0x10) != 0)
+        {
+            int ev[16];
+            ev[0] = 'Mstr';
+            swrEvent_Broadcast('Jdge', ev);
+        }
+        return 1;
+
+    case 'Mstr':
+        jdge->flag &= ~0x10;
+        return 1;
+
+    case 'Paws': // pause-menu result: abort or restart the race
+        if (subEvents[1] < 0)
+        {
+            if (subEvents[2] == 1)
+                swrObjJdge_Clear(jdge, 'Abrt');
+            else if (subEvents[2] == 2)
+                swrObjJdge_Clear(jdge, 'RStr');
+        }
+        return 1;
+
+    case 'Slep':
+        *((unsigned char*) &jdge->obj.flags + 1) |= 0x10;
+        return 1;
+
+    case 'Wake':
+        *((unsigned char*) &jdge->obj.flags + 1) &= ~0x10;
+        return 1;
+
+    case 'JAsn': // resolve a score's finish-time to its pod object, then forward the sub-event
+        *subEvents = 'NAsn';
+        for (int i = 0; i < jdge->num_players; i++)
+        {
+            if (swrScoresPtr[i].time_unk == (float) subEvents[2])
+            {
+                subEvents[2] = (int) swrScoresPtr[i].obj_test_ptr;
+                swrEvent_DispatchSubEvents((void*) subEvents[3], subEvents);
+                break;
+            }
+        }
+        return 1;
+
+    default:
+        return 0;
+    }
 }
 
 // 0x00463FF0

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -313,7 +313,7 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
         jdge->unk1b4_splineId = subEvents[5];
         jdge->cam_splineId = subEvents[6];
         jdge->planet_track_number = subEvents[7];
-        jdge->unk1cc_ms = (float) subEvents[8];
+        jdge->countdownTimer_ms = (float) subEvents[8];
         jdge->num_laps = subEvents[9];
         jdge->best_lap_time_ms = *(float*) (p3 + 0x28);
         jdge->recordLap3_ms = *(float*) (p3 + 0x2c);
@@ -324,7 +324,7 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
             GameSettingFlags &= ~0x4000;
         jdge->flag &= ~0x80;
         swrObjJdge_localRacerId = subEvents[0xe];
-        if (jdge->unk1cc_ms <= 0.0f)
+        if (jdge->countdownTimer_ms <= 0.0f)
             jdge->flag &= ~0x20;
         else
             jdge->flag |= 0x20;
@@ -356,21 +356,21 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
         return 1;
 
     case 'Load': // allocate-time reset of all per-race state
-        swrCam_CamState_InitMainMat4(1, 1, &jdge->unk64_mat, 0);
+        swrCam_CamState_InitMainMat4(1, 1, &jdge->camBaseMat, 0);
         jdge->flag = 0;
         jdge->raceTimer_ms = 0.0f;
         jdge->unk30 = 0;
         jdge->unk2c_spline = NULL;
-        jdge->unk64_mat.vA.x = 1.0f; jdge->unk64_mat.vA.y = 0.0f; jdge->unk64_mat.vA.z = 0.0f; jdge->unk64_mat.vA.w = 0.0f;
-        jdge->unk64_mat.vB.x = 0.0f; jdge->unk64_mat.vB.y = 1.0f; jdge->unk64_mat.vB.z = 0.0f; jdge->unk64_mat.vB.w = 0.0f;
-        jdge->unk64_mat.vC.x = 0.0f; jdge->unk64_mat.vC.y = 0.0f; jdge->unk64_mat.vC.z = 1.0f; jdge->unk64_mat.vC.w = 0.0f;
-        jdge->unk64_mat.vD.x = 0.0f; jdge->unk64_mat.vD.y = 0.0f; jdge->unk64_mat.vD.z = 0.0f; jdge->unk64_mat.vD.w = 1.0f;
+        jdge->camBaseMat.vA.x = 1.0f; jdge->camBaseMat.vA.y = 0.0f; jdge->camBaseMat.vA.z = 0.0f; jdge->camBaseMat.vA.w = 0.0f;
+        jdge->camBaseMat.vB.x = 0.0f; jdge->camBaseMat.vB.y = 1.0f; jdge->camBaseMat.vB.z = 0.0f; jdge->camBaseMat.vB.w = 0.0f;
+        jdge->camBaseMat.vC.x = 0.0f; jdge->camBaseMat.vC.y = 0.0f; jdge->camBaseMat.vC.z = 1.0f; jdge->camBaseMat.vC.w = 0.0f;
+        jdge->camBaseMat.vD.x = 0.0f; jdge->camBaseMat.vD.y = 0.0f; jdge->camBaseMat.vD.z = 0.0f; jdge->camBaseMat.vD.w = 1.0f;
         for (int i = 0; i < 6; i++)
             jdge->splineMarkers[i] = NULL;
         jdge->unk28_model = NULL;
         jdge->unk1d8 = 0;
         jdge->unk1dc = 0;
-        jdge->unk12c = NULL;
+        jdge->camSweepState = NULL;
         jdge->unk134_mat.vD.x = 1.0f;
         jdge->unk134_mat.vD.y = 0.0f;
         jdge->unk134_mat.vD.z = 0.0f;
@@ -442,6 +442,12 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
     default:
         return 0;
     }
+}
+
+// 0x0045dad0
+void swrObjJdge_UpdateViewportLayout(swrObjJdge* jdge, int mode)
+{
+    HANG("TODO");
 }
 
 // 0x00463FF0
@@ -809,6 +815,18 @@ void swrObjTrig_CreateAndActivateTriggerFromMultiplayerEvent(int trigger_index, 
 
 // 0x0047E830
 void swrObjTrig_SendMultiplayerTriggerEvent(swrModel_TriggerDescription* trigger_description, swrRace* player)
+{
+    HANG("TODO");
+}
+
+// 0x004804a0
+void swrScene_SetObjectsLoaded(void)
+{
+    HANG("TODO");
+}
+
+// 0x00428A60
+void swrCam_CamState_InitMainMat4(uint16_t index, uint16_t val1, rdMatrix44* mat, uint16_t val2)
 {
     HANG("TODO");
 }

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -52,6 +52,8 @@
 #define swrObjcMan_F4_ADDR (0x004543f0)
 #define swrObjScene_F0_ADDR (0x00454a10)
 #define swrObjScene_F4_ADDR (0x00454a30)
+// provisional swrScene_ namespace; grouped with the scene callbacks (addr 0x004804a0 is out of sort order)
+#define swrScene_SetObjectsLoaded_ADDR (0x004804a0)
 #define swrModel_clearSceneModelsAndChildren_ADDR (0x00454cc0)
 #define swrObjHang_InitSceneRootNode_ADDR (0x00454D10)
 #define swrObjHang_SetMenuState_ADDR (0x00454d40)
@@ -307,6 +309,8 @@ int swrObjcMan_F4(swrObjcMan* cman, int* subEvents, int p3);
 
 void swrObjScene_F0(swrObjScen* scene);
 int swrObjScene_F4(swrObjScen* scene, int* subEvents);
+// Sets the scene-objects-loaded flag; called by swrObjJdge_F4 at 'Begn'. (provisional swrScene_ namespace)
+void swrScene_SetObjectsLoaded(void);
 
 void swrObjHang_InitSceneRootNode();
 void swrObjHang_SetMenuState(swrObjHang* hang, swrObjHang_STATE state);

--- a/src/Swr/swrSound.c
+++ b/src/Swr/swrSound.c
@@ -803,3 +803,9 @@ unsigned int swrSound_GetHardwareFlags(void)
 {
     return Sound_A3Dinitted ? a3dCaps_hardware.dwFlags : 0;
 }
+
+// 0x00427ad0
+unsigned int swrSound_SelectPlanetIntroMusic(unsigned int planet)
+{
+    HANG("TODO");
+}

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -62,6 +62,7 @@
 // Streamed in-race / menu music controller (channel 7). See the grouped prototypes below.
 #define swrSound_SetMusicFade_ADDR (0x004277f0)
 #define swrSound_UpdateMusic_ADDR (0x00427880)
+#define swrSound_SelectPlanetIntroMusic_ADDR (0x00427ad0)
 #define swrSound_UpdateEngineAudio_ADDR (0x00427b20)
 #define swrSound_ResetMusic_ADDR (0x00427d70)
 #define swrSound_PreloadSoundSet_ADDR (0x00427d90)
@@ -205,6 +206,8 @@ void swrSound_SelectTrackMusic(int planet, int subtrack, int restore);
 void swrSound_UpdateMusic(void);
 void swrSound_SetMusicFade(int mode);
 void swrSound_ResetMusic(void);
+// Arm the per-planet intro music: sets the current music index from swrMusicPlanetIntroTable[planet].
+unsigned int swrSound_SelectPlanetIntroMusic(unsigned int planet);
 
 // Per-frame engine/surface SFX: select and play loop sounds keyed by speed.
 void swrSound_UpdateEngineAudio(int param1, int param2, float* param3);

--- a/src/types.h
+++ b/src/types.h
@@ -757,16 +757,16 @@ extern "C"
         struct swrSpline* unk2c_spline;
         int unk30;
         swrSplineCursor cursor; // 0x34 embedded spline walker (camera/AI path follow)
-        rdMatrix44 unk64_mat; // judge camera base transform (initialized at 'Load' via swrCam_CamState_InitMainMat4)
+        rdMatrix44 camBaseMat; // 0x64. judge camera base transform (reset to identity at 'Load' via swrCam_CamState_InitMainMat4)
         rdMatrix44 unk80_mat;
         rdMatrix44 unkbc_mat;
         int hud_mode; // 0x124. annodue: _hud_mode
         int event;
         char unk128[4];
-        void* unk12c; // post-race camera-sweep state (gates the F0 finish -> results transition)
-        rdMatrix44 unk134_mat;
+        void* camSweepState; // 0x12c. post-race camera-sweep state; while non-null F2 walks unk134_mat and F0 gates the finish -> results transition on it
+        rdMatrix44 unk134_mat; // 0x134. post-race fly-by transform, driven by swrSpline_EvaluateToMatrix only while camSweepState != NULL
         float unk174[11];
-        float unk1a0; // 0x1a0. initialized to 1.0 at 'Load'
+        float unk1a0; // 0x1a0. reset to 1.0 at 'Load'; purpose not yet identified (no reader found in the judge functions)
         void* cam_spline;
         int unk1a8;
         int planetId;
@@ -775,9 +775,9 @@ extern "C"
         SPLINEID cam_splineId;
         int num_players;
         int planet_track_number;
-        int unk1c4; // 0x1c4. set from the race-config sub-event at 'Begn'
+        int unk1c4; // 0x1c4. latched from race-config sub-event word 0xc at 'Begn'; purpose not yet identified
         int num_laps;
-        float unk1cc_ms; // 0x1cc. countdown duration from race config; sets flag bit 0x20 when positive
+        float countdownTimer_ms; // 0x1cc. pre-race countdown timer; loaded from race config and counted down in F0 state 1; sets flag bit 0x20 when positive
         float best_lap_time_ms; // 0x1d0. annodue: RecordLap1
         float recordLap3_ms; // 0x1d4. annodue: RecordLap3
         int unk1d8;

--- a/src/types.h
+++ b/src/types.h
@@ -745,23 +745,24 @@ extern "C"
     typedef struct swrObjJdge
     {
         swrObj obj;
-        int flag;
+        int flag; // low nibble (& 0xf) = swrObjJdge_F0 state-machine selector; 0x10 = multiplayer host;
+                  // 0x40 = no local player (spectate); 0x80 = post-race camera sweep active
         float raceTimer_ms;
         struct swrModel_Node* splineMarkers[6];
         struct swrModel_Node* unk28_model;
         struct swrSpline* unk2c_spline;
         int unk30;
         swrSplineCursor cursor; // 0x34 embedded spline walker (camera/AI path follow)
-        rdMatrix44 unk64_mat;
+        rdMatrix44 unk64_mat; // judge camera base transform (initialized at 'Load' via swrCam_CamState_InitMainMat4)
         rdMatrix44 unk80_mat;
         rdMatrix44 unkbc_mat;
         int hud_mode; // 0x124. annodue: _hud_mode
         int event;
         char unk128[4];
-        void* unk12c;
+        void* unk12c; // post-race camera-sweep state (gates the F0 finish -> results transition)
         rdMatrix44 unk134_mat;
         float unk174[11];
-        int unk1a0;
+        float unk1a0; // 0x1a0. initialized to 1.0 at 'Load'
         void* cam_spline;
         int unk1a8;
         int planetId;
@@ -770,9 +771,9 @@ extern "C"
         SPLINEID cam_splineId;
         int num_players;
         int planet_track_number;
-        char unk1c4[4];
+        int unk1c4; // 0x1c4. set from the race-config sub-event at 'Begn'
         int num_laps;
-        float unk1cc_ms;
+        float unk1cc_ms; // 0x1cc. countdown duration from race config; sets flag bit 0x20 when positive
         float best_lap_time_ms; // 0x1d0. annodue: RecordLap1
         float recordLap3_ms; // 0x1d4. annodue: RecordLap3
         int unk1d8;


### PR DESCRIPTION
Reimplements `swrObjJdge_F4`, the race judge's sub-event dispatcher, and types the bits of the struct it proves.

**`F4`** switches over 13 four-char sub-events: `Begn` (latch the race config -- players / planet / laps / lap records / spline + cam ids), `Load` (reset all per-race state), `Join`/`Mstr` (MP host claim), `Paws` (abort/restart from the pause menu), `Slep`/`Wake` (toggle the entity skip flag), `JAsn` (resolve a score's finish time to its pod object + forward), `RSet`. All 13 event-tag literals static-assert-match the original hex; compiles with the project flags (both `-Werror` gates).

**`types.h`** (layout-preserving, sizeof 0x1e8): `unk1a0` `int`->`float` (stores 1.0 at `Load`), `unk1c4` `char[4]`->`int` (race-config word at `Begn`); documented the `flag` bitfield + `unk64_mat`/`unk12c`/`unk1cc_ms`.

**Globals + helpers `F4` touches:**
- Carved + named `swrSound_SelectPlanetIntroMusic` (0x427ad0 -- arms the per-planet intro music) and `swrScene_SetObjectsLoaded` (0x4804a0); plus `swrEvent_Broadcast` (0x450be0).
- Race-state globals: `swrRace_demoMode`, `swrObjJdge_localRacerId` / `demoHudCycleIndex` / `demoHudCycled` / `creditsScrollState` / `postRaceHudState`, `swrControl_uiInputActive`, `swrPlayerHUD_lightStreakParam`.

**Confidence / flags:**
- High: `F4` control flow + dispatch (hex-verified), the calls to already-named functions, the two field-type fixes, `swrSound_SelectPlanetIntroMusic`.
- Medium (behavioral proposals -- happy to match your DB names): the race-state globals, `swrControl_uiInputActive`, `swrPlayerHUD_lightStreakParam`.
- `swrScene_` is a **provisional namespace** (the first `swrScene_` symbols in src -- open to `swrMain_`/`swrWorld_` if you prefer). `swrEvent_Broadcast`/`swrEvent_BroadcastFiltered` are **vestigial** (build the args then no-op via `swr_noop2` in the release build).