### PR TITLE
swrModel: reimplement the ray-vs-triangle collision math

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -862,11 +862,16 @@ swrRace_dt_raw_d 0x00e22a48 double
 
 swrRace_slopeAngle 0x00e2712c float
 
+swrModel_collisionAcceptBackFaces 0x0050c5cc int # accept faces the ray hits from behind (normal.dir > 0; returned normal is flipped)
+swrModel_collisionAcceptFrontFaces 0x004c1774 int # accept faces the ray hits head-on (normal.dir <= 0)
 swrRace_collisionHitNode 0x0050c5d0 swrModel_Node*
 
 swrModel_collisionUnk250 0x00e98250 int
 swrModel_collisionResultNode 0x00e98254 swrModel_Node*
 swrModel_collisionResultDist 0x00e98258 float
+swrModel_collisionRayBBoxMax 0x00e98260 rdVector3
+swrModel_collisionRayBBoxMin 0x00e98270 rdVector3
+swrModel_collisionCurrentMesh 0x00e98284 swrModel_Mesh*
 swrModel_collisionHitNormal 0x00e98290 rdVector3
 swrModel_collisionUnkE1c 0x00e98e1c int
 swrModel_collisionRayOrigin 0x00e98e40 rdVector3

--- a/src/Primitives/rdMath.c
+++ b/src/Primitives/rdMath.c
@@ -5,24 +5,24 @@
 #include <macros.h>
 #include <General/stdMath.h>
 
-// What is this then ?
+// Plane of triangle a,b,c: out->xyz = normalize(cross(b-a, c-b)), out->w = dot(normal, a)
+// (the plane offset, since a lies on the plane). Used by the ray-vs-mesh face callbacks.
 // 0x004314f0
-// void rdMath_CalcSurfaceNormal2(rdVector4* out, rdVector3* edge1, rdVector3* edge2, rdVector3* edge3)
-// {
-//     rdVector3 tmp1;
-//     rdVector3 tmp2;
+void rdMath_CalcSurfaceNormal2(rdVector4* out, rdVector3* a, rdVector3* b, rdVector3* c)
+{
+    rdVector3 ab;
+    rdVector3 bc;
 
-//     tmp1.x = edge2->x - edge1->x;
-//     tmp2.x = edge3->x - edge2->x;
-//     tmp2.y = edge3->y - edge2->y;
-//     tmp2.z = edge3->z - edge2->z;
-//     tmp1.y = edge2->y - edge1->y;
-//     tmp1.z = edge2->z - edge1->z;
-//     rdVector_Cross3((rdVector3*)out, &tmp1, &tmp2);
-//     rdVector_Normalize3Acc((rdVector3*)out);
-//     out->w = edge1->x * out->x + out->y * edge1->y + out->z * edge1->z;
-//     return;
-// }
+    ab.x = b->x - a->x;
+    ab.y = b->y - a->y;
+    ab.z = b->z - a->z;
+    bc.x = c->x - b->x;
+    bc.y = c->y - b->y;
+    bc.z = c->z - b->z;
+    rdVector_Cross3((rdVector3*) out, &ab, &bc);
+    rdVector_Normalize3Acc((rdVector3*) out);
+    out->w = a->x * out->x + a->y * out->y + a->z * out->z;
+}
 
 // 0x0048eb60
 void rdMath_CalcSurfaceNormal(rdVector3* out, rdVector3* edge1, rdVector3* edge2, rdVector3* edge3)

--- a/src/Primitives/rdMath.h
+++ b/src/Primitives/rdMath.h
@@ -3,8 +3,7 @@
 
 #include "types.h"
 
-// What is this ?
-// #define rdMath_CalcSurfaceNormal2_ADDR (0x004314f0)
+#define rdMath_CalcSurfaceNormal2_ADDR (0x004314f0)
 
 #define rdMath_CalcSurfaceNormal_ADDR (0x0048eb60)
 #define rdMath_DistancePointToPlane_ADDR (0x0048ec50)
@@ -14,7 +13,8 @@
 #define rdMath_QuaternionToAxisAngle_ADDR (0x00481520)
 #define rdMath_AxisAngleToQuaternion_ADDR (0x00481620)
 
-// void rdMath_CalcSurfaceNormal2(rdVector4* out, rdVector3* edge1, rdVector3* edge2, rdVector3* edge3);
+// Plane (normal + offset) of triangle a,b,c: out->xyz = normalize(cross(b-a, c-b)), out->w = dot(normal, a).
+void rdMath_CalcSurfaceNormal2(rdVector4* out, rdVector3* a, rdVector3* b, rdVector3* c);
 
 void rdMath_CalcSurfaceNormal(rdVector3* out, rdVector3* edge1, rdVector3* edge2, rdVector3* edge3);
 float rdMath_DistancePointToPlane(rdVector3* light, rdVector3* normal, rdVector3* vertex);

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -7,6 +7,7 @@
 #include <macros.h>
 #include <Primitives/rdMath.h>
 #include <Primitives/rdMatrix.h>
+#include <Primitives/rdVector.h>
 #include <math.h> // fabs
 
 // 0x00408e60
@@ -1465,16 +1466,201 @@ void swrModel_LoadPuppet(MODELID model, INGAME_MODELID index, int a3, float a4)
     HANG("TODO");
 }
 
+// 0x00441040
+// Is the plane-hit point inside triangle a,b,c? Tests that the three edge-cross products
+// (hitPoint->vertex x edge) agree in sign on their dominant axis. Quirk preserved from the asm:
+// the dominant component is read signed for X/Y but absolute for Z (the original abs's n.z in
+// place), so a Z-dominant axis always takes the ">= 0" branch.
+int swrModel_PointInTriangle(float* origin, float* a, float* b, float* c,
+                             rdVector3* edgeAB, rdVector3* edgeBC, rdVector3* edgeCA)
+{
+    rdVector3 toA, toB, toC, faceN, n0, n1, n2;
+
+    toA.x = a[0] - origin[0]; toA.y = a[1] - origin[1]; toA.z = a[2] - origin[2];
+    toB.x = b[0] - origin[0]; toB.y = b[1] - origin[1]; toB.z = b[2] - origin[2];
+    toC.x = c[0] - origin[0]; toC.y = c[1] - origin[1]; toC.z = c[2] - origin[2];
+
+    rdVector_Cross3(&faceN, edgeAB, edgeBC);
+    if (faceN.x == 0.0f && faceN.y == 0.0f && faceN.z == 0.0f)
+        return 0;
+
+    rdVector_Cross3(&n0, &toA, edgeAB);
+    rdVector_Cross3(&n1, &toB, edgeBC);
+    rdVector_Cross3(&n2, &toC, edgeCA);
+
+    float ax = (n0.x < 0.0f) ? -n0.x : n0.x;
+    float ay = (n0.y < 0.0f) ? -n0.y : n0.y;
+    if (n0.z < 0.0f) n0.z = -n0.z; // abs in place (matches the asm); n0.x/n0.y stay signed
+    float az = n0.z;
+
+    if (az + ay + ax <= 0.0001f) {
+        // n0 ~ 0 (hit near vertex a): decide from n1's dominant axis against n2
+        ax = (n1.x < 0.0f) ? -n1.x : n1.x;
+        ay = (n1.y < 0.0f) ? -n1.y : n1.y;
+        if (n1.z < 0.0f) n1.z = -n1.z;
+        az = n1.z;
+        if (az + ay + ax < 0.001f)
+            return 1;
+        int axis = (ay <= ax) ? ((az <= ax) ? 0 : 2) : ((az <= ay) ? 1 : 2);
+        if (0.0f <= (&n1.x)[axis]) {
+            if (0.0f <= (&n2.x)[axis]) return 1;
+        } else {
+            if ((&n2.x)[axis] <= 0.0f) return 1;
+        }
+    } else {
+        int axis = (ay <= ax) ? ((az <= ax) ? 0 : 2) : ((az <= ay) ? 1 : 2);
+        if (0.0f <= (&n0.x)[axis]) {
+            if (0.0f <= (&n1.x)[axis] && 0.0f <= (&n2.x)[axis]) return 1;
+        } else {
+            if ((&n1.x)[axis] <= 0.0f && (&n2.x)[axis] <= 0.0f) return 1;
+        }
+    }
+    return 0;
+}
+
+// 0x00442470
+// Ray-plane intersection. plane = {normal.xyz, offset}; ray = {origin[3], dir[3], maxDist}.
+// Returns the hit distance t (and writes the point to outPoint), or -1 on a miss: ray parallel
+// to the plane (|normal.dir| < 1e-4), behind the origin, or past maxDist.
+float IntersectRayPlane(float* plane, float* ray, rdVector3* outPoint)
+{
+    float denom = plane[0] * ray[3] + plane[1] * ray[4] + plane[2] * ray[5];
+    if (denom >= -0.0001 && denom <= 0.0001)
+        return -1.0f;
+    float t = (plane[3] - (plane[0] * ray[0] + plane[1] * ray[1] + plane[2] * ray[2])) / denom;
+    if (t < 0.0f)
+        return -1.0f;
+    if (ray[6] < t)
+        return -1.0f;
+    outPoint->x = ray[0] + t * ray[3];
+    outPoint->y = ray[1] + t * ray[4];
+    outPoint->z = ray[2] + t * ray[5];
+    return t;
+}
+
+// 0x00442550
+// Tests one triangle (plane + verts a,b,c) against the active ray; on a closer in-triangle hit,
+// records distance/point/node/normal into the swrModel_collision* result globals. Honours the
+// front/back accept flags (a back-face hit flips the recorded normal to oppose the ray).
+void swrModel_CollideRayTriangle(float* plane, float* a, float* b, float* c, float* ray)
+{
+    float facing = plane[0] * ray[3] + plane[1] * ray[4] + plane[2] * ray[5];
+    int backFace;
+    if (facing <= 0.0f) {
+        if (swrModel_collisionAcceptFrontFaces == 0)
+            return;
+        backFace = 0;
+    } else {
+        if (swrModel_collisionAcceptBackFaces == 0)
+            return;
+        backFace = 1;
+    }
+
+    rdVector3 hit;
+    float t = IntersectRayPlane(plane, ray, &hit);
+    if (t < 0.0f || swrModel_collisionResultDist <= t)
+        return;
+
+    rdVector3 edgeAB, edgeBC, edgeCA;
+    edgeAB.x = b[0] - a[0]; edgeAB.y = b[1] - a[1]; edgeAB.z = b[2] - a[2];
+    edgeBC.x = c[0] - b[0]; edgeBC.y = c[1] - b[1]; edgeBC.z = c[2] - b[2];
+    edgeCA.x = a[0] - c[0]; edgeCA.y = a[1] - c[1]; edgeCA.z = a[2] - c[2];
+
+    if (swrModel_PointInTriangle(&hit.x, a, b, c, &edgeAB, &edgeBC, &edgeCA)) {
+        swrModel_collisionResultDist = t;
+        swrModel_collisionHitPoint = hit;
+        swrModel_collisionUnk250 = 1;
+        swrModel_collisionResultNode = (swrModel_Node*) swrModel_collisionCurrentMesh;
+        if (backFace) {
+            swrModel_collisionHitNormal.x = -plane[0];
+            swrModel_collisionHitNormal.y = -plane[1];
+            swrModel_collisionHitNormal.z = -plane[2];
+        } else {
+            swrModel_collisionHitNormal.x = plane[0];
+            swrModel_collisionHitNormal.y = plane[1];
+            swrModel_collisionHitNormal.z = plane[2];
+        }
+    }
+}
+
+// Does any of `count` verts straddle the ray's bounding box on every axis? (broad-phase cull
+// shared by the two face callbacks below).
+static int faceBBoxOverlapsRay(const rdVector3* verts, int count)
+{
+    const float* mn = &swrModel_collisionRayBBoxMin.x;
+    const float* mx = &swrModel_collisionRayBBoxMax.x;
+    for (int axis = 0; axis < 3; axis++) {
+        int aboveMin = 0, belowMax = 0;
+        for (int i = 0; i < count; i++) {
+            float coord = (&verts[i].x)[axis];
+            if (mn[axis] <= coord) aboveMin = 1;
+            if (coord <= mx[axis]) belowMax = 1;
+        }
+        if (!aboveMin || !belowMax)
+            return 0;
+    }
+    return 1;
+}
+
 // 0x00442720
+// Per-face hook for indexed primitives: gathers the 3/4 verts via the index list, broad-phase
+// culls against the ray bbox, then ray-tests each triangle (a quad is split into two).
 void swrModel_MeshCollisionFaceCallbackIndexed(swrModel_CollisionVertex* vertices, int16_t primitive_type, uint16_t* indices)
 {
-    HANG("TODO");
+    rdVector3 v[4];
+    rdVector4 plane;
+    float* ray = (float*) &swrModel_collisionRayOrigin;
+    int n = (primitive_type == 2) ? 4 : 3;
+    for (int i = 0; i < n; i++) {
+        swrModel_CollisionVertex* vp = &vertices[indices[i]];
+        v[i].x = (float) vp->x;
+        v[i].y = (float) vp->y;
+        v[i].z = (float) vp->z;
+    }
+    if (!faceBBoxOverlapsRay(v, n))
+        return;
+    if (primitive_type == 2) {
+        rdMath_CalcSurfaceNormal2(&plane, &v[0], &v[1], &v[3]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[0].x, &v[1].x, &v[3].x, ray);
+        rdMath_CalcSurfaceNormal2(&plane, &v[1], &v[2], &v[3]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[1].x, &v[2].x, &v[3].x, ray);
+    } else if (primitive_type == 1) {
+        rdMath_CalcSurfaceNormal2(&plane, &v[0], &v[2], &v[1]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[0].x, &v[2].x, &v[1].x, ray);
+    } else {
+        rdMath_CalcSurfaceNormal2(&plane, &v[0], &v[1], &v[2]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[0].x, &v[1].x, &v[2].x, ray);
+    }
 }
 
 // 0x00442C30
+// Per-face hook for non-indexed primitives (verts are sequential). Same broad-phase cull + per-
+// triangle ray test as the indexed variant.
 void swrModel_MeshCollisionFaceCallback(swrModel_CollisionVertex* vertices, int16_t primitive_type)
 {
-    HANG("TODO");
+    rdVector3 v[4];
+    rdVector4 plane;
+    float* ray = (float*) &swrModel_collisionRayOrigin;
+    int n = (primitive_type == 2) ? 4 : 3;
+    for (int i = 0; i < n; i++) {
+        v[i].x = (float) vertices[i].x;
+        v[i].y = (float) vertices[i].y;
+        v[i].z = (float) vertices[i].z;
+    }
+    if (!faceBBoxOverlapsRay(v, n))
+        return;
+    if (primitive_type == 2) {
+        rdMath_CalcSurfaceNormal2(&plane, &v[0], &v[1], &v[3]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[0].x, &v[1].x, &v[3].x, ray);
+        rdMath_CalcSurfaceNormal2(&plane, &v[1], &v[2], &v[3]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[1].x, &v[2].x, &v[3].x, ray);
+    } else if (primitive_type == 1) {
+        rdMath_CalcSurfaceNormal2(&plane, &v[0], &v[2], &v[1]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[0].x, &v[2].x, &v[1].x, ray);
+    } else {
+        rdMath_CalcSurfaceNormal2(&plane, &v[0], &v[1], &v[2]);
+        swrModel_CollideRayTriangle((float*) &plane, &v[0].x, &v[1].x, &v[2].x, ray);
+    }
 }
 
 // 0x00444bf0

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -83,6 +83,7 @@
 #define swrModel_TestTriangleEdges_ADDR (0x004414e0)
 #define swrModel_ClipAndTestTriangle_ADDR (0x00441810)
 #define swrModel_CollideSphereTriangle_ADDR (0x00442090)
+#define IntersectRayPlane_ADDR (0x00442470)
 #define swrModel_CollideRayTriangle_ADDR (0x00442550)
 
 #define swrModel_MeshCollisionFaceCallbackIndexed_ADDR (0x00442720)
@@ -252,7 +253,9 @@ void swrModel_RecordClosestHit(float distSq, float* point, float* hitPoint, floa
 void swrModel_TestTriangleEdges(float* point, float* a, float* b, float* c, float* p5, void* face);
 void swrModel_ClipAndTestTriangle(float* normal, float* a, float* b, float* c, void* p5, void* face, void* p7);
 void swrModel_CollideSphereTriangle(float* faceNormal, float* a, float* b, float* c, float* point);
-void swrModel_CollideRayTriangle(float* faceNormal, float* a, float* b, float* c, int face);
+// ray = {origin[3], dir[3], maxDist} (the swrModel_collisionRay* globals laid out contiguously)
+float IntersectRayPlane(float* plane, float* ray, rdVector3* outPoint);
+void swrModel_CollideRayTriangle(float* plane, float* a, float* b, float* c, float* ray);
 
 void swrModel_MeshCollisionFaceCallbackIndexed(swrModel_CollisionVertex* vertices, int16_t primitive_type, uint16_t* indices);
 void swrModel_MeshCollisionFaceCallback(swrModel_CollisionVertex* vertices, int16_t primitive_type);


### PR DESCRIPTION
Reimplements the self-contained ray-vs-triangle collision math in `swrModel` -- the leaf core of the ray-vs-mesh query (the part #110 left stubbed).

- **`swrModel_MeshCollisionFaceCallback` / `...Indexed`** — per-face hooks: gather a face's 3/4 verts (indexed or sequential), broad-phase cull against the ray bbox, split a quad into two triangles, ray-test each. (These were the HANG stubs #110 added.)
- **`IntersectRayPlane`** — ray-plane hit distance; miss on parallel (`|normal·dir| < 1e-4`), behind the origin, or past maxDist.
- **`swrModel_CollideRayTriangle`** — front/back accept-flag gate → ray-plane → in-triangle test; records the closest hit into the `swrModel_collision*` result globals (a back-face hit flips the stored normal to oppose the ray).
- **`swrModel_PointInTriangle`** — edge-cross sign test via the dominant-axis trick. The asm reads the dominant component signed for X/Y but absolute for Z; I preserved that quirk (commented) so the result matches.
- **`rdMath_CalcSurfaceNormal2`** — plane (normal + offset) from 3 points (was a commented-out placeholder).

Names the collision-query state these read: ray bbox min/max, current mesh, the two face-accept masks. The ray-parallel epsilon is the `±0.0001` **double** pair at `0x4aca68/70` (reads as junk as a float).

Notes:
- Reverse-hook reimpls (dormant; validated by compile + disasm). Full build links clean, dup-`_ADDR` scan clean.
- Fixed `swrModel_CollideRayTriangle`'s last param (was `int face` — it's the ray pointer) and declared `IntersectRayPlane`.
- The traversal layer that feeds these at runtime (`CollideRayWithMesh` / `CollideNodeRecursiveRay` / the mesh iterator + `FUN_00431880`) stays stubbed — a separate follow-up.
- Happy to match your DB names (incl. the two face-accept masks / front-back semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
