### PR TITLE
swrSprite: name the screen dirty-rectangle list (vestigial)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -602,7 +602,7 @@ swrModel_Node1 0x0050ccf8 swrModel_Node*
 swrModel_Node2 0x0050ccfc swrModel_Node*
 swrModel_Node3 0x0050cd00 swrModel_Node*
 
-unk_counter 0x0050cd10 int
+swrSprite_dirtyRectCount 0x0050cd10 short
 
 debug_buffer 0x0050cd18 char[2048]
 
@@ -819,6 +819,8 @@ rdCache_aVertices 0x009630d0 rdVector3[]
 rdCache_aTexVertices 0x00a530d8 rdVector2[]
 
 swrViewport_array 0x00dfb040 swrViewport[4]
+
+swrSprite_dirtyRects 0x00E22720 short[124]
 
 backBufferClearColor 0x00E229A8 int16_t[3]
 

--- a/src/Swr/swrSprite.h
+++ b/src/Swr/swrSprite.h
@@ -91,6 +91,9 @@
 
 #define swrSprite_Draw1_ADDR (0x0044F670)
 
+#define swrSprite_AddDirtyRect_ADDR (0x00484020)
+#define swrSprite_ResetDirtyRects_ADDR (0x00484130)
+
 void swrSprite_SetCursorVisibility2(int visibility);
 
 bool swrSprite_IsCursorVisible(void);
@@ -179,6 +182,13 @@ void swrSprite_GetUIScale(float* out_xscale, float* out_yscale);
 
 int AddDotToMiniMap(char, short, short);
 void RenderMiniMapDotsAndCrosses();
+
+// Dirty-rectangle list: each drawn 2D overlay element registers its bounding box (expanded 1px,
+// clamped, scaled from the 320x240 virtual UI space to screen pixels) into a 31-entry table; the
+// count is reset each frame by swrPlayerHUD_RenderAllViewports. The partial-blit consumer that read
+// the list appears to be gone, so the accumulation is now effectively vestigial.
+void swrSprite_AddDirtyRect(short x1, short y1, short x2, short y2);
+void swrSprite_ResetDirtyRects(void);
 
 void swrSprite_Draw1(swrSpriteTexture*, short, int, float, float, float angle, short, short, int, float, unsigned __int8, float, unsigned __int8);
 


### PR DESCRIPTION
A small 2D-overlay primitive used across swrText/swrRace/swrObjJdge:

- `swrSprite_AddDirtyRect`@0x484020 — appends a screen-space rect (1px-expanded, clamped, scaled 320x240 → real pixels) to a 31-entry list (`swrSprite_dirtyRects`@0xe22720 / `swrSprite_dirtyRectCount`@0x50cd10).
- `swrSprite_ResetDirtyRects`@0x484130 — clears the count each frame from swrPlayerHUD_RenderAllViewports.

Classic dirty-rect accumulator, but nothing reads the list back any more — looks like the partial-blit path it fed is gone, so it's effectively dead. Named it + the globals (was `unk_counter`) and noted that. Header + globals only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)