### PR TITLE
swrRace: reimplement the pod orientation / surface / ground-contact pipeline

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -832,6 +832,21 @@ swrRace_deltaTimeSecs 0x00e22a40 double
 
 swrRace_dt_raw_d 0x00e22a48 double
 
+swrRace_slopeAngle 0x00e2712c float
+
+swrRace_collisionHitNode 0x0050c5d0 swrModel_Node*
+
+swrModel_collisionUnk250 0x00e98250 int
+swrModel_collisionResultNode 0x00e98254 swrModel_Node*
+swrModel_collisionResultDist 0x00e98258 float
+swrModel_collisionHitNormal 0x00e98290 rdVector3
+swrModel_collisionUnkE1c 0x00e98e1c int
+swrModel_collisionRayOrigin 0x00e98e40 rdVector3
+swrModel_collisionRayDir 0x00e98e4c rdVector3
+swrModel_collisionRayMaxDist 0x00e98e58 float
+swrModel_collisionHitPoint 0x00e98e60 rdVector3
+swrModel_collisionUnkE70 0x00e98e70 int
+
 swrRace_fdeltaTimeSecs 0x00e22a50 float
 
 spline_progress_values 0x00E22A60 rdVector2[500]

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -1464,3 +1464,27 @@ void swrModel_LoadPuppet(MODELID model, INGAME_MODELID index, int a3, float a4)
 {
     HANG("TODO");
 }
+
+// 0x00442720
+void swrModel_MeshCollisionFaceCallbackIndexed(swrModel_CollisionVertex* vertices, int16_t primitive_type, uint16_t* indices)
+{
+    HANG("TODO");
+}
+
+// 0x00442C30
+void swrModel_MeshCollisionFaceCallback(swrModel_CollisionVertex* vertices, int16_t primitive_type)
+{
+    HANG("TODO");
+}
+
+// 0x00444bf0
+void swrModel_CollideNodeRecursiveRay(swrModel_NodeTransformed* node, void* query, unsigned int flags)
+{
+    HANG("TODO");
+}
+
+// 0x00444f10
+float swrModel_CollideRayWithMesh(swrModel_Mesh* mesh, float* ray, float* outPoint, float* outNormal)
+{
+    HANG("TODO");
+}

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1,12 +1,15 @@
 #include "swrRace.h"
 
 #include "swrObj.h"
+#include "swrModel.h"
+#include "swrSpline.h"
 #include "swrEvent.h"
 #include "macros.h"
 #include "globals.h"
 
 #include <General/stdMath.h>
 #include <Primitives/rdVector.h>
+#include <Primitives/rdMatrix.h>
 
 // 0x00401340
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4)
@@ -175,11 +178,84 @@ void swrRace_BuyPitdroidsMenu(swrObjHang* hang)
     HANG("TODO");
 }
 
+// Sets up the global ray-collision query state from `ray` (= {origin.xyz, dir.xyz, maxDist}),
+// installs the per-face callbacks, resets the matrix stack, then recursively ray-tests the model's
+// node tree (CollideNodeRecursiveRay, which latches the closest hit into the query globals). On a hit
+// (closest <= maxDist) it fills outHit/outNormal and returns the hit distance; -1.0 on a miss. The hit
+// node is published to swrRace_collisionHitNode.
 // 0x00444d10
-float swrRace_InitUnk(int a, float b, float c, int* d)
+float swrRace_InitUnk(swrModel_Node* model, float* ray, rdVector3* outHit, rdVector3* outNormal)
 {
-    HANG("TODO");
-    return 0.0;
+    if (model == NULL) {
+        swrModel_collisionResultDist = -1.0;
+    } else {
+        swrModel_collisionResultDist = ray[6] + 200.0f;// closest-hit accumulator, init past maxDist
+        swrModel_collisionResultNode = NULL;
+        swrModel_collisionRayMaxDist = ray[6];
+        swrModel_collisionRayDir.x = ray[3];
+        swrModel_collisionRayDir.y = ray[4];
+        swrModel_collisionRayDir.z = ray[5];
+        swrModel_collisionRayOrigin.x = ray[0];
+        swrModel_collisionRayOrigin.y = ray[1];
+        swrModel_collisionRayOrigin.z = ray[2];
+        swrModel_collisionUnkE1c = 1;
+        swrModel_meshCollisionFaceCallback = swrModel_MeshCollisionFaceCallback;
+        swrModel_meshCollisionFaceCallbackIndexed = swrModel_MeshCollisionFaceCallbackIndexed;
+        swrModel_collisionUnkE70 = 0;
+        swrModel_collisionUnk250 = 0;
+        swrRace_ResetMatrixStack();
+        swrModel_CollideNodeRecursiveRay((swrModel_NodeTransformed*) model, ray, 0);
+        if (swrModel_collisionResultDist <= ray[6]) {
+            outHit->x = swrModel_collisionHitPoint.x;
+            outHit->y = swrModel_collisionHitPoint.y;
+            outHit->z = swrModel_collisionHitPoint.z;
+            outNormal->x = swrModel_collisionHitNormal.x;
+            outNormal->y = swrModel_collisionHitNormal.y;
+            outNormal->z = swrModel_collisionHitNormal.z;
+        } else {
+            swrModel_collisionResultDist = -1.0;
+        }
+    }
+    if (swrModel_collisionResultNode != NULL)
+        swrRace_collisionHitNode = swrModel_collisionResultNode;
+    return swrModel_collisionResultDist;
+}
+
+// Resets the collision-query matrix stack to a single identity matrix.
+// 0x00445150
+void swrRace_ResetMatrixStack(void)
+{
+    rdMatrixStack44_size = 0;
+    rdMatrixStack44[0].vA.x = 1.0;
+    rdMatrixStack44[0].vA.y = 0.0;
+    rdMatrixStack44[0].vA.z = 0.0;
+    rdMatrixStack44[0].vA.w = 0.0;
+    rdMatrixStack44[0].vB.x = 0.0;
+    rdMatrixStack44[0].vB.y = 1.0;
+    rdMatrixStack44[0].vB.z = 0.0;
+    rdMatrixStack44[0].vB.w = 0.0;
+    rdMatrixStack44[0].vC.x = 0.0;
+    rdMatrixStack44[0].vC.y = 0.0;
+    rdMatrixStack44[0].vC.z = 1.0;
+    rdMatrixStack44[0].vC.w = 0.0;
+    rdMatrixStack44[0].vD.x = 0.0;
+    rdMatrixStack44[0].vD.y = 0.0;
+    rdMatrixStack44[0].vD.z = 0.0;
+    rdMatrixStack44[0].vD.w = 1.0;
+}
+
+// Clears the collision-query "hit node" result before a ray query (the query latches it on hit).
+// 0x00441020
+void swrRace_ResetCollisionHit(void)
+{
+    swrRace_collisionHitNode = NULL;
+}
+
+// Returns the node hit by the most recent ray query (NULL if none).
+// 0x00441030
+swrModel_Node* swrRace_GetCollisionHit(void)
+{
+    return swrRace_collisionHitNode;
 }
 
 // TODO: look at 0x0045cf60
@@ -860,10 +936,117 @@ void swrRace_ActivateTriggersInRange(swrRace* a, swrModel_TriggerDescription* a2
     HANG("TODO");
 }
 
+// Eases *value toward target at `rate` units/sec (used for the traction/skid multipliers below).
+static void swrRace_easeTraction(float* value, float target, double rate)
+{
+    if (target <= *value) {
+        if (target < *value) {
+            *value = *value - swrRace_deltaTimeSecs * rate;
+            if (*value < target)
+                *value = target;
+        }
+    } else {
+        *value = *value + swrRace_deltaTimeSecs * rate;
+        if (target < *value)
+            *value = target;
+    }
+}
+
+// Reads the terrain mesh's swrModel_Behavior tag and translates its bitfields into pod flags +
+// traction targets each frame. behavior.unk1 & 0x20 sets flags1 0x400 (the surface-relative "magnet"
+// gravity); vehicle_reaction bits drive zero-g/orbit (1/2), surface friction (4/8/0x10/0x20), wall
+// reactions, reflections, triggers, etc. The clear mask 0xff63fb1e drops the per-frame tag bits up
+// front so they re-latch only while the pod is over a tagged surface.
 // 0x00476ea0
 void swrRace_UpdateSurfaceTag(swrRace* test)
 {
-    // TODO
+    float iceTarget = 0.0;
+    float terrainTractionTarget = 1.0;
+    float terrainSkidTarget = 1.0;
+
+    if (((test->flags0 & 0x2000000) != 0) && (test->speedValue < 75.0f))
+        iceTarget = 75.0f - test->speedValue;
+
+    test->flags1 = test->flags1 & 0xff63fb1e;
+
+    swrModel_Behavior* behavior = NULL;
+    if (test->terrainModel != NULL)
+        behavior = swrModel_MeshGetBehavior((swrModel_Mesh*) test->terrainModel);
+
+    if (behavior != NULL) {
+        uint32_t toggles = test->collisionToggles & ~behavior->unk20;
+        test->collisionToggles = (((behavior->unk21 >> 8) | (toggles >> 8)) & 0xFFFFFF) << 8;
+
+        if ((behavior->unk1 & 0x10) != 0)
+            test->flags1 = test->flags1 | 0x80;
+        if ((behavior->unk1 & 0x20) != 0)
+            test->flags1 = test->flags1 | 0x400;// surface-relative "magnet" gravity
+        if ((behavior->vehicle_reaction & 0x2000) != 0)
+            test->flags1 = test->flags1 | 0x40000;
+        if ((behavior->vehicle_reaction & 0x4000) != 0)
+            test->flags1 = test->flags1 | 0x80000;
+        if (((behavior->vehicle_reaction & 0x20000) != 0) && ((test->flags0 & 0x80) != 0) &&
+            ((test->flags1 & 0x4000000) == 0))
+            test->flags1 = test->flags1 | 0x800000;
+        if ((behavior->vehicle_reaction & 0x8000) != 0)
+            test->flags1 = test->flags1 | 0x100000;
+
+        // debug hotkey: toggle the zero-g flag while held
+        if (((swrRace_DebugFlag & 0x2000) != 0) && ((inRaceLocalPlayerInputBitset1[0] & 0x100) != 0) &&
+            (((uint8_t) inRaceLocalPlayerInputBitset3[0] & 0x80) != 0))
+            test->flags0 = test->flags0 ^ 0x2000000;
+
+        if ((behavior->vehicle_reaction & 1) != 0)
+            test->flags0 = test->flags0 | 0x2000000;
+        if (((behavior->vehicle_reaction & 2) != 0) && ((test->flags0 & 0x2000000) != 0)) {
+            // entering zero-g/orbit: seed velocityDir from the last move, clear the slide
+            test->velocityDir.x = test->transform.vD.x - test->positionPrev.x;
+            test->velocityDir.y = test->transform.vD.y - test->positionPrev.y;
+            test->velocityDir.z = test->transform.vD.z - test->positionPrev.z;
+            test->unk10_3 = 0x40400000;// 3.0f
+            test->velocitySlope.x = 0.0;
+            test->velocitySlope.y = 0.0;
+            test->velocitySlope.z = 0.0;
+            test->flags0 = (test->flags0 & 0xfdffffff) | 0x4000000;
+        }
+
+        if ((behavior->vehicle_reaction & 4) != 0)
+            iceTarget = 200.0f;
+        if ((behavior->vehicle_reaction & 8) != 0) {
+            terrainTractionTarget = 0.75f;
+            if ((test->flags0 & 0x2000000) != 0)
+                test->flags0 = test->flags0 & 0xff7fffff;
+        }
+        if ((behavior->vehicle_reaction & 0x10) != 0) {
+            terrainTractionTarget = 0.1f;
+            test->flags0 = test->flags0 & 0xff7fffff;
+        }
+        if ((behavior->vehicle_reaction & 0x20) != 0)
+            terrainSkidTarget = 0.2f;
+        if ((test->flags1 & 0x2000000) != 0)
+            terrainSkidTarget = 1.0f;
+        if ((behavior->vehicle_reaction & 0x400) != 0)
+            test->flags1 = test->flags1 | 1;
+        if (behavior->triggers != NULL)
+            swrRace_ActivateTriggersInRange(test, behavior->triggers);
+        if (((behavior->vehicle_reaction & 0x1000) != 0) && (swrConfig_VIDEO_REFLECTIONS == 1))
+            test->flags1 = test->flags1 | 0x40;
+        if ((behavior->vehicle_reaction & 0x20000000) != 0)
+            test->flags1 = test->flags1 | 0x20;
+    }
+
+    if (specialActiveTrigger != NULL)
+        swrRace_ActivateTriggersInRange(test, specialActiveTrigger);
+
+    swrRace_easeTraction(&test->iceTractionMultiplier, iceTarget, 25.0);
+    swrRace_easeTraction(&test->terrainTractionMultiplier, terrainTractionTarget, 0.5);
+    swrRace_easeTraction(&test->terrainSkidModifier, terrainSkidTarget, 0.5);
+
+    test->unk11_1 = 0;
+    if (((((float) test->unk1998 - 400.0f) * 0.0016666667f < 1.0f) || ((test->flags0 & 0x20) != 0) ||
+         ((test->flags1 & 0x4000000) != 0)) &&
+        (((test->flags1 & 0x80000) != 0) && ((test->flags1 & 0x200) == 0)))
+        test->flags0 = test->flags0 | 0x1000;
 }
 
 // 0x004774f0
@@ -965,6 +1148,367 @@ void swrRace_ApplyGravity(swrRace* player, float* a, float b)
     a[2] += player->fallRate * gz;
 }
 
+// Normal-mode slope steering (no magnet). Projects world gravity (unk194_vec) onto the surface plane
+// to accumulate the downhill slide into velocitySlope (force quadratic in the steer term), and drives
+// unk8_1 (auto-tilt) from the downhill/facing alignment. Also publishes the slope angle to
+// swrRace_slopeAngle. Bails near-flat / near-inverted surfaces (dot(normal, worldDown) outside
+// [-0.995, 0.995]); out1 is scratch for the gradient, out2 the integrated slide.
+// 0x004791d0
+void swrRace_ApplySlopeSteering(swrRace* player, int param_2, int param_3, float param_4,
+                                rdVector3* normal, rdVector3* out1, rdVector3* out2)
+{
+    rdVector3 downhillAxis;
+    rdVector3 slopeForce;
+    rdVector3 surfDir;
+    rdVector3 vbFlat;
+
+    float dotND = normal->x * player->unk194_vec.x + normal->y * player->unk194_vec.y +
+                  normal->z * player->unk194_vec.z;
+    if ((dotND < -0.995) || (0.995 < dotND)) {
+        rdVector_Set3(out1, 0.0, 0.0, 0.0);
+        rdVector_Scale3(&player->velocitySlope, 0.9f, &player->velocitySlope);
+        rdVector_Copy3(out2, &player->velocitySlope);
+        player->unk8_1 = 0.0;
+        return;
+    }
+
+    rdVector_Cross3(&downhillAxis, normal, &player->unk194_vec);
+    rdVector_Cross3(out1, normal, &downhillAxis);
+    rdVector_Normalize3Acc(out1);// out1 = normalized downhill gradient on the surface
+    float slopeSin = out1->x * player->unk194_vec.x + out1->y * player->unk194_vec.y +
+                     out1->z * player->unk194_vec.z;
+    swrRace_slopeAngle = stdMath_ArcSin(slopeSin);
+
+    float steerMag;
+    if (param_4 <= 50.0f)
+        steerMag = (1.0f - param_4 * 0.02f) * slopeSin;
+    else
+        steerMag = 0.0;
+
+    float force = steerMag * steerMag * 400.0f;
+    rdVector_Scale3(&slopeForce, -force, out1);
+    rdVector_Scale3Add3(out2, &player->velocitySlope, swrRace_deltaTimeSecs + swrRace_deltaTimeSecs,
+                        &slopeForce);
+    float outLen = rdVector_Len3(out2);
+    float absLen = (outLen < 0.0) ? -outLen : outLen;
+    float absForce = (force < 0.0) ? -force : force;
+    if (absForce < absLen) {
+        float scale = force / outLen;
+        if (scale < 0.0)
+            scale = -scale;
+        rdVector_Scale3(out2, scale, out2);
+    }
+    rdVector_Copy3(&player->velocitySlope, out2);
+
+    surfDir.x = out1->x;
+    surfDir.y = out1->y;
+    surfDir.z = 0.0;
+    vbFlat.x = player->transform.vB.x;
+    vbFlat.y = player->transform.vB.y;
+    vbFlat.z = 0.0;
+    float surfLen = rdVector_Normalize3Acc(&surfDir);
+    if (surfLen < 0.01f) {
+        surfDir.x = -normal->x;
+        surfDir.y = -normal->y;
+        surfDir.z = -normal->z;
+    }
+    rdVector_Normalize3Acc(&vbFlat);
+    float align = surfDir.x * vbFlat.x + surfDir.y * vbFlat.y + surfDir.z * vbFlat.z;
+    float tiltScale = 0.0;
+    if (0.0 <= align) {
+        if (0.70700002f < align)
+            align = (1.0f - align) * 2.5445292f * 0.70700002f;
+        tiltScale = (surfDir.x * out1->x + surfDir.y * out1->y + surfDir.z * out1->z) * align;
+        if (0.0 <= surfDir.y * vbFlat.x - surfDir.x * vbFlat.y)
+            tiltScale = tiltScale * -2.0f;
+        else
+            tiltScale = tiltScale + tiltScale;
+    }
+
+    if (steerMag + 0.15f < 0.0) {
+        float t = (steerMag + 0.15f) * 1.1764705f;
+        player->unk8_1 = t * t * tiltScale * 600.0f;
+        return;
+    }
+    player->unk8_1 = 0.0;
+}
+
+// Magnet-mode slope steering (flags1 0x400): keeps the pod glued to a tagged surface. Same gravity-on-
+// surface velocitySlope build as the normal version but with a much stronger, speed-tiered steer term,
+// and the auto-tilt (unk8_1) aligns the pod's facing to the downhill direction. Same near-flat /
+// near-inverted bail. NOTE: the [-0.995, 0.995] gate + the speed tiers are the limits a "banking magnet"
+// corkscrew mode would relax. param_2/param_3/param_4 are unused here (kept for signature parity).
+// 0x00479550
+void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int param_2, int param_3, float param_4,
+                                      rdVector3* normal, rdVector3* out1, rdVector3* out2)
+{
+    rdVector3 downhillAxis;
+    rdVector3 slopeForce;
+    rdVector3 surfDir;
+    rdVector3 vbFlat;
+
+    float dotND = normal->x * player->unk194_vec.x + normal->y * player->unk194_vec.y +
+                  normal->z * player->unk194_vec.z;
+    if ((dotND < -0.995) || (0.995 < dotND)) {
+        rdVector_Set3(out1, 0.0, 0.0, 0.0);
+        rdVector_Scale3(&player->velocitySlope, 0.9f, &player->velocitySlope);
+        rdVector_Copy3(out2, &player->velocitySlope);
+        player->unk8_1 = 0.0;
+        return;
+    }
+
+    rdVector_Cross3(&downhillAxis, normal, &player->unk194_vec);
+    rdVector_Normalize3Acc(&downhillAxis);
+    rdVector_Cross3(out1, normal, &downhillAxis);// out1 = downhill gradient on the surface
+    float slopeSin = out1->x * player->unk194_vec.x + out1->y * player->unk194_vec.y +
+                     out1->z * player->unk194_vec.z;
+    float slopeAngle = stdMath_ArcSin(slopeSin);
+    float steerMag = slopeAngle * -1.1111112f;
+
+    if (200.0f <= player->speedValue) {
+        if (250.0f <= player->speedValue) {
+            if (300.0f <= player->speedValue) {
+                if (350.0f <= player->speedValue)
+                    steerMag = (steerMag - 80.0f) * 5.0f;
+                else
+                    steerMag = (steerMag - 60.0f) * 2.5f;
+            } else {
+                steerMag = (steerMag - 40.0f) * 1.6666666f;
+            }
+        } else {
+            steerMag = (steerMag - 25.0f) * 1.3333334f;
+        }
+    }
+    if (steerMag < 0.0)
+        steerMag = 0.0;
+    if (87.0f < slopeAngle)
+        steerMag = steerMag + steerMag;
+
+    rdVector_Scale3(&slopeForce, -steerMag, out1);
+    rdVector_Scale3Add3(out2, &player->velocitySlope, swrRace_deltaTimeSecs + swrRace_deltaTimeSecs,
+                        &slopeForce);
+    float outLen = rdVector_Len3(out2);
+    float absLen = (outLen < 0.0) ? -outLen : outLen;
+    float absSteer = (steerMag < 0.0) ? -steerMag : steerMag;
+    if (absSteer < absLen) {
+        float scale = steerMag / outLen;
+        if (scale < 0.0)
+            scale = -scale;
+        rdVector_Scale3(out2, scale, out2);
+    }
+    rdVector_Copy3(&player->velocitySlope, out2);
+
+    surfDir.x = out1->x;
+    surfDir.y = out1->y;
+    surfDir.z = 0.0;
+    vbFlat.x = player->transform.vB.x;
+    vbFlat.y = player->transform.vB.y;
+    vbFlat.z = 0.0;
+    float surfLen = rdVector_Normalize3Acc(&surfDir);
+    if (surfLen < 0.01f) {
+        surfDir.x = -normal->x;
+        surfDir.y = -normal->y;
+        surfDir.z = -normal->z;
+    }
+    rdVector_Normalize3Acc(&vbFlat);
+    float align = surfDir.x * vbFlat.x + surfDir.y * vbFlat.y + surfDir.z * vbFlat.z;
+    if (0.0 <= align) {
+        float a = stdMath_ArcSin(align);
+        float side = vbFlat.x * downhillAxis.x + vbFlat.y * downhillAxis.y + vbFlat.z * downhillAxis.z;
+        if (side <= 0.0)
+            player->unk8_1 = -(a * slopeSin);
+        else
+            player->unk8_1 = -(-a * slopeSin);
+    } else {
+        player->unk8_1 = 0.0;
+    }
+}
+
+// Casts a ray "down" (world unk194_vec, or -unk160 in magnet mode, started 2 units up) to find the
+// ground. Tries the fast mesh ray (CollideRayWithMesh) then the full query (InitUnk); in magnet mode,
+// retries once straight down (world gravity) if the surface-relative cast missed. Writes the surface
+// normal to param_3 (world-up on a miss) and the hit node to player->terrainModel. Returns the ground
+// distance minus a 2-unit skin, or a large value (100000) when nothing was hit.
+// 0x004772f0
+float swrRace_RaycastGround(swrRace* player, rdVector3* param_2, int* param_3)
+{
+    rdVector3 down;
+    rdVector3 origin;
+    rdVector3 outPoint;
+    rdVector3 outNormal;
+    float ray[7];
+    float hitDist;
+
+    if ((player->flags1 & 0x400) == 0) {
+        down = player->unk194_vec;
+    } else {
+        down.x = -player->unk160.x;
+        down.y = -player->unk160.y;
+        down.z = -player->unk160.z;
+    }
+    rdVector_Scale3Add3(&origin, param_2, -2.0f, &down);
+    ray[0] = origin.x;
+    ray[1] = origin.y;
+    ray[2] = origin.z;
+    ray[3] = down.x;
+    ray[4] = down.y;
+    ray[5] = down.z;
+    ray[6] = 10000.0f;
+
+    swrRace_ResetCollisionHit();
+    if ((player->flags1 & 0x80) == 0)
+        hitDist = swrModel_CollideRayWithMesh((swrModel_Mesh*) player->unkec_node, ray,
+                                              (float*) &outPoint, (float*) &outNormal);
+    else
+        hitDist = -1.0f;
+
+    if (hitDist < 0.0)
+        hitDist = swrRace_InitUnk(player->model_unk, ray, &outPoint, &outNormal);
+
+    if (((player->flags1 & 0x400) != 0) && (hitDist < 0.0)) {
+        // surface-relative cast missed: retry straight down (world gravity)
+        ray[3] = player->unk194_vec.x;
+        ray[4] = player->unk194_vec.y;
+        ray[5] = player->unk194_vec.z;
+        hitDist = swrRace_InitUnk(player->model_unk, ray, &outPoint, &outNormal);
+    }
+
+    player->terrainModel = swrRace_GetCollisionHit();
+
+    if (hitDist < 0.0) {
+        ((float*) param_3)[0] = 0.0;
+        ((float*) param_3)[1] = 0.0;
+        ((float*) param_3)[2] = 1.0;
+        player->thrust = -10000.0f;
+        return 100000.0f;
+    }
+
+    ((float*) param_3)[0] = outNormal.x;
+    ((float*) param_3)[1] = outNormal.y;
+    ((float*) param_3)[2] = outNormal.z;
+    player->thrust = outPoint.z;
+    return hitDist - 2.0f;
+}
+
+// Per-frame ground-contact orchestrator. Raycasts the ground (RaycastGround) to get the surface
+// normal, stores it as the pod's "up" in unk160, runs slope steering (magnet variant when flags1
+// 0x400 is set), applies gravity, then resolves track/wall collision and hover pads. Returns the
+// ground distance (also cached in groundToPodMeasure). The `up.z < 0.05` floor below is THE limit a
+// vertical/inverted "magnet" corkscrew would have to lift -- it stops the surface normal from ever
+// pointing sideways-past-vertical or downward.
+// 0x00479e10
+float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int param_3, rdVector3* up, int param_5)
+{
+    rdVector3 prevPos;
+    rdVector3 slopeOut1;
+    rdVector3 slopeOut2;
+    rdVector3 wallDelta;
+    rdVector3 collideNormal;
+    rdMatrix44 splineMat;
+    float groundDist;
+
+    prevPos.x = velocity[0];
+    prevPos.y = velocity[1];
+    prevPos.z = velocity[2];
+
+    const float progress = ((float) player->unk1998 - 400.0f) * 0.0016666667f;
+    if ((progress < 1.0f) || ((player->flags0 & 0x20) != 0) || ((player->flags1 & 0x4000000) != 0)) {
+        uint32_t flags1;
+        if (((player->flags1 & 0x400000) == 0) || ((player->flags1 & 0x800000) == 0)) {
+            groundDist = swrRace_RaycastGround(player, (rdVector3*) velocity, (int*) up);
+            flags1 = player->flags1;
+            if ((flags1 & 0x800000) == 0)
+                flags1 = flags1 & 0xffbfffff;
+            else
+                flags1 = flags1 | 0x400000;
+        } else {
+            groundDist = velocity[2] - player->thrust;
+            up->x = player->unk160.x;
+            up->y = player->unk160.y;
+            up->z = player->unk160.z;
+            player->terrainModel = player->unkec_node;
+            flags1 = player->flags1 | 0x20000000;
+        }
+        player->flags1 = flags1;
+
+        // surface-relative magnet mode: keep the "up" normal from tipping past ~horizontal/inverted
+        if (((flags1 & 0x400) != 0) && (up->z < 0.05f)) {
+            up->z = 0.05f;
+            rdVector_Normalize3Acc(up);
+        }
+        player->unk160.x = up->x;
+        player->unk160.y = up->y;
+        player->unk160.z = up->z;
+
+        if (((player->flags0 & 0x5000) == 0) &&
+            ((0.1f < player->gravityMultiplier) || (0.1f < -player->gravityMultiplier) ||
+             ((player->flags0 & 0x2000) == 0))) {
+            if ((player->flags1 & 0x400) == 0)
+                swrRace_ApplySlopeSteering(player, (int) velocity, param_3, groundDist, up, &slopeOut1,
+                                           &slopeOut2);
+            else
+                swrRace_ApplySlopeSteeringMagnet(player, (int) velocity, param_3, groundDist, up,
+                                                 &slopeOut1, &slopeOut2);
+        }
+
+        if ((player->flags0 & 0x4000000) == 0)
+            swrRace_ApplyGravity(player, velocity, groundDist);
+
+        if (groundDist < 0.0)
+            groundDist = 2.0f;
+
+        if ((((uint8_t) player->flags0 & 0xf) == 2) && ((player->flags0 & 0x20) == 0) &&
+            (0.0f <= progress && progress <= 1.0f)) {
+            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            velocity[2] = progress * (splineMat.vD.z - velocity[2]) + velocity[2];
+        }
+
+        if ((player->flags1 & 0x800000) == 0) {
+            if ((player->flags0 & 0x20) == 0) {
+                swrRace_CollideBlockMove((rdVector3*) velocity, &prevPos, player->model_unk, &collideNormal);
+            } else {
+                rdVector3 before;
+                before.x = velocity[0];
+                before.y = velocity[1];
+                before.z = velocity[2];
+                swrRace_DetectWallScrape(player, velocity, (float*) param_3);
+                wallDelta.x = player->unk154_vec.x + (velocity[0] - before.x);
+                wallDelta.y = player->unk154_vec.y + (velocity[1] - before.y);
+                wallDelta.z = player->unk154_vec.z + (velocity[2] - before.z);
+                swrRace_ApplyWallCollision(player, &wallDelta, up);
+            }
+        }
+
+        if (1.0f <= ((float) player->unk1998 - 40.0f) * 0.016666668f) {
+            // no fresh hover-pad data: mark all four pads "no ground"
+            float* pad = (float*) (player->unk4d0 + 0xdf8);
+            for (int i = 0; i < 4; i++) {
+                *pad = -100000.0f;
+                pad += 0x10;
+            }
+        } else {
+            groundDist = swrRace_UpdateHoverPads(player, (rdVector3*) velocity, *(int*) (param_5 + 8),
+                                                 groundDist, &up->x);
+        }
+    } else {
+        player->terrainModel = player->unkec_node;
+        player->flags1 = player->flags1 | 0x20000000;
+        if (((uint8_t) player->flags0 & 0xf) == 2) {
+            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            velocity[2] = splineMat.vD.z;
+        }
+        groundDist = 2.0f;
+        up->x = 0.0;
+        up->y = 0.0;
+        up->z = 1.0;
+        if (((uint8_t) player->flags0 & 0xf) == 2)
+            player->flags1 = player->flags1 | 2;
+    }
+
+    player->groundToPodMeasure = groundDist;
+    return groundDist;
+}
+
 // 0x0046bd20
 int swrRace_BoostCharge(int player)
 {
@@ -972,17 +1516,243 @@ int swrRace_BoostCharge(int player)
     return 0;
 }
 
+// Extracts the pitch (out->y, measured from horizontal) and signed roll/bank (out->z) of a
+// forward/right basis relative to a reference (down) vector. Angles are in degrees
+// (stdMath_ArcCos). out->x is unused (0). Leaf used by swrRace_AlignToSurface.
+// 0x00476390
+void swrRace_ComputeTiltAngles(rdVector3* fwd, rdVector3* right, rdVector3* ref, rdVector3* out)
+{
+    rdVector3 refCrossFwd;
+    rdVector3 rightCross;
+    float len;
+
+    out->x = 0.0;
+    out->z = 0.0;
+    out->y = stdMath_ArcCos(fwd->x * ref->x + fwd->y * ref->y + fwd->z * ref->z) - 90.0f;
+
+    rdVector_Cross3(&refCrossFwd, ref, fwd);
+    rdVector_Cross3(&rightCross, right, &refCrossFwd);
+    len = rdVector_Len3(&refCrossFwd);
+    if (len <= 0.01f)
+        return;
+
+    float roll = stdMath_ArcCos((right->x * refCrossFwd.x + right->y * refCrossFwd.y +
+                                 right->z * refCrossFwd.z) /
+                                len);
+    if (0.0 < rightCross.x * fwd->x + rightCross.y * fwd->y + rightCross.z * fwd->z)
+        out->z = -roll;
+    else
+        out->z = roll;
+}
+
+// Builds a surface-aligned basis (right = vB x up, fwd = up x right), measures the pod's
+// heading/tilt error against it via swrRace_ComputeTiltAngles, and accumulates a correction into
+// the turn input pRDot (->y heading, ->z tilt). In magnet mode (flags1 0x400) the surface-tilt
+// alignment (out->z / bank) is clamped to +-85 deg. groundDist/hoverHi/hoverLo gate how strongly
+// the correction applies as the pod nears the ground.
+// 0x004764e0
+void swrRace_AlignToSurface(swrRace* player, rdVector3* up, rdVector3* fwd_vB, rdVector3* vA_fallback,
+                            rdVector3* down_ref, float groundDist, float hoverHi, float hoverLo, rdVector3* pRDot)
+{
+    rdVector3 surfRight;
+    rdVector3 surfFwd;
+    rdVector3 angles;
+    float len;
+
+    rdVector_Cross3(&surfRight, fwd_vB, up);
+    len = rdVector_Len3(&surfRight);
+    if (0.01f < len)
+        rdVector_Scale3(&surfRight, 1.0f / len, &surfRight);
+    else
+        surfRight = *vA_fallback;
+
+    rdVector_Cross3(&surfFwd, up, &surfRight);
+    len = rdVector_Len3(&surfFwd);
+    if (0.01f < len)
+        rdVector_Scale3(&surfFwd, 1.0f / len, &surfFwd);
+    else
+        surfFwd = *fwd_vB;
+
+    swrRace_ComputeTiltAngles(&surfFwd, &surfRight, down_ref, &angles);
+
+    // magnet mode: clamp the surface-tilt (bank) alignment to +-85 deg
+    if ((player->flags1 & 0x400) != 0) {
+        if (85.0f < angles.z)
+            angles.z = 85.0f;
+        if (angles.z < -85.0f)
+            angles.z = -85.0f;
+    }
+
+    float headingDelta = angles.y - pRDot->y;
+    float headingGain = 0.33333334f;
+    if ((angles.y < pRDot->y) || (headingGain = 0.5f, pRDot->y < angles.y))
+        headingDelta = headingDelta * headingGain;
+
+    float tiltDelta = (angles.z - pRDot->z) * 0.125f;
+
+    if ((player->flags0 & 0x4000000) == 0) {
+        float blend = (hoverHi - groundDist) / (hoverHi - hoverLo);
+        if (blend <= 0.0) {
+            tiltDelta = pRDot->z * -0.125f;
+            headingDelta = 0.0;
+            if (-37.0f < pRDot->y)
+                headingDelta = swrRace_deltaTimeSecs * -22.0f;
+            if ((player->pitch < 0.0) && (pRDot->y < -10.0f))
+                headingDelta = headingDelta - swrRace_deltaTimeSecs * player->pitch * 20.0f;
+        } else if (blend < 1.0f) {
+            headingDelta = blend * headingDelta;
+            tiltDelta = tiltDelta * blend;
+        }
+    }
+
+    pRDot->y = headingDelta + pRDot->y;
+    pRDot->z = tiltDelta + pRDot->z;
+}
+
 // 0x00477ad0
 void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotion, rdVector3* pRDot)
 {
-    // See swe1r-decomp
-    HANG("TODO");
+    swrRace* player = (swrRace*) pEngine;
+    float hoverHi = player->podStats.hoverHeight * 1.5f;
+    float hoverLo = (player->podStats.intersectRadius + player->podStats.intersectRadius +
+                     player->podStats.hoverHeight) *
+                    0.33333334f;
+
+    // Outside magnet mode, lift the standing tilt target out of pRDot->z before re-aligning.
+    if ((player->flags1 & 0x400) == 0)
+        pRDot->z = pRDot->z - player->tiltAngleTarget;
+
+    swrRace_AlignToSurface(player, (rdVector3*) pXformZ, (rdVector3*) &player->transform.vB,
+                           (rdVector3*) &player->transform.vA, &player->unk194_vec, ZMotion, hoverHi,
+                           hoverLo, pRDot);
+
+    // Magnet mode (flags1 0x400) suppresses ALL of the player banking + manual tilt below; only the
+    // surface alignment from swrRace_AlignToSurface reaches the tilt axis.
+    if ((player->flags1 & 0x400) == 0) {
+        pRDot->z = player->tiltAngleTarget + pRDot->z;
+
+        // Bank-into-turn: ease tiltAngleTarget toward the turn-rate-driven lean (capped at 300 deg
+        // on the ground / 70 deg airborne), then blend the change into pRDot->z.
+        float prevTilt = player->tiltAngleTarget;
+        float maxAngle = ((player->flags0 & 0x80) == 0) ? 70.0f : 300.0f;
+        swrRace_SetAngleFromTurnRate(&player->tiltAngleTarget, player->turnRate,
+                                     *(void**) &player->turnRateTarget, player->podStats.maxTurnRate,
+                                     maxAngle);
+        pRDot->z = pRDot->z - (player->tiltAngleTarget - prevTilt) * 0.2f;
+
+        // Manual tilt (player holding a lean) pulls pRDot->z toward tiltManualMult * 80 deg.
+        if (player->tiltManualMult != 0.0) {
+            float mag = player->tiltManualMult;
+            if (mag < 0.0)
+                mag = -mag;
+            pRDot->z = (player->tiltManualMult * 80.0f - pRDot->z) * mag + pRDot->z;
+        }
+    }
+
+    player->tiltAngle = pRDot->z;
 }
 
-// 0x00477c27
-void swrRace_UpdateTurn2(int player, int a, int b, int c)
+// Per-frame orientation update: rotates the pod's transform basis (vA/vB/vC) by the accumulated turn
+// input (turnInput->z about vB via a vector-angle matrix, ->y pitch about the horizontal surface axis,
+// ->x roll about Z), then stores the new position into vD. Above a progress threshold (and outside
+// debug/zero-g) it takes a cheap yaw-only path. Re-normalizes the basis every 8 frames to fight drift.
+// NOTE: address corrected 0x00477c27 -> 0x00477c30 (the former was a bogus {return;} with no xrefs).
+// 0x00477c30
+void swrRace_UpdateTurn2(swrRace* player, rdVector3* pos, rdVector3* turnInput)
 {
-    // TODO
+    rdMatrix44 m;
+    float vAx = player->transform.vA.x;
+    float vAy = player->transform.vA.y;
+    float vAz = player->transform.vA.z;
+    float vBx = player->transform.vB.x;
+    float vBy = player->transform.vB.y;
+    float vBz = player->transform.vB.z;
+    float vCx = player->transform.vC.x;
+    float vCy = player->transform.vC.y;
+    float vCz = player->transform.vC.z;
+
+    if ((((float) player->unk1998 - 400.0f) * 0.0016666667f < 1.0f) || ((player->flags0 & 0x20) != 0) ||
+        ((player->flags1 & 0x4000000) != 0)) {
+        // full 3-axis update: build a horizontal axis (hx, hy) from vB (fall back to vC near-vertical)
+        float hx = -vBx;
+        float hy = vBy;
+        float h = stdMath_Sqrt(hx * hx + vBy * vBy);
+        if (h < 0.1f) {
+            hx = -vCx;
+            hy = vCy;
+            h = stdMath_Sqrt(hx * hx + vCy * vCy);
+        }
+        hy = hy / h;
+        hx = hx / h;
+
+        rdMatrix_BuildFromVectorAngle44(&m, turnInput->z, vBx, vBy, vBz);
+
+        // pitch rotation about the (hx, hy, 0) axis
+        float ps, pc;
+        stdMath_SinCos(turnInput->y, &ps, &pc);
+        float hx2 = hx * hx;
+        float r00 = pc * hx2 + hy * hy;
+        float r11 = pc * hy * hy + hx2;
+        float r01 = (1.0f - pc) * hx * hy;
+        float r02 = hy * ps;
+        float r12 = -(hx * ps);
+        float r20 = -r12;
+        float r21 = -r02;
+
+        float a0 = m.vA.z * r20 + m.vA.y * r01 + m.vA.x * r00;
+        float a1 = m.vA.z * r21 + m.vA.y * r11 + m.vA.x * r01;
+        float a2 = pc * m.vA.z + m.vA.y * r02 + m.vA.x * r12;
+        float b0 = m.vB.z * r20 + m.vB.y * r01 + m.vB.x * r00;
+        float b1 = m.vB.z * r21 + m.vB.y * r11 + m.vB.x * r01;
+        float b2 = pc * m.vB.z + m.vB.y * r02 + m.vB.x * r12;
+        float c0 = m.vC.z * r20 + m.vC.y * r01 + m.vC.x * r00;
+        float c1 = m.vC.z * r21 + m.vC.y * r11 + m.vC.x * r01;
+        float c2 = pc * m.vC.z + m.vC.y * r02 + m.vC.x * r12;
+
+        // roll rotation about Z
+        float rs, rc;
+        stdMath_SinCos(turnInput->x, &rs, &rc);
+        float a0r = rc * a0 - rs * a1;
+        float a1r = rs * a0 + rc * a1;
+        float b0r = rc * b0 - rs * b1;
+        float b1r = rs * b0 + rc * b1;
+        float c0r = rc * c0 - rs * c1;
+        float c1r = rs * c0 + rc * c1;
+
+        player->transform.vA.x = vAz * c0r + vAy * b0r + vAx * a0r;
+        player->transform.vA.y = vAz * c1r + vAy * b1r + vAx * a1r;
+        player->transform.vA.z = vAz * c2 + vAy * b2 + vAx * a2;
+        player->transform.vB.x = vBz * c0r + vBy * b0r + vBx * a0r;
+        player->transform.vB.y = vBz * c1r + vBy * b1r + vBx * a1r;
+        player->transform.vB.z = vBz * c2 + vBy * b2 + vBx * a2;
+        player->transform.vC.x = vCz * c0r + vCy * b0r + vCx * a0r;
+        player->transform.vC.y = vCz * c1r + vCy * b1r + vCx * a1r;
+        player->transform.vC.z = vCz * c2 + vCy * b2 + vCx * a2;
+    } else {
+        // cheap yaw-only update (roll about Z by turnInput->x)
+        float rs, rc;
+        stdMath_SinCos(turnInput->x, &rs, &rc);
+        player->transform.vA.x = rc * vAx - rs * vAy;
+        player->transform.vA.y = rc * vAy + rs * vAx;
+        player->transform.vB.x = rc * vBx - rs * vBy;
+        player->transform.vB.y = rc * vBy + rs * vBx;
+        player->transform.vA.z = vAz;
+        player->transform.vC.x = rc * vCx - rs * vCy;
+        player->transform.vB.z = vBz;
+        player->transform.vC.z = vCz;
+        player->transform.vC.y = rc * vCy + rs * vCx;
+    }
+
+    player->unk1e6c = player->unk1e6c - 1;
+    if (player->unk1e6c < 0) {
+        rdVector_Normalize3Acc((rdVector3*) &player->transform.vA);
+        rdVector_Normalize3Acc((rdVector3*) &player->transform.vB);
+        rdVector_Normalize3Acc((rdVector3*) &player->transform.vC);
+        player->unk1e6c = 8;
+    }
+    player->transform.vD.x = pos->x;
+    player->transform.vD.y = pos->y;
+    player->transform.vD.z = pos->z;
 }
 
 // 0x004783e0

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -12,6 +12,7 @@
 #include <General/utils.h>
 #include <Primitives/rdVector.h>
 #include <Primitives/rdMatrix.h>
+#include <Unknown/rdMatrixStack.h>
 
 // 0x00401340
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4)
@@ -205,7 +206,7 @@ float swrRace_InitUnk(swrModel_Node* model, float* ray, rdVector3* outHit, rdVec
         swrModel_meshCollisionFaceCallbackIndexed = swrModel_MeshCollisionFaceCallbackIndexed;
         swrModel_collisionUnkE70 = 0;
         swrModel_collisionUnk250 = 0;
-        swrRace_ResetMatrixStack();
+        rdMatrixStack44_Init();
         swrModel_CollideNodeRecursiveRay((swrModel_NodeTransformed*) model, ray, 0);
         if (swrModel_collisionResultDist <= ray[6]) {
             outHit->x = swrModel_collisionHitPoint.x;
@@ -221,29 +222,6 @@ float swrRace_InitUnk(swrModel_Node* model, float* ray, rdVector3* outHit, rdVec
     if (swrModel_collisionResultNode != NULL)
         swrRace_collisionHitNode = swrModel_collisionResultNode;
     return swrModel_collisionResultDist;
-}
-
-// Resets the collision-query matrix stack to a single identity matrix.
-// 0x00445150
-void swrRace_ResetMatrixStack(void)
-{
-    rdMatrixStack44_size = 0;
-    rdMatrixStack44[0].vA.x = 1.0;
-    rdMatrixStack44[0].vA.y = 0.0;
-    rdMatrixStack44[0].vA.z = 0.0;
-    rdMatrixStack44[0].vA.w = 0.0;
-    rdMatrixStack44[0].vB.x = 0.0;
-    rdMatrixStack44[0].vB.y = 1.0;
-    rdMatrixStack44[0].vB.z = 0.0;
-    rdMatrixStack44[0].vB.w = 0.0;
-    rdMatrixStack44[0].vC.x = 0.0;
-    rdMatrixStack44[0].vC.y = 0.0;
-    rdMatrixStack44[0].vC.z = 1.0;
-    rdMatrixStack44[0].vC.w = 0.0;
-    rdMatrixStack44[0].vD.x = 0.0;
-    rdMatrixStack44[0].vD.y = 0.0;
-    rdMatrixStack44[0].vD.z = 0.0;
-    rdMatrixStack44[0].vD.w = 1.0;
 }
 
 // Clears the collision-query "hit node" result before a ray query (the query latches it on hit).
@@ -1216,7 +1194,7 @@ void swrRace_ApplyGravity(swrRace* player, float* a, float b)
 // swrRace_slopeAngle. Bails near-flat / near-inverted surfaces (dot(normal, worldDown) outside
 // [-0.995, 0.995]); out1 is scratch for the gradient, out2 the integrated slide.
 // 0x004791d0
-void swrRace_ApplySlopeSteering(swrRace* player, int param_2, int param_3, float param_4,
+void swrRace_ApplySlopeSteering(swrRace* player, int velocity, int scrapeData, float groundDist,
                                 rdVector3* normal, rdVector3* out1, rdVector3* out2)
 {
     rdVector3 downhillAxis;
@@ -1242,8 +1220,8 @@ void swrRace_ApplySlopeSteering(swrRace* player, int param_2, int param_3, float
     swrRace_slopeAngle = stdMath_ArcSin(slopeSin);
 
     float steerMag;
-    if (param_4 <= 50.0f)
-        steerMag = (1.0f - param_4 * 0.02f) * slopeSin;
+    if (groundDist <= 50.0f)
+        steerMag = (1.0f - groundDist * 0.02f) * slopeSin;
     else
         steerMag = 0.0;
 
@@ -1299,9 +1277,9 @@ void swrRace_ApplySlopeSteering(swrRace* player, int param_2, int param_3, float
 // surface velocitySlope build as the normal version but with a much stronger, speed-tiered steer term,
 // and the auto-tilt (unk8_1) aligns the pod's facing to the downhill direction. Same near-flat /
 // near-inverted bail. NOTE: the [-0.995, 0.995] gate + the speed tiers are the limits a "banking magnet"
-// corkscrew mode would relax. param_2/param_3/param_4 are unused here (kept for signature parity).
+// corkscrew mode would relax. velocity/scrapeData/groundDist are unused here (kept for signature parity).
 // 0x00479550
-void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int param_2, int param_3, float param_4,
+void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeData, float groundDist,
                                       rdVector3* normal, rdVector3* out1, rdVector3* out2)
 {
     rdVector3 downhillAxis;
@@ -1389,10 +1367,10 @@ void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int param_2, int param_3,
 // Casts a ray "down" (world unk194_vec, or -unk160 in magnet mode, started 2 units up) to find the
 // ground. Tries the fast mesh ray (CollideRayWithMesh) then the full query (InitUnk); in magnet mode,
 // retries once straight down (world gravity) if the surface-relative cast missed. Writes the surface
-// normal to param_3 (world-up on a miss) and the hit node to player->terrainModel. Returns the ground
+// normal to outSurfaceNormal (world-up on a miss) and the hit node to player->terrainModel. Returns the ground
 // distance minus a 2-unit skin, or a large value (100000) when nothing was hit.
 // 0x004772f0
-float swrRace_RaycastGround(swrRace* player, rdVector3* param_2, int* param_3)
+float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNormal)
 {
     rdVector3 down;
     rdVector3 origin;
@@ -1408,7 +1386,7 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* param_2, int* param_3)
         down.y = -player->unk160.y;
         down.z = -player->unk160.z;
     }
-    rdVector_Scale3Add3(&origin, param_2, -2.0f, &down);
+    rdVector_Scale3Add3(&origin, pos, -2.0f, &down);
     ray[0] = origin.x;
     ray[1] = origin.y;
     ray[2] = origin.z;
@@ -1438,16 +1416,16 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* param_2, int* param_3)
     player->terrainModel = swrRace_GetCollisionHit();
 
     if (hitDist < 0.0) {
-        ((float*) param_3)[0] = 0.0;
-        ((float*) param_3)[1] = 0.0;
-        ((float*) param_3)[2] = 1.0;
+        ((float*) outSurfaceNormal)[0] = 0.0;
+        ((float*) outSurfaceNormal)[1] = 0.0;
+        ((float*) outSurfaceNormal)[2] = 1.0;
         player->thrust = -10000.0f;
         return 100000.0f;
     }
 
-    ((float*) param_3)[0] = outNormal.x;
-    ((float*) param_3)[1] = outNormal.y;
-    ((float*) param_3)[2] = outNormal.z;
+    ((float*) outSurfaceNormal)[0] = outNormal.x;
+    ((float*) outSurfaceNormal)[1] = outNormal.y;
+    ((float*) outSurfaceNormal)[2] = outNormal.z;
     player->thrust = outPoint.z;
     return hitDist - 2.0f;
 }
@@ -1459,7 +1437,7 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* param_2, int* param_3)
 // vertical/inverted "magnet" corkscrew would have to lift -- it stops the surface normal from ever
 // pointing sideways-past-vertical or downward.
 // 0x00479e10
-float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int param_3, rdVector3* up, int param_5)
+float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeData, rdVector3* up, int hoverPadState)
 {
     rdVector3 prevPos;
     rdVector3 slopeOut1;
@@ -1506,10 +1484,10 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int param_3,
             ((0.1f < player->gravityMultiplier) || (0.1f < -player->gravityMultiplier) ||
              ((player->flags0 & 0x2000) == 0))) {
             if ((player->flags1 & 0x400) == 0)
-                swrRace_ApplySlopeSteering(player, (int) velocity, param_3, groundDist, up, &slopeOut1,
+                swrRace_ApplySlopeSteering(player, (int) velocity, scrapeData, groundDist, up, &slopeOut1,
                                            &slopeOut2);
             else
-                swrRace_ApplySlopeSteeringMagnet(player, (int) velocity, param_3, groundDist, up,
+                swrRace_ApplySlopeSteeringMagnet(player, (int) velocity, scrapeData, groundDist, up,
                                                  &slopeOut1, &slopeOut2);
         }
 
@@ -1533,7 +1511,7 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int param_3,
                 before.x = velocity[0];
                 before.y = velocity[1];
                 before.z = velocity[2];
-                swrRace_DetectWallScrape(player, velocity, (float*) param_3);
+                swrRace_DetectWallScrape(player, velocity, (float*) scrapeData);
                 wallDelta.x = player->unk154_vec.x + (velocity[0] - before.x);
                 wallDelta.y = player->unk154_vec.y + (velocity[1] - before.y);
                 wallDelta.z = player->unk154_vec.z + (velocity[2] - before.z);
@@ -1549,7 +1527,7 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int param_3,
                 pad += 0x10;
             }
         } else {
-            groundDist = swrRace_UpdateHoverPads(player, (rdVector3*) velocity, *(int*) (param_5 + 8),
+            groundDist = swrRace_UpdateHoverPads(player, (rdVector3*) velocity, *(int*) (hoverPadState + 8),
                                                  groundDist, &up->x);
         }
     } else {
@@ -1669,6 +1647,8 @@ void swrRace_AlignToSurface(swrRace* player, rdVector3* up, rdVector3* fwd_vB, r
 
     pRDot->y = headingDelta + pRDot->y;
     pRDot->z = tiltDelta + pRDot->z;
+}
+
 // Walk a model-node tree gathering up to 10 distinct mesh-group entries (deduped by
 // their data pointer) into the swrRace_meshNodeCollection scratch list.
 // 0x0046e750
@@ -2376,4 +2356,28 @@ void swrRace_IncrementFrameTimer(void)
     swrRace_fdeltaTimeSecs = (float)swrRace_deltaTimeSecs;
     timetotal = timetotal + swrRace_deltaTimeSecs;
     frametotal = frametotal + 1;
+}
+
+// 0x0044abc0
+int swrRace_CollideBlockMove(rdVector3* curPos, rdVector3* prevPos, swrModel_Node* model, rdVector3* outNormal)
+{
+    HANG("TODO");
+}
+
+// 0x00477940
+void swrRace_DetectWallScrape(swrRace* player, float* velocity, float* scrapeOut)
+{
+    HANG("TODO");
+}
+
+// 0x00479920
+void swrRace_ApplyWallCollision(swrRace* player, rdVector3* normal, rdVector3* dir)
+{
+    HANG("TODO");
+}
+
+// 0x00476740
+float swrRace_UpdateHoverPads(swrRace* player, rdVector3* pos, int padFlags, float groundDist, float* up)
+{
+    HANG("TODO");
 }

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -58,7 +58,6 @@
 #define swrRace_ResetCollisionHit_ADDR (0x00441020)
 #define swrRace_GetCollisionHit_ADDR (0x00441030)
 #define swrRace_InitUnk_ADDR (0x00444d10)
-#define swrRace_ResetMatrixStack_ADDR (0x00445150)
 
 #define swrRace_ComputeStatBars_ADDR (0x00449330)
 
@@ -265,8 +264,6 @@ void swrRace_BuyPitdroidsMenu(swrObjHang* hang);
 float swrRace_InitUnk(swrModel_Node* model, float* ray, rdVector3* outHit, rdVector3* outNormal);
 void swrRace_ResetCollisionHit(void);
 swrModel_Node* swrRace_GetCollisionHit(void);
-// Resets the collision-query matrix stack to a single identity matrix.
-void swrRace_ResetMatrixStack(void);
 
 void swrRace_ComputeStatBars(PodHandlingData* out_stats, PodHandlingData* stats);
 
@@ -337,7 +334,7 @@ void swrRace_CalcTargetTurnRate(swrRace* player);
 void swrRace_UpdateSpinoutNodes(swrRace* player);
 // Ground-contact / vertical-motion integrator: applies gravity, follows terrain
 // and the track spline for hover height, sets groundToPodMeasure (also returned).
-float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int param_3, rdVector3* up, int param_5);
+float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeData, rdVector3* up, int hoverPadState);
 
 // swrObjTest_F3 per-frame model/effects pipeline:
 // Resets the pod model-node visibility flags each frame.
@@ -407,13 +404,13 @@ void swrRace_UpdateCatchup(swrRace* player);
 // Spawns the explosion effect (type-8 Smok) and destruction sounds for the pod.
 void swrRace_SpawnExplosionEffect(swrRace* player);
 // Raycasts the terrain collision mesh; sets terrainModel (0x140) and ground height, returns distance.
-float swrRace_RaycastGround(swrRace* player, rdVector3* param_2, int* param_3);
+float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNormal);
 // Samples the 4 hover-pad ground heights and builds the shadow transforms (0x1290); returns hover height.
-float swrRace_UpdateHoverPads(swrRace* player, rdVector3* param_2, int param_3, float param_4, float* param_5);
+float swrRace_UpdateHoverPads(swrRace* player, rdVector3* pos, int padFlags, float groundDist, float* up);
 // Slope steering: turns the pod along the ground slope (sets 0x1f8) and slope velocity (0x1c4).
-void swrRace_ApplySlopeSteering(swrRace* player, int param_2, int param_3, float param_4, rdVector3* normal, rdVector3* out1, rdVector3* out2);
+void swrRace_ApplySlopeSteering(swrRace* player, int velocity, int scrapeData, float groundDist, rdVector3* normal, rdVector3* out1, rdVector3* out2);
 // Magnet/tube variant of slope steering (flags1 0x400).
-void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int param_2, int param_3, float param_4, rdVector3* normal, rdVector3* out1, rdVector3* out2);
+void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeData, float groundDist, rdVector3* normal, rdVector3* out1, rdVector3* out2);
 // Wall collision response: reflects velocity off the wall normal into velocityCollision and dispatches hit/scrape events.
 void swrRace_ApplyWallCollision(swrRace* player, rdVector3* normal, rdVector3* dir);
 
@@ -427,7 +424,7 @@ void swrRace_HandleDeathExplosion(swrRace* player);
 // Builds a scrape spray/spark billboard transform on an engine slot.
 void swrRace_SetupScrapeSpray(swrRace* player, float scale, int param_3, int param_4, int param_5, float side);
 // Raycasts sideways for nearby walls and spawns scrape spray on contact.
-void swrRace_DetectWallScrape(swrRace* player, float* param_2, float* param_3);
+void swrRace_DetectWallScrape(swrRace* player, float* velocity, float* scrapeOut);
 // Computes the collisionToggles bitmask (0x26c) from the pod's position.
 void swrRace_UpdateCollisionToggles(swrRace* player);
 

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -54,7 +54,11 @@
 
 #define swrRace_BuyPitdroidsMenu_ADDR (0x0043f380)
 
+// ray-collision query: reset/read the global hit-node result (set by the query during traversal)
+#define swrRace_ResetCollisionHit_ADDR (0x00441020)
+#define swrRace_GetCollisionHit_ADDR (0x00441030)
 #define swrRace_InitUnk_ADDR (0x00444d10)
+#define swrRace_ResetMatrixStack_ADDR (0x00445150)
 
 #define swrRace_ApplyStatsMultipliers_ADDR (0x00449330)
 
@@ -86,6 +90,9 @@
 #define swrRace_BoostCharge_ADDR (0x0046bd20)
 
 #define swrRace_CalculateTiltFromTurn_ADDR (0x00477ad0)
+// tilt/orientation alignment helpers (feed CalculateTiltFromTurn)
+#define swrRace_ComputeTiltAngles_ADDR (0x00476390)
+#define swrRace_AlignToSurface_ADDR (0x004764e0)
 
 #define swrRace_TakeDamage_ADDR (0x00474cd0)
 
@@ -94,13 +101,16 @@
 
 #define swrRace_ApplyGravity_ADDR (0x004774f0)
 
-#define swrRace_UpdateTurn2_ADDR (0x00477c27)
+// 0x00477c27 was a bogus {return;} mis-identification (no xrefs); the real per-frame orientation
+// integrator the name refers to is at 0x00477c30 (called by swrObjTest_SuperUnk).
+#define swrRace_UpdateTurn2_ADDR (0x00477c30)
 
 #define swrRace_UpdateSpeed_ADDR (0x004783e0)
 #define swrRace_ApplyBoost_ADDR (0x004787f0)
 #define swrRace_UpdateHeat_ADDR (0x004788c0)
 #define swrRace_ApplyTraction_ADDR (0x00478a70)
 #define swrRace_MainSpeed_ADDR (0x00478d80)
+#define swrRace_CollideBlockMove_ADDR (0x0044abc0)
 #define swrRace_CollideTrack_ADDR (0x0044acb0)
 
 #define swrRace_DeathSpeed_ADDR (0x0047b000)
@@ -250,7 +260,12 @@ void swrRace_GenerateDefaultDataSAV(int user_tgfd, int slot);
 
 void swrRace_BuyPitdroidsMenu(swrObjHang* hang);
 
-float swrRace_InitUnk(int a, float b, float c, int* d);
+// ray = {origin.xyz, dir.xyz, maxDist}; returns hit distance (<0 = miss), fills outHit/outNormal.
+float swrRace_InitUnk(swrModel_Node* model, float* ray, rdVector3* outHit, rdVector3* outNormal);
+void swrRace_ResetCollisionHit(void);
+swrModel_Node* swrRace_GetCollisionHit(void);
+// Resets the collision-query matrix stack to a single identity matrix.
+void swrRace_ResetMatrixStack(void);
 
 void swrRace_ApplyStatsMultipliers(PodHandlingData* out_stats, PodHandlingData* stats);
 
@@ -289,8 +304,14 @@ void swrRace_ApplyGravity(swrRace* player, float* a, float b);
 int swrRace_BoostCharge(int player);
 
 void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotion, rdVector3* pRDot);
+// Extracts pitch + signed-roll angles of a forward/right basis relative to a reference (down) vector.
+void swrRace_ComputeTiltAngles(rdVector3* fwd, rdVector3* right, rdVector3* ref, rdVector3* out);
+// Builds a surface-aligned basis from the pod forward + surface normal and accumulates the heading/tilt
+// correction into pRDot (turn input). The +-85 deg pitch clamp + the magnet (flags1 0x400) gating live here.
+void swrRace_AlignToSurface(swrRace* player, rdVector3* up, rdVector3* fwd_vB, rdVector3* vA_fallback,
+                            rdVector3* down_ref, float groundDist, float hoverHi, float hoverLo, rdVector3* pRDot);
 
-void swrRace_UpdateTurn2(int player, int a, int b, int c);
+void swrRace_UpdateTurn2(swrRace* player, rdVector3* pos, rdVector3* turnInput);
 
 float swrRace_UpdateSpeed(swrRace* player);
 float swrRace_ApplyBoost(swrRace* player);
@@ -301,6 +322,8 @@ void swrRace_MainSpeed(swrRace* player, rdVector3* b, rdVector3* c, rdVector3* d
 // One iteration of swept track collision: tests the segment prevPos->curPos against the
 // collision model, and on a hit pushes curPos back out along the surface normal (also
 // written to outNormal). Returns nonzero when it resolved a collision. (was FUN_0044acb0)
+// Collision step that BLOCKS the move (snaps curPos back to prevPos) on hit, vs CollideTrack which pushes out.
+int swrRace_CollideBlockMove(rdVector3* curPos, rdVector3* prevPos, swrModel_Node* model, rdVector3* outNormal);
 int swrRace_CollideTrack(rdVector3* curPos, rdVector3* prevPos, swrModel_Node* model, rdVector3* outNormal);
 
 void swrRace_DeathSpeed(swrRace* player, float a, float b);

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -76,3 +76,9 @@ char* swrSpline_LoadSplineById(char* splineBuffer)
     swrSpline_LoadSpline((int)splineBuffer, (unsigned short**)&splineBuffer);
     return splineBuffer;
 }
+
+// 0x0044eeb0
+void swrSpline_EvaluateAtOffset(void* cursor, rdMatrix44* out, float t)
+{
+    HANG("TODO");
+}


### PR DESCRIPTION
Reimplements the pod orientation / surface / ground-contact pipeline in `swrRace` (the chain `swrObjTest_F2` runs each frame to keep the pod sitting on and aligned to the track):

- **`swrRace_InitUnk`** -> sets up and runs a ray-vs-collision-mesh query (was a stub).
- **`swrRace_ResetCollisionHit` / `swrRace_GetCollisionHit`** -> the hit-node result accessors.
- **`swrRace_RaycastGround`** -> casts "down" (surface-relative in magnet mode, with a straight-down retry) to find the ground; returns the contact distance + surface normal.
- **`swrRace_UpdateGroundContact`** -> the orchestrator: raycast, store the surface "up", slope-steer, gravity, track/wall collision, hover pads.
- **`swrRace_ApplySlopeSteering` / `...Magnet`** -> steer the pod along the ground slope; the magnet variant keeps it glued to a tagged surface.
- **`swrRace_ComputeTiltAngles` / `swrRace_AlignToSurface`** -> pitch/bank of the pod basis vs the surface, eased into the heading/tilt rates.
- **`swrRace_UpdateTurn2`** -> the per-frame orientation integrator (was a stub).

Names the collision-query globals it uses (`swrModel_collision*`, `swrRace_slopeAngle`, etc.).

Notes:
- These are reverse-hook reimpls (dormant; validated by compile + disasm), built on current master.
- The 9 not-yet-reimplemented callees (`swrModel_Collide*`, `swrSpline_EvaluateAtOffset`, `swrRace_{CollideBlockMove,DetectWallScrape,ApplyWallCollision,UpdateHoverPads}`) get HANG stubs so the dll still links.
- Full build links clean; duplicate-`_ADDR` scan clean (this caught + removed a `swrRace_ResetMatrixStack` that duplicated the canonical `rdMatrixStack44_Init`).
- Happy to match your DB names on anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
