### PR TITLE
swrRace: reimplement AI opponent difficulty/pacing system

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -48,6 +48,9 @@ swrConfig_currentInputDeviceType 0x004b2030 swrConfig_DEVICE
 
 swrTextFmtString1 0x004b2304 char[4] = "%s\0\0"
 
+swrConfig_FORCE_ENABLED 0x004b2910 int
+swrControl_forceFeedbackAvailable 0x004b2914 int
+
 swrConfig_joystick_enabled 0x004b2944 int = 1
 swrConfig_keyboard_enabled 0x004b2948 int = 1
 joystick_detected 0x004b294c int = 1
@@ -84,6 +87,7 @@ swrUI_unk_ptr 0x004b5d74 swrUI_unk*
 Main_nut_delay_ms 0x004b6718 int = 32
 Main_hiRes_sound 0x004b6d14 int = 1
 Main_doppler_sound 0x004b6d18 int = 0
+Main_sound_reflections 0x004b6d1c int
 Main_sound 0x004b6d20 int = 1
 Main_sound_gain_adjust 0x004b6d24 float
 swrRace_voices_enabled 0x004b6d28 int = 1
@@ -258,7 +262,7 @@ drawDistance 0x004c4a5c float
 
 miniMapAlpha 0x004C5298 float
 
-ai_level 0x004c707c float
+# ai_level removed: duplicate of swrRace_AILevel at 0x004c707c (canonically a float)
 ai_spread 0x004c7080 float
 
 Main_sound_3dimpact 0x004c7aa8 int = -1
@@ -269,7 +273,7 @@ Main_sound_rolloff 0x004c7d78 float = 0.15
 Main_sound_gain 0x004c7d7c float = 1.0
 Sound_A3Dinitted 0x004c7d80 int = 1
 
-swrRace_AILevel 0x004c707c int
+swrRace_AILevel 0x004c707c float
 
 swrRace_DeathSpeedMin 0x004c7bb8 float = 325.00
 swrRace_DeathSpeedDrop 0x004c7bbc float = 140.0
@@ -399,6 +403,7 @@ swrSound_Initted 0x004eb450 int
 
 swrSound_Ready 0x004eb458 int
 swrRace_music_enabled 0x004eb45c int
+Main_sound_reverb 0x004eb460 int
 
 swrSoundHashTable 0x004eb464 tHashTable*
 
@@ -1289,3 +1294,14 @@ swrWeather_particleStates 0x00e9a960 char[80]
 # left for a follow-up (their exact element struct / count want more verification).
 swrPlanetTable 0x00e98f40 swrPlanetInfo[8]
 swrPlanetHoloModelNodes 0x00e299f4 void*[8]
+
+# AI difficulty / pacing globals (see swrRace_AI, InitAISettingsForTrack).
+# ai_track_script: per-signature-track scripted-AI selector (1..6, -1 = none); read by swrRace_AutopilotSteer / swrRace_UpdatePlayerControl.
+ai_track_script 0x004c7084 int
+# track_spline_variant: per-track spline path variant masking nearby control-point ranges; read by swrSpline_CollectNearbyPoints.
+track_spline_variant 0x0050cb58 int
+# ai_rank_speed_factor: rank->speed coupling for the simplified pacing path in swrRace_AI; unused in the shipped game (no writer, always 0).
+ai_rank_speed_factor 0x0050cae0 float
+
+# Total spline length of the active track; cached by swrSpline_TraceProgress, read by swrSpline_GetTrackLength.
+swrSpline_trackLength 0x004c7be0 float

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -262,7 +262,6 @@ drawDistance 0x004c4a5c float
 
 miniMapAlpha 0x004C5298 float
 
-# ai_level removed: duplicate of swrRace_AILevel at 0x004c707c (canonically a float)
 ai_spread 0x004c7080 float
 
 Main_sound_3dimpact 0x004c7aa8 int = -1

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -350,10 +350,76 @@ void InitPrimaryLight()
     HANG("TODO");
 }
 
+// Seeds the global AI tuning for the track that is about to start. Picks a base
+// level and spread from a hard-coded per-(planet, track) table, scales the level by
+// the AI Speed menu setting (+/-10%), and arms the scripted-AI / spline-variant
+// selectors used on a handful of signature tracks. Consumed each frame by swrRace_AI.
 // 0x004667E0
-void InitAISettingsForTrack(swrObjJdge*)
+void InitAISettingsForTrack(swrObjJdge* judge)
 {
-    HANG("TODO");
+    // 8 planets x 4 tracks, each a (base level, spread) pair. Built on the stack just
+    // as the original does; empty track slots are 0,0. The base level is later * 0.1.
+    float aiTable[64] = {
+        8.64f,     20.0f, 11.2f,     38.0f, 0.0f,      0.0f,  0.0f,      0.0f,  // planet 0
+        8.784f,    35.0f, 9.700001f, 38.0f, 10.8f,     38.0f, 11.35f,    32.0f, // planet 1
+        8.775f,    26.0f, 9.700001f, 35.0f, 9.991f,    40.0f, 0.0f,      0.0f,  // planet 2
+        9.9328f,   36.0f, 10.85f,    35.0f, 10.3f,     35.0f, 0.0f,      0.0f,  // planet 3
+        10.0395f,  37.0f, 10.0f,     34.0f, 10.05f,    35.0f, 10.45f,    27.0f, // planet 4
+        8.459999f, 23.0f, 9.224999f, 40.0f, 9.700001f, 35.0f, 0.0f,      0.0f,  // planet 5
+        8.801999f, 25.0f, 10.4f,     30.0f, 10.6f,     33.0f, 0.0f,      0.0f,  // planet 6
+        8.865f,    32.0f, 9.9425f,   30.0f, 10.1f,     33.0f, 0.0f,      0.0f,  // planet 7
+    };
+    int idx = (judge->planet_track_number + judge->planetId * 4) * 2;
+
+    ai_track_script = -1;
+    track_spline_variant = 0;
+
+    swrRace_AILevel = aiTable[idx] * 0.1f;
+    ai_spread = aiTable[idx + 1];
+
+    // A few signature tracks run scripted AI behaviour (see swrRace_AutopilotSteer)
+    // and use an alternate spline path variant.
+    if (judge->planetId == 1 && judge->planet_track_number != 3) {
+        ai_track_script = 1;
+        track_spline_variant = (judge->planet_track_number == 0);
+        if (judge->planet_track_number == 1) {
+            track_spline_variant = 2;
+        }
+        if (judge->planet_track_number == 2) {
+            track_spline_variant = 3;
+        }
+    }
+    if (judge->planetId == 3) {
+        if (judge->planet_track_number == 1) {
+            ai_track_script = 6;
+        }
+        if (judge->planet_track_number == 2) {
+            ai_track_script = 5;
+        }
+    }
+    if (judge->planetId == 4 && judge->planet_track_number != 3) {
+        if (judge->planet_track_number == 0) {
+            ai_track_script = 2;
+        }
+        if (judge->planet_track_number == 1) {
+            ai_track_script = 3;
+        }
+        if (judge->planet_track_number == 2) {
+            ai_track_script = 4;
+        }
+    }
+
+    // AI Speed menu setting (Slow / Average / Fast -> -1 / 0 / 1) scales the whole field.
+    if (judge->aiSpeedSetting == -1) {
+        swrRace_AILevel *= 0.9f;
+    } else if (judge->aiSpeedSetting == 1) {
+        swrRace_AILevel *= 1.1f;
+    }
+
+    // Reverse-track / special-event override: fixed spread.
+    if ((judge->flag & 0x20) != 0) {
+        ai_spread = 2.0f;
+    }
 }
 
 // 0x00466BD0

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -2,10 +2,12 @@
 
 #include "swrObj.h"
 #include "swrEvent.h"
+#include "swrSpline.h"
 #include "macros.h"
 #include "globals.h"
 
 #include <General/stdMath.h>
+#include <General/utils.h>
 #include <Primitives/rdVector.h>
 
 // 0x00401340
@@ -842,10 +844,146 @@ void swrRace_Tilt(swrRace* player, float b)
     }
 }
 
+// Per-frame "brain" for one AI racer. It never touches the flight model directly;
+// it only computes a per-racer speed multiplier (aiSpeedTarget, smoothed into
+// multiplayerStats) and a cross-track steer target (aiSteerTarget). The smoothed
+// multiplier is copied into speedMultiplier by swrRace_UpdateCatchup and scales the
+// pod in swrRace_UpdateSpeed. The two tuning inputs are the globals swrRace_AILevel
+// (track base level * AI Speed setting) and ai_spread, both set in InitAISettingsForTrack.
 // 0x0046b670
 void swrRace_AI(int player)
 {
-    // TODO
+    swrRace* p = (swrRace*) player;
+
+    // Start from the track/difficulty-wide base level.
+    p->aiSpeedTarget = swrRace_AILevel;
+
+    if ((p->flags1 & 0x2000000) != 0) {
+        // Finished / parked: coast at a fixed 0.65x and bleed off the parking timer.
+        p->aiSpeedTarget = 0.65f;
+        p->podStats.turnResponse = 1500.0f;
+        p->podStats.maxTurnRate = 400.0f;
+        if (p->unk108 <= 5625.0f) {
+            p->unk108 = 5625.0f;
+        } else {
+            p->unk108 -= (float) (swrRace_deltaTimeSecs * 100.0);
+        }
+    } else {
+        // Normalize the tuning by track length so the feel is consistent across courses.
+        float invTrackLen = 500000.0f / swrSpline_GetTrackLength();
+        float spreadScaled = ai_spread * 0.0001f;
+        float spreadBand = spreadScaled * invTrackLen;
+
+        if ((p->flags0 & 0x100) != 0) {
+            // Locked control (e.g. pre-start): no steering, pick a coarse pace.
+            p->aiSteerTarget = 0.0f;
+            if ((short) p->score_ptr->results_P1_Position == 1) {
+                p->aiSpeedTarget *= 1.06f;
+            } else if (spreadBand * 3.0f < p->unk130) {
+                p->aiSpeedTarget *= 1.4f;
+            } else {
+                p->aiSpeedTarget *= 1.1f;
+            }
+        } else if ((short) p->score_ptr->results_P1_Position == 1) {
+            // Not racing for this slot: freeze steering, leave the target at base.
+            p->aiSteerTarget = 0.0f;
+        } else {
+            // Tick the decision timer; on expiry reroll the interval and nudge the
+            // target finishing position by +/-1, kept within +/-2 of the baseline.
+            p->aiDecisionTimer -= (float) swrRace_deltaTimeSecs;
+            if (p->aiDecisionTimer < 0.0f) {
+                // rand() * 2^-31 gives [0,1); next reroll in ~8..18 seconds.
+                p->aiDecisionTimer = (float) swrUtils_Rand() * 4.6566129e-10f * 10.0f + 8.0f;
+
+                float r = (float) swrUtils_Rand() * 4.6566129e-10f;
+                if (r < 0.15f) {
+                    int newRank = p->aiRankTarget - 1; // try to move up a place
+                    p->aiRankTarget = newRank;
+                    if (newRank < 2 || newRank - p->aiRankBaseline > 2 || p->aiRankBaseline - newRank > 2) {
+                        p->aiRankTarget = newRank + 1; // out of band: revert
+                    }
+                } else if (0.85f < r) {
+                    int newRank = p->aiRankTarget + 1; // try to drop back a place
+                    p->aiRankTarget = newRank;
+                    if (newRank - p->aiRankBaseline > 2 || p->aiRankBaseline - newRank > 2) {
+                        p->aiRankTarget = newRank - 1; // out of band: revert
+                    }
+                }
+            }
+
+            if (0.0f < ai_rank_speed_factor) {
+                // Simplified rank-only pacing. Disabled in the shipped game:
+                // ai_rank_speed_factor has no writer and stays 0.
+                float base = p->aiSpeedTarget * 1.06f;
+                p->aiSpeedTarget =
+                    (1.0f - ((float) p->aiRankTarget - 1.0f) * ai_rank_speed_factor) * base;
+            } else {
+                // Full model: a cross-track steer target, plus a speed target derived
+                // from the gap to the racing line, the target rank, and the spread band.
+                float steer = (((float) p->aiRankTarget - 1.0f) * spreadScaled - 0.0008f) * invTrackLen;
+                p->aiSteerTarget = steer;
+
+                float v;
+                if (spreadBand * 0.25f < p->unk12c && (p->flags0 & 0x18000) != 0) {
+                    float gap = (p->flags0 & 0x8000) != 0 ? p->unk130 : p->unk134;
+                    v = (0.0f < gap) ? gap * 10.3f : gap * 10.02f;
+                } else {
+                    v = (p->unk12c - steer) * 10.0f;
+                }
+
+                float target = (v * 40.0f) / invTrackLen + 1.045f;
+                if (1.6f < target) {
+                    target = 1.6f;
+                }
+                if (target < 0.5f) {
+                    target = 0.5f;
+                }
+                p->aiSpeedTarget = target;
+            }
+        }
+    }
+
+    // Slew the applied multiplier toward the target at 0.2/sec, never overshooting.
+    if (p->multiplayerStats < p->aiSpeedTarget) {
+        p->multiplayerStats += (float) (swrRace_deltaTimeSecs * 0.2);
+        if (p->aiSpeedTarget < p->multiplayerStats) {
+            p->multiplayerStats = p->aiSpeedTarget;
+        }
+    } else if (p->aiSpeedTarget < p->multiplayerStats) {
+        p->multiplayerStats -= (float) (swrRace_deltaTimeSecs * 0.2);
+        if (p->aiSpeedTarget > p->multiplayerStats) {
+            p->multiplayerStats = p->aiSpeedTarget;
+        }
+    }
+}
+
+// Picks the speed multiplier source for one racer and commits it to speedMultiplier.
+// AI racers (flags0 0x80) defer to swrRace_AI. 'Locl' splitscreen humans (flags0 0x20)
+// with an active catchup field get a distance-based boost (capped at 1.25x); everyone
+// else holds a neutral 1.0x.
+// 0x0046ce30
+void swrRace_UpdateCatchup(swrRace* player)
+{
+    swrScore* score = player->score_ptr;
+
+    if ((player->flags0 & 0x20) == 0 || *(int*) &score->unkc == 0) {
+        if ((player->flags0 & 0x80) != 0) {
+            swrRace_AI((int) player);
+        } else {
+            player->multiplayerStats = 1.0f;
+        }
+    } else {
+        player->multiplayerStats = 1.0f;
+        if (1 < NumLocalPlayers() && 0.0f < player->unk130) {
+            float invTrackLen = 500000.0f / swrSpline_GetTrackLength();
+            float boost = (player->unk130 * 100.0f) / invTrackLen + 1.0f;
+            player->multiplayerStats = boost;
+            if (1.25f < boost) {
+                player->multiplayerStats = 1.25f;
+            }
+        }
+    }
+    player->speedMultiplier = player->multiplayerStats;
 }
 
 // 0x00474cd0

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -879,7 +879,7 @@ void swrRace_AI(int player)
             p->aiSteerTarget = 0.0f;
             if ((short) p->score_ptr->results_P1_Position == 1) {
                 p->aiSpeedTarget *= 1.06f;
-            } else if (spreadBand * 3.0f < p->unk130) {
+            } else if (spreadBand * 3.0f < p->rivalGapAhead) {
                 p->aiSpeedTarget *= 1.4f;
             } else {
                 p->aiSpeedTarget *= 1.1f;
@@ -924,11 +924,11 @@ void swrRace_AI(int player)
                 p->aiSteerTarget = steer;
 
                 float v;
-                if (spreadBand * 0.25f < p->unk12c && (p->flags0 & 0x18000) != 0) {
-                    float gap = (p->flags0 & 0x8000) != 0 ? p->unk130 : p->unk134;
+                if (spreadBand * 0.25f < p->aiLineOffset && (p->flags0 & 0x18000) != 0) {
+                    float gap = (p->flags0 & 0x8000) != 0 ? p->rivalGapAhead : p->rivalGapBehind;
                     v = (0.0f < gap) ? gap * 10.3f : gap * 10.02f;
                 } else {
-                    v = (p->unk12c - steer) * 10.0f;
+                    v = (p->aiLineOffset - steer) * 10.0f;
                 }
 
                 float target = (v * 40.0f) / invTrackLen + 1.045f;
@@ -974,9 +974,9 @@ void swrRace_UpdateCatchup(swrRace* player)
         }
     } else {
         player->multiplayerStats = 1.0f;
-        if (1 < NumLocalPlayers() && 0.0f < player->unk130) {
+        if (1 < NumLocalPlayers() && 0.0f < player->rivalGapAhead) {
             float invTrackLen = 500000.0f / swrSpline_GetTrackLength();
-            float boost = (player->unk130 * 100.0f) / invTrackLen + 1.0f;
+            float boost = (player->rivalGapAhead * 100.0f) / invTrackLen + 1.0f;
             player->multiplayerStats = boost;
             if (1.25f < boost) {
                 player->multiplayerStats = 1.25f;

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -4,6 +4,7 @@
 #include "types_enums.h"
 #include "macros.h"
 #include "swrAssetBuffer.h"
+#include "globals.h"
 
 // 0x00446fc0
 void swrSpline_LoadSpline(int index, unsigned short** b)
@@ -75,4 +76,11 @@ char* swrSpline_LoadSplineById(char* splineBuffer)
 {
     swrSpline_LoadSpline((int)splineBuffer, (unsigned short**)&splineBuffer);
     return splineBuffer;
+}
+
+// Active track's total spline length, cached by swrSpline_TraceProgress during bake.
+// 0x0047e870
+float swrSpline_GetTrackLength(void)
+{
+    return swrSpline_trackLength;
 }

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -24,6 +24,7 @@
 // Graph traversal, post-load baking, and point projection (control points form
 // a directed graph keyed by a per-node "progress" band; baking assigns
 // arc-length progress and tessellates each segment).
+#define swrSpline_GetTrackLength_ADDR (0x0047e870)
 #define swrSpline_CursorInit_ADDR (0x0047e880)
 #define swrSpline_ProjectPoint_ADDR (0x0047eb60)
 #define swrSpline_ForEachSample_ADDR (0x0047ee20)
@@ -66,6 +67,9 @@ void swrSpline_EvaluateAtOffset(void* cursor, rdMatrix44* out, float t);
 
 // Seed the cursor to nodeIndex and fill its 4 level lookahead chain.
 void swrSpline_CursorSeek(void* cursor, int nodeIndex);
+
+// Return the active track's total spline length (cached in a global during bake).
+float swrSpline_GetTrackLength(void);
 
 // Initialize a cursor for spline (zeroes it then seeks to the start). Returns
 // the cursor.

--- a/src/types.h
+++ b/src/types.h
@@ -460,10 +460,10 @@ extern "C"
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
         rdVector4 unk118_vec;
         int unk128;
-        int unk12c;
-        int unk130;
-        int unk134;
-        int unk138;
+        float unk12c;        // 0x12c. AI pacing: lateral offset from the racing line
+        float unk130;        // 0x130. AI / splitscreen catchup: signed progress gap
+        float unk134;        // 0x134. AI pacing: secondary gap term
+        float aiSteerTarget; // 0x138. AI cross-track steer target (written by swrRace_AI)
         struct swrModel_Node* model_unk; // 0x13c. Collision related ?
         struct swrModel_Node* terrainModel;
         rdVector3 unk144;
@@ -505,11 +505,11 @@ extern "C"
         float unk10_1; // 0x220
         float unk10_2; // 0x224
         int unk10_3; // 0x228
-        float multiplayerStats; // 0x22c.
-        float unk230;
-        float unk234;
-        float unk238;
-        float unk23c;
+        float multiplayerStats; // 0x22c. Applied speed multiplier this frame; for AI, the smoothed value swrRace_AI ramps toward aiSpeedTarget
+        float aiSpeedTarget;    // 0x230. AI target speed multiplier (base swrRace_AILevel, modulated by rank/spread)
+        float aiDecisionTimer;  // 0x234. AI countdown to the next target-rank reroll
+        int aiRankBaseline;     // 0x238. AI assigned finishing position
+        int aiRankTarget;       // 0x23c. AI current target position (random-walks within +/-2 of aiRankBaseline)
         float iceTractionMultiplier; // 0x240
         float terrainTractionMultiplier; // 0x244
         float terrainSkidModifier; // 0x248
@@ -770,7 +770,7 @@ extern "C"
         SPLINEID cam_splineId;
         int num_players;
         int planet_track_number;
-        char unk1c4[4];
+        int aiSpeedSetting; // 0x1c4. AI Speed menu setting: -1 Slow / 0 Average / 1 Fast (scales swrRace_AILevel)
         int num_laps;
         float unk1cc_ms;
         float best_lap_time_ms; // 0x1d0. annodue: RecordLap1

--- a/src/types.h
+++ b/src/types.h
@@ -460,9 +460,9 @@ extern "C"
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
         rdVector4 unk118_vec;
         int unk128;
-        float unk12c;        // 0x12c. AI pacing: lateral offset from the racing line
-        float unk130;        // 0x130. AI / splitscreen catchup: signed progress gap
-        float unk134;        // 0x134. AI pacing: secondary gap term
+        float aiLineOffset;  // 0x12c. AI lateral offset from the racing line (also a HUD rival-gap slot)
+        float rivalGapAhead; // 0x130. signed progress gap to the rival ahead (AI rubber-band + splitscreen catchup)
+        float rivalGapBehind;// 0x134. signed progress gap to the rival behind
         float aiSteerTarget; // 0x138. AI cross-track steer target (written by swrRace_AI)
         struct swrModel_Node* model_unk; // 0x13c. Collision related ?
         struct swrModel_Node* terrainModel;


### PR DESCRIPTION
Reverse-engineers and reimplements the AI opponent speed/spread system — how the AILevel multiplier, `ai_spread`, and the AI Speed menu setting actually drive opponent pacing.

Functions (reverse-hooked, dormant):
- `swrRace_AI` (0x46b670) — per-frame pacing: a speed multiplier, a target-rank rubber-band, and a cross-track steer target.
- `InitAISettingsForTrack` (0x4667e0) — per-(planet, track) AILevel/spread table, then the AI Speed setting (Slow/Average/Fast -> x0.9 / x1.0 / x1.1).
- `swrRace_UpdateCatchup` (0x46ce30) — dispatch between AI pacing, splitscreen distance-catchup, and a neutral 1.0x.
- `swrSpline_GetTrackLength` (0x47e870) — trivial accessor the AI code calls (reimplemented so it links).

Also names a few previously-unknown globals (`ai_track_script`, `track_spline_variant`, `ai_rank_speed_factor`, `swrSpline_trackLength`), removes the duplicate `ai_level` at 0x4c707c (kept as `swrRace_AILevel`, corrected to float), and documents the swrRace AI fields + `swrObjJdge.aiSpeedSetting` in types.h.

Builds clean (full `dinput.dll` links, all 4 reverse-hooks register), names match the Ghidra DB, K&R braces per the new style guide. Left `swrRace_AutopilotSteer`/`swrRace_UpdatePlayerControl` for a follow-up (FPU-stack decompiler artifacts need assembly-level work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)