### PR TITLE
swrRace: pod-stat display + engine-damage helpers

### DIFF
--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -184,8 +184,11 @@ float swrRace_InitUnk(int a, float b, float c, int* d)
 
 // TODO: look at 0x0045cf60
 
+// Convert a pod's raw handling stats into the normalized 0..1 garage display bars
+// (consumed by swrRace_VehicleStatisticsSubMenu and swrObjHang_ComputeUpgradedStats).
+// Display only: the flight model reads the raw podStats directly, never this output.
 // 0x00449330
-void swrRace_ApplyStatsMultipliers(PodHandlingData* out_stats, PodHandlingData* stats)
+void swrRace_ComputeStatBars(PodHandlingData* out_stats, PodHandlingData* stats)
 {
     int i;
     float tmp;
@@ -848,10 +851,34 @@ void swrRace_AI(int player)
     // TODO
 }
 
+// Accumulate collision/scrape damage into engine part `engineIndex`. The hit magnitude
+// is scaled by podStats.damageImmunity (really a damage *multiplier*: higher = more
+// fragile), capped at 1.0 (fully destroyed), recorded as that part's worst damage, and
+// added to totalDamage. No-op while invincible, spun out (flags0 0x6000), or finished
+// (flags1 0x2000000).
 // 0x00474cd0
-void swrRace_TakeDamage(int player, int a, float b)
+void swrRace_TakeDamage(int player, int engineIndex, float amount)
 {
-    // TODO
+    swrRace* p = (swrRace*) player;
+
+    if (swrRace_IsInvincible != 0) {
+        return;
+    }
+    if ((p->flags0 & 0x6000) != 0 || (p->flags1 & 0x2000000) != 0) {
+        return;
+    }
+
+    p->flags0 &= 0xff7fffff; // taking damage cancels an active boost
+    float health = p->podStats.damageImmunity * amount + p->engineHealth[engineIndex];
+    p->engineHealth[engineIndex] = health;
+    if (1.0f < health) {
+        p->engineHealth[engineIndex] = 1.0f;
+    }
+    p->engineStatus[engineIndex] |= 1;
+    if (p->engineHealthMin[engineIndex] < p->engineHealth[engineIndex]) {
+        p->engineHealthMin[engineIndex] = p->engineHealth[engineIndex];
+    }
+    p->totalDamage += amount;
 }
 
 // 0x00476AC0

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -806,6 +806,39 @@ void swrRace_InRaceEndStatistics(void* param_1, void* param_2)
     HANG("TODO");
 }
 
+// Bitmask of which engine sides have damaged/disabled parts (status bits 0x14):
+// 0x1 = a left engine (parts 0..2), 0x2 = a right engine (parts 3..5).
+// 0x0046a9c0
+unsigned int swrRace_GetDamagedEngineSides(swrRace* player)
+{
+    unsigned int sides = 0;
+    for (int i = 0; i < 6; i++) {
+        if ((player->engineStatus[i] & 0x14) != 0) {
+            sides |= (i < 3) ? 1 : 2;
+        }
+    }
+    return sides;
+}
+
+// Handling bias from asymmetric engine damage: each badly damaged engine (health > 0.8)
+// shifts the result by -0.33 (left, parts 0..2) or +0.33 (right, parts 3..5), so a
+// lopsidedly damaged pod pulls to one side.
+// 0x0046a9f0
+float swrRace_GetEngineDamagePenalty(swrRace* player)
+{
+    float penalty = 0.0f;
+    for (int i = 0; i < 6; i++) {
+        if (0.8f < player->engineHealth[i]) {
+            if (i < 3) {
+                penalty -= 0.33f;
+            } else {
+                penalty += 0.33f;
+            }
+        }
+    }
+    return penalty;
+}
+
 // 0x0046ab10
 void swrRace_Repair(swrRace* player)
 {

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -56,7 +56,7 @@
 
 #define swrRace_InitUnk_ADDR (0x00444d10)
 
-#define swrRace_ApplyStatsMultipliers_ADDR (0x00449330)
+#define swrRace_ComputeStatBars_ADDR (0x00449330)
 
 #define swrRace_ApplyUpgradesToStats_ADDR (0x00449d00)
 
@@ -252,7 +252,7 @@ void swrRace_BuyPitdroidsMenu(swrObjHang* hang);
 
 float swrRace_InitUnk(int a, float b, float c, int* d);
 
-void swrRace_ApplyStatsMultipliers(PodHandlingData* out_stats, PodHandlingData* stats);
+void swrRace_ComputeStatBars(PodHandlingData* out_stats, PodHandlingData* stats);
 
 void swrRace_ApplyUpgradesToStats(PodHandlingData* pActiveStats, PodHandlingData* pBaseStats, char* pUpgradeLevels, char* pUpgradeHealths);
 
@@ -279,7 +279,7 @@ void swrRace_Tilt(swrRace* player, float b);
 
 void swrRace_AI(int player);
 
-void swrRace_TakeDamage(int player, int a, float b);
+void swrRace_TakeDamage(int player, int engineIndex, float amount);
 
 void swrRace_ActivateTriggersInRange(swrRace* a, swrModel_TriggerDescription* a2);
 void swrRace_UpdateSurfaceTag(swrRace* test);

--- a/src/types.h
+++ b/src/types.h
@@ -402,23 +402,27 @@ extern "C"
         rdVector3 yaw_roll_pitch;
     } swrTranslationRotation;
 
+    // Per-pod handling stats. These are the RAW physics values the flight model reads
+    // directly; swrRace_ComputeStatBars converts them into the 0..1 garage display bars.
+    // 7 fields are player-upgradeable in the parts shop (swrRace_CalculateUpgradedStat
+    // categories 0..6, tagged below); the rest are fixed per pod.
     typedef struct PodHandlingData
     {
-        float antiSkid;
-        float turnResponse;
-        float maxTurnRate;
-        float acceleration;
-        float maxSpeed;
-        float airBrakeInv;
-        float deceleration_interval;
-        float boost_thrust;
-        float heatRate;
-        float coolRate;
-        float hoverHeight;
-        float repairRate;
-        float bumpMass;
-        float damageImmunity;
-        float intersectRadius;
+        float antiSkid;              // upgrade 0 (Traction): turn grip, higher = less skid
+        float turnResponse;          // upgrade 1 (Turning): how fast turn rate ramps to target
+        float maxTurnRate;           // turn rate cap
+        float acceleration;          // upgrade 2 (Acceleration): speed-curve denom, LOWER = quicker
+        float maxSpeed;              // upgrade 3 (Top Speed): asymptotic top speed
+        float airBrakeInv;           // upgrade 4 (Air Brake): brake decay, LOWER = stronger brake
+        float deceleration_interval; // off-throttle coast deceleration
+        float boost_thrust;          // boost power
+        float heatRate;              // engineTemp drain rate while boosting (higher = overheats sooner)
+        float coolRate;              // upgrade 5 (Cooling): engineTemp recovery rate
+        float hoverHeight;           // ride height off the track
+        float repairRate;            // upgrade 6 (Repair): pit-droid heal speed
+        float bumpMass;              // pod-vs-pod collision mass (heavier resists knockback)
+        float damageImmunity;        // damage MULTIPLIER, higher = more fragile (see swrRace_TakeDamage)
+        float intersectRadius;       // collision radius; entity copy is hardcoded to 2.0 in swrRace_Init
     } PodHandlingData; // sizeof(0x3c) == 0xf floats OK
 
     // Used to do the C-style "Inheritance" for different game objects


### PR DESCRIPTION
A cluster of small swrRace reimpls around pod stats and engine damage:

- `swrRace_TakeDamage` (0x474cd0): apply per-engine collision/scrape damage, scaled by `podStats.damageImmunity` (really a damage *multiplier* - higher = more fragile), capped at 1.0.
- `swrRace_GetDamagedEngineSides` (0x46a9c0) / `swrRace_GetEngineDamagePenalty` (0x46a9f0): the read side - which engine sides are damaged, and the handling pull from asymmetric damage.
- Renamed `swrRace_ApplyStatsMultipliers` -> `swrRace_ComputeStatBars` (0x449330): it builds the 0..1 garage stat bars (read only by `VehicleStatisticsSubMenu` / `ComputeUpgradedStats`), not physics multipliers - the flight model reads the raw `podStats` directly. Renamed in my Ghidra DB too; easy to revert the name if you'd rather keep the old one.
- Documented every `PodHandlingData` field's gameplay role in types.h, tagging the 7 parts-shop upgrades and the `damageImmunity` / `intersectRadius` gotchas.

Builds clean (full dll links), reverse-hooks register. New bodies are K&R; the `ComputeStatBars` body is the pre-existing Allman reimpl, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)