### PR TITLE
swrRace: reimplement swrRace_CollideTrack

### DIFF
--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -2140,7 +2140,38 @@ void swrRace_ApplyTraction(swrRace* player, float b, rdVector3* c, rdVector3* d)
 // 0x0044acb0
 int swrRace_CollideTrack(rdVector3* curPos, rdVector3* prevPos, swrModel_Node* model, rdVector3* outNormal)
 {
-    HANG("TODO");
+    rdVector3 seg;
+    seg.x = curPos->x - prevPos->x;
+    seg.y = curPos->y - prevPos->y;
+    seg.z = curPos->z - prevPos->z;
+
+    float len = rdVector_Len3(&seg);
+    if (0.001f < len) {
+        // Cast a ray from prevPos along the unit movement direction, over the segment length.
+        float inv = 1.0f / len;
+        float ray[7];
+        ray[0] = prevPos->x;
+        ray[1] = prevPos->y;
+        ray[2] = prevPos->z;
+        ray[3] = seg.x * inv;
+        ray[4] = seg.y * inv;
+        ray[5] = seg.z * inv;
+        ray[6] = len;
+
+        rdVector3 hitPoint, normal;
+        float dist = swrRace_InitUnk(model, ray, &hitPoint, &normal);
+        if (0.0f <= dist) {
+            // Push curPos back out past the contact plane along the normal (+2.0 of clearance,
+            // i.e. the stored -2.0 skin subtracted).
+            float push = (normal.x * hitPoint.x + normal.y * hitPoint.y + normal.z * hitPoint.z) -
+                         (normal.x * curPos->x + normal.y * curPos->y + normal.z * curPos->z) + 2.0f;
+            curPos->x += normal.x * push;
+            curPos->y += normal.y * push;
+            curPos->z += normal.z * push;
+            *outNormal = normal;
+            return 1;
+        }
+    }
     return 0;
 }
 


### PR DESCRIPTION
Reimplements `swrRace_CollideTrack` (was a HANG stub).

Casts a ray from the pod's previous position along its movement direction over the segment length (the ray-vs-collision-mesh query is `swrRace_InitUnk`, which landed in #110). On a hit it pushes `curPos` back out past the contact plane along the surface normal (+2.0 clearance) and returns the normal. `swrRace_MainSpeed` calls this each frame to stop the pod tunnelling through track geometry.

Constants verified against `.rdata` (`0x4acc00..0c` = 0.001 / 1.0 / 0.0 / -2.0; the -2.0 skin is subtracted, giving the +2.0 clearance). Build links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
