### PR TITLE
swrRace: name pod orientation fields (world_gravity / autoTilt / up) per #110 review

### DIFF
--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1097,15 +1097,15 @@ void swrRace_ApplyGravity(swrRace* player, float* a, float b)
     uint32_t flags1 = player->flags1;
     if ((flags1 & 0x400) == 0)
     {
-        gx = player->unk194_vec.x;
-        gy = player->unk194_vec.y;
-        gz = player->unk194_vec.z;
+        gx = player->world_gravity.x;
+        gy = player->world_gravity.y;
+        gz = player->world_gravity.z;
     }
     else
     {
-        gx = -player->unk160.x;
-        gy = -player->unk160.y;
-        gz = -player->unk160.z;
+        gx = -player->up.x;
+        gy = -player->up.y;
+        gz = -player->up.z;
     }
 
     // Distance to the hover plane, corrected for the pod's roll.
@@ -1188,9 +1188,9 @@ void swrRace_ApplyGravity(swrRace* player, float* a, float b)
     a[2] += player->fallRate * gz;
 }
 
-// Normal-mode slope steering (no magnet). Projects world gravity (unk194_vec) onto the surface plane
+// Normal-mode slope steering (no magnet). Projects world gravity (world_gravity) onto the surface plane
 // to accumulate the downhill slide into velocitySlope (force quadratic in the steer term), and drives
-// unk8_1 (auto-tilt) from the downhill/facing alignment. Also publishes the slope angle to
+// autoTilt (auto-tilt) from the downhill/facing alignment. Also publishes the slope angle to
 // swrRace_slopeAngle. Bails near-flat / near-inverted surfaces (dot(normal, worldDown) outside
 // [-0.995, 0.995]); out1 is scratch for the gradient, out2 the integrated slide.
 // 0x004791d0
@@ -1202,21 +1202,21 @@ void swrRace_ApplySlopeSteering(swrRace* player, int velocity, int scrapeData, f
     rdVector3 surfDir;
     rdVector3 vbFlat;
 
-    float dotND = normal->x * player->unk194_vec.x + normal->y * player->unk194_vec.y +
-                  normal->z * player->unk194_vec.z;
+    float dotND = normal->x * player->world_gravity.x + normal->y * player->world_gravity.y +
+                  normal->z * player->world_gravity.z;
     if ((dotND < -0.995) || (0.995 < dotND)) {
         rdVector_Set3(out1, 0.0, 0.0, 0.0);
         rdVector_Scale3(&player->velocitySlope, 0.9f, &player->velocitySlope);
         rdVector_Copy3(out2, &player->velocitySlope);
-        player->unk8_1 = 0.0;
+        player->autoTilt = 0.0;
         return;
     }
 
-    rdVector_Cross3(&downhillAxis, normal, &player->unk194_vec);
+    rdVector_Cross3(&downhillAxis, normal, &player->world_gravity);
     rdVector_Cross3(out1, normal, &downhillAxis);
     rdVector_Normalize3Acc(out1);// out1 = normalized downhill gradient on the surface
-    float slopeSin = out1->x * player->unk194_vec.x + out1->y * player->unk194_vec.y +
-                     out1->z * player->unk194_vec.z;
+    float slopeSin = out1->x * player->world_gravity.x + out1->y * player->world_gravity.y +
+                     out1->z * player->world_gravity.z;
     swrRace_slopeAngle = stdMath_ArcSin(slopeSin);
 
     float steerMag;
@@ -1267,15 +1267,15 @@ void swrRace_ApplySlopeSteering(swrRace* player, int velocity, int scrapeData, f
 
     if (steerMag + 0.15f < 0.0) {
         float t = (steerMag + 0.15f) * 1.1764705f;
-        player->unk8_1 = t * t * tiltScale * 600.0f;
+        player->autoTilt = t * t * tiltScale * 600.0f;
         return;
     }
-    player->unk8_1 = 0.0;
+    player->autoTilt = 0.0;
 }
 
 // Magnet-mode slope steering (flags1 0x400): keeps the pod glued to a tagged surface. Same gravity-on-
 // surface velocitySlope build as the normal version but with a much stronger, speed-tiered steer term,
-// and the auto-tilt (unk8_1) aligns the pod's facing to the downhill direction. Same near-flat /
+// and the auto-tilt (autoTilt) aligns the pod's facing to the downhill direction. Same near-flat /
 // near-inverted bail. NOTE: the [-0.995, 0.995] gate + the speed tiers are the limits a "banking magnet"
 // corkscrew mode would relax. velocity/scrapeData/groundDist are unused here (kept for signature parity).
 // 0x00479550
@@ -1287,21 +1287,21 @@ void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeD
     rdVector3 surfDir;
     rdVector3 vbFlat;
 
-    float dotND = normal->x * player->unk194_vec.x + normal->y * player->unk194_vec.y +
-                  normal->z * player->unk194_vec.z;
+    float dotND = normal->x * player->world_gravity.x + normal->y * player->world_gravity.y +
+                  normal->z * player->world_gravity.z;
     if ((dotND < -0.995) || (0.995 < dotND)) {
         rdVector_Set3(out1, 0.0, 0.0, 0.0);
         rdVector_Scale3(&player->velocitySlope, 0.9f, &player->velocitySlope);
         rdVector_Copy3(out2, &player->velocitySlope);
-        player->unk8_1 = 0.0;
+        player->autoTilt = 0.0;
         return;
     }
 
-    rdVector_Cross3(&downhillAxis, normal, &player->unk194_vec);
+    rdVector_Cross3(&downhillAxis, normal, &player->world_gravity);
     rdVector_Normalize3Acc(&downhillAxis);
     rdVector_Cross3(out1, normal, &downhillAxis);// out1 = downhill gradient on the surface
-    float slopeSin = out1->x * player->unk194_vec.x + out1->y * player->unk194_vec.y +
-                     out1->z * player->unk194_vec.z;
+    float slopeSin = out1->x * player->world_gravity.x + out1->y * player->world_gravity.y +
+                     out1->z * player->world_gravity.z;
     float slopeAngle = stdMath_ArcSin(slopeSin);
     float steerMag = slopeAngle * -1.1111112f;
 
@@ -1356,15 +1356,15 @@ void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeD
         float a = stdMath_ArcSin(align);
         float side = vbFlat.x * downhillAxis.x + vbFlat.y * downhillAxis.y + vbFlat.z * downhillAxis.z;
         if (side <= 0.0)
-            player->unk8_1 = -(a * slopeSin);
+            player->autoTilt = -(a * slopeSin);
         else
-            player->unk8_1 = -(-a * slopeSin);
+            player->autoTilt = -(-a * slopeSin);
     } else {
-        player->unk8_1 = 0.0;
+        player->autoTilt = 0.0;
     }
 }
 
-// Casts a ray "down" (world unk194_vec, or -unk160 in magnet mode, started 2 units up) to find the
+// Casts a ray "down" (world world_gravity, or -up in magnet mode, started 2 units up) to find the
 // ground. Tries the fast mesh ray (CollideRayWithMesh) then the full query (InitUnk); in magnet mode,
 // retries once straight down (world gravity) if the surface-relative cast missed. Writes the surface
 // normal to outSurfaceNormal (world-up on a miss) and the hit node to player->terrainModel. Returns the ground
@@ -1380,11 +1380,11 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNorm
     float hitDist;
 
     if ((player->flags1 & 0x400) == 0) {
-        down = player->unk194_vec;
+        down = player->world_gravity;
     } else {
-        down.x = -player->unk160.x;
-        down.y = -player->unk160.y;
-        down.z = -player->unk160.z;
+        down.x = -player->up.x;
+        down.y = -player->up.y;
+        down.z = -player->up.z;
     }
     rdVector_Scale3Add3(&origin, pos, -2.0f, &down);
     ray[0] = origin.x;
@@ -1407,9 +1407,9 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNorm
 
     if (((player->flags1 & 0x400) != 0) && (hitDist < 0.0)) {
         // surface-relative cast missed: retry straight down (world gravity)
-        ray[3] = player->unk194_vec.x;
-        ray[4] = player->unk194_vec.y;
-        ray[5] = player->unk194_vec.z;
+        ray[3] = player->world_gravity.x;
+        ray[4] = player->world_gravity.y;
+        ray[5] = player->world_gravity.z;
         hitDist = swrRace_InitUnk(player->model_unk, ray, &outPoint, &outNormal);
     }
 
@@ -1431,7 +1431,7 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNorm
 }
 
 // Per-frame ground-contact orchestrator. Raycasts the ground (RaycastGround) to get the surface
-// normal, stores it as the pod's "up" in unk160, runs slope steering (magnet variant when flags1
+// normal, stores it as the pod's "up" in up, runs slope steering (magnet variant when flags1
 // 0x400 is set), applies gravity, then resolves track/wall collision and hover pads. Returns the
 // ground distance (also cached in groundToPodMeasure). The `up.z < 0.05` floor below is THE limit a
 // vertical/inverted "magnet" corkscrew would have to lift -- it stops the surface normal from ever
@@ -1463,9 +1463,9 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
                 flags1 = flags1 | 0x400000;
         } else {
             groundDist = velocity[2] - player->thrust;
-            up->x = player->unk160.x;
-            up->y = player->unk160.y;
-            up->z = player->unk160.z;
+            up->x = player->up.x;
+            up->y = player->up.y;
+            up->z = player->up.z;
             player->terrainModel = player->unkec_node;
             flags1 = player->flags1 | 0x20000000;
         }
@@ -1476,9 +1476,9 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
             up->z = 0.05f;
             rdVector_Normalize3Acc(up);
         }
-        player->unk160.x = up->x;
-        player->unk160.y = up->y;
-        player->unk160.z = up->z;
+        player->up.x = up->x;
+        player->up.y = up->y;
+        player->up.z = up->z;
 
         if (((player->flags0 & 0x5000) == 0) &&
             ((0.1f < player->gravityMultiplier) || (0.1f < -player->gravityMultiplier) ||
@@ -1788,7 +1788,7 @@ void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotio
         pRDot->z = pRDot->z - player->tiltAngleTarget;
 
     swrRace_AlignToSurface(player, (rdVector3*) pXformZ, (rdVector3*) &player->transform.vB,
-                           (rdVector3*) &player->transform.vA, &player->unk194_vec, ZMotion, hoverHi,
+                           (rdVector3*) &player->transform.vA, &player->world_gravity, ZMotion, hoverHi,
                            hoverLo, pRDot);
 
     // Magnet mode (flags1 0x400) suppresses ALL of the player banking + manual tilt below; only the

--- a/src/types.h
+++ b/src/types.h
@@ -473,7 +473,7 @@ extern "C"
         rdVector3 unk144;
         float speedLoss;
         rdVector3 unk154_vec;
-        rdVector3 unk160; // Down direction ?
+        rdVector3 up; // 0x160. live surface normal the pod treats as "up"; RaycastGround writes the ground/collision normal here each frame (clamped so it can't tip past vertical)
         rdVector3 positionPrev; // 0x16c. Same as 0x2cc position ?
         rdVector3 positionDeath;
         // Shifted by 4 bytes from annodue ?
@@ -481,7 +481,7 @@ extern "C"
         float thrust; // 0x188. default 0.1, 1.0 with thrust, 1.32 thrust nose down, 0.68 thrust nose up
         float gravityMultiplier; // 0x18c
         float unk190; // float, fall related
-        rdVector3 unk194_vec;
+        rdVector3 world_gravity; // 0x194. world gravity / "down" reference direction (gravity acts along this unless the surface-magnet flag swaps in -up)
         float speedValue; // 0x1a0
         float accelThrust; // 0x1a4
         float boostValue; // 0x1a8
@@ -496,7 +496,7 @@ extern "C"
         float turnRate; // 0x1ec
         float turnRateTarget; // 0x1f0
         float turnModifier; // 0x1f4
-        float unk8_1; // 0x1f8
+        float autoTilt; // 0x1f8. slope auto-tilt torque (drives the pod's bank toward the downhill/surface alignment)
         float unk8_11; // 0x1fc
         float tiltAngleTarget; // 0x200
         float tiltAngle; // 0x204


### PR DESCRIPTION
Follow-up to #110 addressing your review comments -- names the three pod orientation/surface fields you flagged:

- `swrRace.unk194_vec` -> `world_gravity` (the world "down" / gravity reference direction)
- `swrRace.unk8_1` -> `autoTilt` (the slope auto-tilt torque)
- `swrRace.unk160` -> `up` (the live surface normal the pod treats as up -- also corrects the stale `// Down direction ?` comment; it's up)

types.h + the swrRace.c usages. Scoped carefully: the unrelated `unk160` on the swrViewport struct and the sibling `unk8_11` field are left untouched. Build links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
