### PR TITLE
swrSpline: name the minimap track-point sampler + track-length getter

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -276,6 +276,8 @@ swrRace_DeathSpeedDrop 0x004c7bbc float = 140.0
 
 swrRace_FireTimer 0x004c7bc0 float = -1.0
 
+swrSpline_trackLength 0x004c7be0 float
+
 sithControl_secFPS 0x004c8174 float
 sithControl_msecFPS 0x004c8178 float
 

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -24,6 +24,7 @@
 // Graph traversal, post-load baking, and point projection (control points form
 // a directed graph keyed by a per-node "progress" band; baking assigns
 // arc-length progress and tessellates each segment).
+#define swrSpline_GetTrackLength_ADDR (0x0047e870)
 #define swrSpline_CursorInit_ADDR (0x0047e880)
 #define swrSpline_ProjectPoint_ADDR (0x0047eb60)
 #define swrSpline_ForEachSample_ADDR (0x0047ee20)
@@ -31,6 +32,7 @@
 #define swrSpline_BuildProgressTable_ADDR (0x0047f470)
 #define swrSpline_ResetNodeProgress_ADDR (0x0047f6c0)
 #define swrSpline_Build_ADDR (0x0047f6f0)
+#define swrSpline_CollectNearbyPoints_ADDR (0x00480170)
 
 void swrSpline_LoadSpline(int index, unsigned short** b);
 
@@ -92,5 +94,13 @@ void swrSpline_ResetNodeProgress(int nodeIndex);
 // Top level post-load processing (called by LoadTrackSpline): resets junction
 // nodes, builds the progress table, then tessellates.
 void swrSpline_Build(swrSpline* spline, int unk);
+
+// Returns the integrated track/spline length (swrSpline_trackLength, set by swrSpline_TraceProgress).
+float swrSpline_GetTrackLength(void);
+
+// Sample every spline segment near `center` (within +/- range on each axis), writing each hit as an
+// (x,y) offset from center into outPoints (up to maxPoints); `density` controls the sample spacing.
+// Returns the number of points found. Used to draw the track outline on the in-race minimap.
+int swrSpline_CollectNearbyPoints(swrSpline* spline, float* center, float range, int maxPoints, rdVector2* outPoints, float density);
 
 #endif // SWRSPLINE_H


### PR DESCRIPTION
Two swrSpline functions that surfaced while reversing the in-race minimap:

- `swrSpline_CollectNearbyPoints`@0x480170 — samples each spline segment near a center point and writes the hits as (x,y) offsets; used to draw the track outline on the minimap.
- `swrSpline_GetTrackLength`@0x47e870 — returns the integrated track length (`swrSpline_trackLength`@0x4c7be0, set by `swrSpline_TraceProgress`, read by the fire effects + the HUD gap-arrow scale).

Header decls + the one global; no body changes. Names match your DB (both were FUN_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)