### PR TITLE
swrMultiplayer: name SetNetworkTick + the networkTick global

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -362,6 +362,8 @@ time_buffer 0x004e9f20 char[256]
 
 multiplayer_isHost 0x004eb1c8 int
 
+swrMultiplayer_networkTick 0x004eb1e0 int
+
 g_objHang1 0x004eb21c swrObjHang*
 
 multiplayer_sync_timer_ms 0x004eb230 int

--- a/src/Swr/swrMultiplayer.h
+++ b/src/Swr/swrMultiplayer.h
@@ -76,6 +76,7 @@
 
 // Multiplayer menu UI: the host/join/race-setup screen builders + their helpers.
 #define swrMultiplayer_GetSessionName_ADDR (0x0041bd10)
+#define swrMultiplayer_SetNetworkTick_ADDR (0x0041bd50)
 #define swrMultiplayer_SetRacerListDisplay_ADDR (0x0041bd90)
 #define swrMultiplayer_ResetRaceSettings_ADDR (0x0041c260)
 #define swrMultiplayer_BroadcastRaceSettings_ADDR (0x0041c2a0)
@@ -273,6 +274,7 @@ int swrMultiplayer_PumpPackets(void);
 int swrMultiplayer_IsAvailable(void);                               // can a session start? gates the MP menu entry
 unsigned int swrMultiplayer_CreateSession(wchar_t* a1, wchar_t* a2, wchar_t* a3, char* a4, int a5);
 char* swrMultiplayer_GetSessionName(void);
+void swrMultiplayer_SetNetworkTick(int value); // sets swrMultiplayer_networkTick (read by UpdateNetworkTick/ApplyEvent)
 void swrMultiplayer_SetRacerListDisplay(int enabled, int x, int y); // toggle racer-list overlay + free slot cache
 void swrMultiplayer_FreeRacerSlot(int slot);
 void swrMultiplayer_ResetRaceSettings(void);                        // reset racer ids + track (Boonta) / laps (3)


### PR DESCRIPTION
`swrMultiplayer_SetNetworkTick`@0x41bd50 is the one-line setter for the network tick counter (`swrMultiplayer_networkTick`@0x4eb1e0, read by the tick-update + event-apply paths). Header decl + the global; no body changes.

Built clean (dinput.dll links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)