### PR TITLE
feat: gamepad menu navigation (D-pad, START, BACK) for modern controllers

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -323,7 +323,7 @@ swrConfig_mouse_enabled 0x004d6b38 int
 stdControl_joystickDeviceIndex 0x004d6b3c int
 swrControl_acceptPressedEdge 0x004d6b40 int
 
-DAT_004d6b44 0x004d6b44 int
+swrControl_cancelPressedEdge 0x004d6b44 int
 DAT_004d6b48 0x004d6b48 int
 swrControl_acceptReleasedEdge 0x004d6b4c int
 

--- a/dinput_hook/CMakeLists.txt
+++ b/dinput_hook/CMakeLists.txt
@@ -43,6 +43,7 @@ if (NOT USE_RELEASE_HOOK)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/generated/hook_generated.c
     )
     target_compile_definitions(dinput_hook PRIVATE ENABLE_GLFW_INPUT_HANDLING=0)
+    target_compile_definitions(dinput_hook PRIVATE ENABLE_GAMEPAD_NAV=1)
     target_link_libraries(dinput_hook PRIVATE swe1r_functions swe1r_globals imgui kernel32  Dwmapi dxguid detours ddraw opengl32 glad glfw fastgltf)
     target_link_options(dinput_hook PRIVATE "-Wl,--kill-at")
 

--- a/dinput_hook/game_deltas/Window_delta.c
+++ b/dinput_hook/game_deltas/Window_delta.c
@@ -1,4 +1,5 @@
 #include "Window_delta.h"
+#include "swrGamepadNav_delta.h"
 
 #include <stdio.h>
 #include <Windows.h>
@@ -255,6 +256,9 @@ int Window_SmushPlayCallback_delta(const SmushImage *image) {
     // poll events here to avoid a non-responsive window if the controls are inactive
     glfwPollEvents();
     return stdControl_ReadKey(DIK_ESCAPE, 0) || stdControl_ReadKey(DIK_RETURN, 0) ||
+#if ENABLE_GAMEPAD_NAV
+           swrGamepadNav_SkipPressed() ||
+#endif
            glfwWindowShouldClose(glfwGetCurrentContext());
 }
 

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
@@ -39,9 +39,6 @@ extern FILE *hook_log;
 #include "../imgui_utils.h"     // imgui_state.enable_gamepad_nav (toggle)
 #include "../hook_helper.h"     // hook_call_original
 
-extern "C" void hook_function(const char *function_name, uint32_t original_address,
-                              uint8_t *hook_address);
-
 typedef void *(__cdecl *swrEvent_GetItemFn)(int, int);
 typedef void(__cdecl *swrUI_UpdatePlayerMenuInputFn)(int);
 typedef void(__cdecl *updateInRaceInputBitsetsFn)(void);
@@ -165,7 +162,7 @@ int swrGamepadNav_SkipPressed(void) {
 // that for the D-pad here. swrUI_ProcessMouse renders the UI tree so it runs every frame a
 // menu is up; HandleKeyEvent self-gates on UI visibility, so this is inert outside menus
 // (and harmless on the hangar bitset screens, which don't navigate by focus).
-static void __cdecl swrUI_ProcessMouse_delta(void) {
+void __cdecl swrUI_ProcessMouse_delta(void) {
     hook_call_original((swrUI_ProcessMouseFn) swrUI_ProcessMouse_ADDR);
     if (!imgui_state.enable_gamepad_nav)
         return;
@@ -197,7 +194,7 @@ static void __cdecl swrUI_ProcessMouse_delta(void) {
 // input before the front-end menu builder reads it, then restore. The original then
 // edge-detects + auto-repeats it into the menu bitsets (and its own input-enable
 // gate decides whether to act), so the D-pad behaves exactly like the analog stick.
-static void __cdecl swrUI_UpdatePlayerMenuInput_delta(int player) {
+void __cdecl swrUI_UpdatePlayerMenuInput_delta(int player) {
     int augment = 0;
     if (imgui_state.enable_gamepad_nav && player == 0) {
         if (g_held & XINPUT_GAMEPAD_DPAD_UP)
@@ -222,7 +219,7 @@ static void __cdecl swrUI_UpdatePlayerMenuInput_delta(int player) {
 // In-race system buttons: feed START / BACK into the game's rising-edge input set
 // after the original computes it, so the game's own pause / HUD-cycle logic runs
 // exactly as if the keyboard keys were pressed. Also handles START-to-resume.
-static void __cdecl updateInRaceInputBitsets_delta(void) {
+void __cdecl updateInRaceInputBitsets_delta(void) {
     hook_call_original((updateInRaceInputBitsetsFn) updateInRaceInputBitsets_ADDR);
     if (!imgui_state.enable_gamepad_nav)
         return;
@@ -253,21 +250,10 @@ static void __cdecl updateInRaceInputBitsets_delta(void) {
 // Cantina taunt cutscene: it advances/skips as soon as the accept or cancel edge is set
 // (the same edges Enter/Esc set). Set the cancel edge on START so START skips it. Scoped
 // to this scene, so START stays inert in normal menus.
-static void __cdecl swrObjHang_UpdateTauntScene_delta(void *hang) {
+void __cdecl swrObjHang_UpdateTauntScene_delta(void *hang) {
     if (imgui_state.enable_gamepad_nav && (g_pressed & XINPUT_GAMEPAD_START))
         swrControl_cancelPressedEdge = 1;
     hook_call_original((swrObjHang_UpdateTauntSceneFn) swrObjHang_UpdateTauntScene_ADDR, hang);
-}
-
-void swrGamepadNav_RegisterHooks(void) {
-    hook_function("swrUI_ProcessMouse", (uint32_t) swrUI_ProcessMouse_ADDR,
-                  (uint8_t *) swrUI_ProcessMouse_delta);
-    hook_function("swrUI_UpdatePlayerMenuInput", (uint32_t) swrUI_UpdatePlayerMenuInput_ADDR,
-                  (uint8_t *) swrUI_UpdatePlayerMenuInput_delta);
-    hook_function("updateInRaceInputBitsets", (uint32_t) updateInRaceInputBitsets_ADDR,
-                  (uint8_t *) updateInRaceInputBitsets_delta);
-    hook_function("swrObjHang_UpdateTauntScene", (uint32_t) swrObjHang_UpdateTauntScene_ADDR,
-                  (uint8_t *) swrObjHang_UpdateTauntScene_delta);
 }
 
 #endif // ENABLE_GAMEPAD_NAV

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
@@ -2,12 +2,15 @@
 // Modern-gamepad UI/system navigation. See swrGamepadNav_delta.h for the why.
 //
 // SW Racer reads DirectInput, where an XInput pad's stick and face buttons are
-// already usable (the stick navigates menus; bound buttons work in a race) but
-// the D-pad (a POV hat), START and BACK are never mapped. This bridge reads those
-// via XInput and feeds the game's own input paths:
-//   * D-pad  -> the held in-race input bitset (inRaceLocalPlayerInputBitset3) the
-//               front-end menu builder (swrUI_UpdatePlayerMenuInput) consumes, so
-//               the D-pad navigates every menu exactly like the analog stick;
+// usable (the stick navigates menus; bound buttons work in a race) on the pads
+// DirectInput enumerates -- but not every controller -- while the D-pad (a POV
+// hat), START and BACK are never mapped. This bridge reads those via XInput and
+// feeds the game's own input paths:
+//   * D-pad, and the left stick (folded into the D-pad bits in swrGamepadNav_Poll),
+//               -> the held in-race input bitset (inRaceLocalPlayerInputBitset3) the
+//               front-end menu builder (swrUI_UpdatePlayerMenuInput) consumes (plus
+//               the swrUI focus path), so both navigate every menu like the analog
+//               stick does on a DirectInput-enumerated pad;
 //   * START  -> in-race pause / resume, and cutscene (FMV) skip;
 //   * BACK   -> swrObjJdge_CycleHudMode (the keyboard Caps-Lock HUD function).
 //
@@ -131,6 +134,27 @@ static void nav_refresh_pad(uint32_t now) {
     g_padIndex = -1;
 }
 
+// Map the left analog stick to virtual D-pad bits so the stick drives the very same menu
+// navigation as the D-pad. The game already reads the stick through DirectInput on the pads
+// it enumerates, but that path does not reach every controller; folding the stick into the
+// D-pad bits here makes stick menu-nav work on any XInput pad. Because these bits only feed the
+// D-pad's menu paths (front-end + pause), in-race steering -- read straight off the analog axes
+// via DirectInput -- is unaffected. Per-axis past the standard deadzone; the two axes are
+// independent (a vertical menu ignores the horizontal bit and vice versa).
+static WORD nav_stick_to_dpad(const XINPUT_GAMEPAD &pad) {
+    const SHORT dz = XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE;
+    WORD bits = 0;
+    if (pad.sThumbLY > dz)
+        bits |= XINPUT_GAMEPAD_DPAD_UP;
+    else if (pad.sThumbLY < -dz)
+        bits |= XINPUT_GAMEPAD_DPAD_DOWN;
+    if (pad.sThumbLX > dz)
+        bits |= XINPUT_GAMEPAD_DPAD_RIGHT;
+    else if (pad.sThumbLX < -dz)
+        bits |= XINPUT_GAMEPAD_DPAD_LEFT;
+    return bits;
+}
+
 void swrGamepadNav_Poll(void) {
     if (!g_xinputTried)
         nav_load_xinput();
@@ -143,10 +167,13 @@ void swrGamepadNav_Poll(void) {
     WORD buttons = 0;
     if (g_padIndex >= 0) {
         XINPUT_STATE st;
-        if (p_XInputGetState((DWORD) g_padIndex, &st) == ERROR_SUCCESS)
-            buttons = st.Gamepad.wButtons;
-        else
+        if (p_XInputGetState((DWORD) g_padIndex, &st) == ERROR_SUCCESS) {
+            // Treat the left stick as a D-pad so it shares every menu-nav path (and the
+            // hold-to-repeat) below; the directional bits are inert in-race except when paused.
+            buttons = st.Gamepad.wButtons | nav_stick_to_dpad(st.Gamepad);
+        } else {
             g_padIndex = -1;// likely unplugged; rescan next frame
+        }
     }
     g_pressed = buttons & ~g_prevButtons;
     g_held = buttons;

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
@@ -1,0 +1,273 @@
+//
+// Modern-gamepad UI/system navigation. See swrGamepadNav_delta.h for the why.
+//
+// SW Racer reads DirectInput, where an XInput pad's stick and face buttons are
+// already usable (the stick navigates menus; bound buttons work in a race) but
+// the D-pad (a POV hat), START and BACK are never mapped. This bridge reads those
+// via XInput and feeds the game's own input paths:
+//   * D-pad  -> the held in-race input bitset (inRaceLocalPlayerInputBitset3) the
+//               front-end menu builder (swrUI_UpdatePlayerMenuInput) consumes, so
+//               the D-pad navigates every menu exactly like the analog stick;
+//   * START  -> in-race pause / resume, and cutscene (FMV) skip;
+//   * BACK   -> swrObjJdge_CycleHudMode (the keyboard Caps-Lock HUD function).
+//
+// Menu nav rides the game's own per-player builder: it edge-detects the held bits
+// into swrUI_localPlayersInputPressedBitset (one step per press) and auto-repeats
+// list nav, and it applies the game's own input-enable gate -- so injecting the
+// D-pad as held bits gives behaviour identical to the stick. In-race pause/HUD are
+// OR'd into inRaceLocalPlayerInputBitset1 (the "just pressed" set), firing once per
+// press like a keyboard key. Pure XInput reads + writes into game state.
+//
+
+#if ENABLE_GAMEPAD_NAV
+
+#include "swrGamepadNav_delta.h"
+
+#include <windows.h>
+#include <xinput.h>
+
+extern "C" {
+#include <types.h>
+#include <globals.h>            // pauseState, inRaceLocalPlayerInputBitset1/3
+#include <Swr/swrObj.h>         // swrUI_UpdatePlayerMenuInput_ADDR, updateInRaceInputBitsets_ADDR
+#include <Swr/swrUI.h>          // swrUI_ProcessMouse_ADDR, swrUI_HandleKeyEvent_ADDR
+#include <Swr/swrEvent.h>       // swrEvent_GetItem_ADDR (in-race detection)
+
+extern FILE *hook_log;
+}
+
+#include "../imgui_utils.h"     // imgui_state.enable_gamepad_nav (toggle)
+#include "../hook_helper.h"     // hook_call_original
+
+extern "C" void hook_function(const char *function_name, uint32_t original_address,
+                              uint8_t *hook_address);
+
+typedef void *(__cdecl *swrEvent_GetItemFn)(int, int);
+typedef void(__cdecl *swrUI_UpdatePlayerMenuInputFn)(int);
+typedef void(__cdecl *updateInRaceInputBitsetsFn)(void);
+typedef void(__cdecl *swrUI_ProcessMouseFn)(void);
+typedef int(__cdecl *swrUI_HandleKeyEventFn)(int, int);
+typedef void(__cdecl *swrObjHang_UpdateTauntSceneFn)(void *);
+
+// 'Jdge' race-manager event id: swrEvent_GetItem('Jdge', 0) is non-null only while
+// a race is running (null in menus). The game's own in-race test.
+#define JDGE_EVENT 0x4a646765
+
+// In-race action bits (read via KeyDownForPlayer1Or2 from the rising-edge bitset).
+#define INPUT_BIT_CYCLE_HUD 0x40 // swrObjJdge_CycleHudMode <- KeyDownForPlayer1Or2(0x40)
+#define INPUT_BIT_PAUSE 0x200    // swrObjJdge_CheckIfPauseRequested <- KeyDownForPlayer1Or2(0x200)
+
+// Menu directional bits in the in-race input bitset (the front-end menus read these:
+// vertical menus use up/down, horizontal lists use left/right). Matches the analog
+// axis thresholds in updateInRaceInputBitsets.
+#define MENU_BIT_UP 0x4000
+#define MENU_BIT_DOWN 0x8000
+#define MENU_BIT_LEFT 0x10000
+#define MENU_BIT_RIGHT 0x20000
+
+// In-race pause menu (swrRace_UpdateInRaceMenu) reads these rising-edge bits:
+// up = 0x4000, down = 0x8000 (shared with MENU_BIT_*), accept/activate = 0x1.
+#define PAUSE_MENU_ACCEPT 0x1
+
+// pauseState values (written by requestPause / the pause-menu scroll): 0 = none,
+// 2 = scrolling in, 1 = fully paused, 3 = scrolling out -> endPause (resume).
+#define PAUSE_STATE_NONE 0
+#define PAUSE_STATE_PAUSED 1
+#define PAUSE_STATE_RESUMING 3
+
+// swrUI page/widget screens (splash, mode-select, options) navigate via the focus
+// system, not the menu bitset -- they read arrow-key events through swrUI_HandleKeyEvent.
+// The keyboard drives that as Window_msg_default_handler -> swrUI_HandleKeyEvent(vk, 1)
+// on key-down. So map the D-pad to the VK arrow codes and call HandleKeyEvent exactly
+// like a key-down, with keyboard-style hold-to-repeat (OS key-repeat = repeated down).
+static const int NAV_VK[4] = {0x26, 0x28, 0x25, 0x27};// VK_UP, VK_DOWN, VK_LEFT, VK_RIGHT
+static const WORD NAV_BIT[4] = {XINPUT_GAMEPAD_DPAD_UP, XINPUT_GAMEPAD_DPAD_DOWN,
+                                XINPUT_GAMEPAD_DPAD_LEFT, XINPUT_GAMEPAD_DPAD_RIGHT};
+static const uint32_t NAV_REPEAT_DELAY_MS = 400;// hold-to-repeat: delay before first repeat
+static const uint32_t NAV_REPEAT_RATE_MS = 110; // hold-to-repeat: interval between repeats
+static uint32_t g_navNextFire[4] = {0, 0, 0, 0};
+static WORD g_navPrevHeld = 0;// d-pad directions we have an outstanding key-down for
+
+// --- XInput, loaded dynamically (no hard link dependency, mirrors the renderer) -
+typedef DWORD(WINAPI *XInputGetState_t)(DWORD, XINPUT_STATE *);
+static XInputGetState_t p_XInputGetState = nullptr;
+static bool g_xinputTried = false;
+static int g_padIndex = -1;       // currently connected pad (0..3), -1 = none
+static uint32_t g_lastScanMs = 0; // last time we scanned for a pad
+
+// Latched controller state, refreshed once per present by swrGamepadNav_Poll.
+static WORD g_held = 0;   // buttons currently down
+static WORD g_pressed = 0;// buttons that went down this poll (rising edge)
+static WORD g_prevButtons = 0;
+
+static void nav_load_xinput() {
+    g_xinputTried = true;
+    const char *dlls[] = {"xinput1_4.dll", "xinput1_3.dll", "xinput9_1_0.dll"};
+    for (const char *name: dlls) {
+        HMODULE mod = LoadLibraryA(name);
+        if (!mod)
+            continue;
+        p_XInputGetState = (XInputGetState_t) GetProcAddress(mod, "XInputGetState");
+        if (p_XInputGetState) {
+            fprintf(hook_log, "[gamepad-nav] using %s for XInput.\n", name);
+            fflush(hook_log);
+            return;
+        }
+    }
+    fprintf(hook_log, "[gamepad-nav] no XInput DLL found; gamepad navigation disabled.\n");
+    fflush(hook_log);
+}
+
+// Find the first connected pad. Rescans at most once a second so an unplugged /
+// late-plugged controller is picked up without polling every slot every frame.
+static void nav_refresh_pad(uint32_t now) {
+    if (g_padIndex >= 0 && (now - g_lastScanMs) < 1000)
+        return;
+    g_lastScanMs = now;
+    for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
+        XINPUT_STATE st;
+        if (p_XInputGetState(i, &st) == ERROR_SUCCESS) {
+            g_padIndex = (int) i;
+            return;
+        }
+    }
+    g_padIndex = -1;
+}
+
+void swrGamepadNav_Poll(void) {
+    if (!g_xinputTried)
+        nav_load_xinput();
+    if (!p_XInputGetState)
+        return;
+
+    const uint32_t now = GetTickCount();
+    nav_refresh_pad(now);
+
+    WORD buttons = 0;
+    if (g_padIndex >= 0) {
+        XINPUT_STATE st;
+        if (p_XInputGetState((DWORD) g_padIndex, &st) == ERROR_SUCCESS)
+            buttons = st.Gamepad.wButtons;
+        else
+            g_padIndex = -1;// likely unplugged; rescan next frame
+    }
+    g_pressed = buttons & ~g_prevButtons;
+    g_held = buttons;
+    g_prevButtons = buttons;
+}
+
+int swrGamepadNav_SkipPressed(void) {
+    return (imgui_state.enable_gamepad_nav && (g_pressed & XINPUT_GAMEPAD_START)) ? 1 : 0;
+}
+
+// swrUI page/widget screens (splash, mode-select, options) navigate by focus, driven by
+// the keyboard as Window_msg_default_handler -> swrUI_HandleKeyEvent(vk, 1/0). Replicate
+// that for the D-pad here. swrUI_ProcessMouse renders the UI tree so it runs every frame a
+// menu is up; HandleKeyEvent self-gates on UI visibility, so this is inert outside menus
+// (and harmless on the hangar bitset screens, which don't navigate by focus).
+static void __cdecl swrUI_ProcessMouse_delta(void) {
+    hook_call_original((swrUI_ProcessMouseFn) swrUI_ProcessMouse_ADDR);
+    if (!imgui_state.enable_gamepad_nav)
+        return;
+
+    const uint32_t now = GetTickCount();
+    for (int i = 0; i < 4; i++) {
+        const bool held = (g_held & NAV_BIT[i]) != 0;
+        const bool wasHeld = (g_navPrevHeld & NAV_BIT[i]) != 0;
+        if (held) {
+            bool fire = false;
+            if (!wasHeld) {
+                fire = true;// initial key-down
+                g_navNextFire[i] = now + NAV_REPEAT_DELAY_MS;
+            } else if ((int32_t) (now - g_navNextFire[i]) >= 0) {
+                fire = true;// OS-style key-repeat while held
+                g_navNextFire[i] = now + NAV_REPEAT_RATE_MS;
+            }
+            if (fire)
+                ((swrUI_HandleKeyEventFn) swrUI_HandleKeyEvent_ADDR)(NAV_VK[i], 1);// key-down
+            g_navPrevHeld |= NAV_BIT[i];
+        } else if (wasHeld) {
+            ((swrUI_HandleKeyEventFn) swrUI_HandleKeyEvent_ADDR)(NAV_VK[i], 0);// key-up
+            g_navPrevHeld &= ~NAV_BIT[i];
+        }
+    }
+}
+
+// Menu navigation: temporarily fold the D-pad into the local player's held in-race
+// input before the front-end menu builder reads it, then restore. The original then
+// edge-detects + auto-repeats it into the menu bitsets (and its own input-enable
+// gate decides whether to act), so the D-pad behaves exactly like the analog stick.
+static void __cdecl swrUI_UpdatePlayerMenuInput_delta(int player) {
+    int augment = 0;
+    if (imgui_state.enable_gamepad_nav && player == 0) {
+        if (g_held & XINPUT_GAMEPAD_DPAD_UP)
+            augment |= MENU_BIT_UP;
+        if (g_held & XINPUT_GAMEPAD_DPAD_DOWN)
+            augment |= MENU_BIT_DOWN;
+        if (g_held & XINPUT_GAMEPAD_DPAD_LEFT)
+            augment |= MENU_BIT_LEFT;
+        if (g_held & XINPUT_GAMEPAD_DPAD_RIGHT)
+            augment |= MENU_BIT_RIGHT;
+    }
+    if (augment == 0) {
+        hook_call_original((swrUI_UpdatePlayerMenuInputFn) swrUI_UpdatePlayerMenuInput_ADDR, player);
+        return;
+    }
+    const int saved = inRaceLocalPlayerInputBitset3[player];
+    inRaceLocalPlayerInputBitset3[player] = saved | augment;
+    hook_call_original((swrUI_UpdatePlayerMenuInputFn) swrUI_UpdatePlayerMenuInput_ADDR, player);
+    inRaceLocalPlayerInputBitset3[player] = saved;// don't disturb the in-race edge calc
+}
+
+// In-race system buttons: feed START / BACK into the game's rising-edge input set
+// after the original computes it, so the game's own pause / HUD-cycle logic runs
+// exactly as if the keyboard keys were pressed. Also handles START-to-resume.
+static void __cdecl updateInRaceInputBitsets_delta(void) {
+    hook_call_original((updateInRaceInputBitsetsFn) updateInRaceInputBitsets_ADDR);
+    if (!imgui_state.enable_gamepad_nav)
+        return;
+    if (((swrEvent_GetItemFn) swrEvent_GetItem_ADDR)(JDGE_EVENT, 0) == nullptr)
+        return;// not in a race
+
+    if (g_pressed & XINPUT_GAMEPAD_START) {
+        if (pauseState == PAUSE_STATE_NONE)
+            inRaceLocalPlayerInputBitset1[0] |= INPUT_BIT_PAUSE;// -> requestPause
+        else if (pauseState == PAUSE_STATE_PAUSED)
+            pauseState = PAUSE_STATE_RESUMING;// scroll out -> endPause (resume)
+    }
+    if (g_pressed & XINPUT_GAMEPAD_BACK)
+        inRaceLocalPlayerInputBitset1[0] |= INPUT_BIT_CYCLE_HUD;// -> swrObjJdge_CycleHudMode
+
+    // While paused, the pause menu (swrRace_UpdateInRaceMenu) navigates from this same
+    // rising-edge bitset: D-pad up/down move the cursor, A activates the entry.
+    if (pauseState != PAUSE_STATE_NONE) {
+        if (g_pressed & XINPUT_GAMEPAD_DPAD_UP)
+            inRaceLocalPlayerInputBitset1[0] |= MENU_BIT_UP;
+        if (g_pressed & XINPUT_GAMEPAD_DPAD_DOWN)
+            inRaceLocalPlayerInputBitset1[0] |= MENU_BIT_DOWN;
+        if (g_pressed & XINPUT_GAMEPAD_A)
+            inRaceLocalPlayerInputBitset1[0] |= PAUSE_MENU_ACCEPT;
+    }
+}
+
+// Cantina taunt cutscene: it advances/skips as soon as the accept or cancel edge is set
+// (the same edges Enter/Esc set). Set the cancel edge on START so START skips it. Scoped
+// to this scene, so START stays inert in normal menus.
+static void __cdecl swrObjHang_UpdateTauntScene_delta(void *hang) {
+    if (imgui_state.enable_gamepad_nav && (g_pressed & XINPUT_GAMEPAD_START))
+        swrControl_cancelPressedEdge = 1;
+    hook_call_original((swrObjHang_UpdateTauntSceneFn) swrObjHang_UpdateTauntScene_ADDR, hang);
+}
+
+void swrGamepadNav_RegisterHooks(void) {
+    hook_function("swrUI_ProcessMouse", (uint32_t) swrUI_ProcessMouse_ADDR,
+                  (uint8_t *) swrUI_ProcessMouse_delta);
+    hook_function("swrUI_UpdatePlayerMenuInput", (uint32_t) swrUI_UpdatePlayerMenuInput_ADDR,
+                  (uint8_t *) swrUI_UpdatePlayerMenuInput_delta);
+    hook_function("updateInRaceInputBitsets", (uint32_t) updateInRaceInputBitsets_ADDR,
+                  (uint8_t *) updateInRaceInputBitsets_delta);
+    hook_function("swrObjHang_UpdateTauntScene", (uint32_t) swrObjHang_UpdateTauntScene_ADDR,
+                  (uint8_t *) swrObjHang_UpdateTauntScene_delta);
+}
+
+#endif // ENABLE_GAMEPAD_NAV

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.h
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.h
@@ -23,9 +23,12 @@
 extern "C" {
 #endif
 
-// Register the game-function hooks the bridge needs (menu nav + in-race actions).
-// Must run during hook registration, before init_hooks() applies detours.
-void swrGamepadNav_RegisterHooks(void);
+// Game-function hooks the bridge installs (menu nav + in-race actions).
+// Registered inline in init_renderer_hooks().
+void __cdecl swrUI_ProcessMouse_delta(void);
+void __cdecl swrUI_UpdatePlayerMenuInput_delta(int player);
+void __cdecl updateInRaceInputBitsets_delta(void);
+void __cdecl swrObjHang_UpdateTauntScene_delta(void *hang);
 
 // Per-frame poll: read the controller and latch its held / just-pressed state.
 // Safe to call every frame, in or out of a race (also runs in the cutscene loop).

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.h
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.h
@@ -3,13 +3,13 @@
 // Modern-gamepad UI/system navigation for SW Racer.
 //
 // The game's input layer reads DirectInput, where an XInput pad's analog stick,
-// face buttons and triggers are visible (the stick already navigates menus and
-// the bound buttons already work in a race), but the D-pad (a POV hat), START and
-// BACK/SELECT are never mapped to anything. Rather than touch the binding tables,
-// this bridge reads the pad directly via XInput and drives the game's *own*
-// mechanisms:
-//   * D-pad -> swrUI_HandleKeyEvent arrow events (same path the stick uses), so
-//     the D-pad navigates menus;
+// face buttons and triggers are visible (the stick navigates menus and the bound
+// buttons work in a race) on the pads DirectInput enumerates -- but that path does
+// not reach every controller, and the D-pad (a POV hat), START and BACK/SELECT are
+// never mapped to anything. Rather than touch the binding tables, this bridge reads
+// the pad directly via XInput and drives the game's *own* mechanisms:
+//   * D-pad, and the left analog stick (mapped to the same directions), -> the
+//     game's menu navigation, so both navigate menus on any XInput pad;
 //   * START -> in-race pause (and resume), and cutscene skip;
 //   * BACK/SELECT -> cycle the HUD mode (the keyboard Caps-Lock function).
 //

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.h
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Modern-gamepad UI/system navigation for SW Racer.
+//
+// The game's input layer reads DirectInput, where an XInput pad's analog stick,
+// face buttons and triggers are visible (the stick already navigates menus and
+// the bound buttons already work in a race), but the D-pad (a POV hat), START and
+// BACK/SELECT are never mapped to anything. Rather than touch the binding tables,
+// this bridge reads the pad directly via XInput and drives the game's *own*
+// mechanisms:
+//   * D-pad -> swrUI_HandleKeyEvent arrow events (same path the stick uses), so
+//     the D-pad navigates menus;
+//   * START -> in-race pause (and resume), and cutscene skip;
+//   * BACK/SELECT -> cycle the HUD mode (the keyboard Caps-Lock function).
+//
+// Pure XInput reads + writes into the game's input state, independent of the
+// legacy DirectInput path, so it works on any XInput controller. Compile-time
+// gated by ENABLE_GAMEPAD_NAV (see dinput_hook/CMakeLists.txt).
+
+#if ENABLE_GAMEPAD_NAV
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Register the game-function hooks the bridge needs (menu nav + in-race actions).
+// Must run during hook registration, before init_hooks() applies detours.
+void swrGamepadNav_RegisterHooks(void);
+
+// Per-frame poll: read the controller and latch its held / just-pressed state.
+// Safe to call every frame, in or out of a race (also runs in the cutscene loop).
+void swrGamepadNav_Poll(void);
+
+// Non-zero on the frame START is pressed -- used by the cutscene-skip path.
+int swrGamepadNav_SkipPressed(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ENABLE_GAMEPAD_NAV

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -279,7 +279,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
                 rdMatrix_Copy44(&rdMatrix44_unk3, &rdMatrix44_unk4);
             }
         }
-        if (DAT_004d6b44 != 0) {
+        if (swrControl_cancelPressedEdge != 0) {
             FUN_00440550(77);
             iVar8 = 3;
             swrObjHang_state2 = swrObjHang_STATE_SELECT_TRACK;
@@ -832,7 +832,7 @@ LAB_0043b5c4:
                 DAT_0050c54c = 1;
                 return;
             }
-            if ((DAT_004d6b44 != 0) && (DAT_00e2a698 == 0)) {
+            if ((swrControl_cancelPressedEdge != 0) && (DAT_00e2a698 == 0)) {
                 if (multiplayer_enabled) {
                     FUN_004118b0();
                     return;
@@ -1213,7 +1213,7 @@ LAB_0043b9b4:
                     DAT_0050c554 = 1;
                     return;
                 }
-                if (DAT_004d6b44 != 0 && DAT_00e2a698 == 0) {
+                if (swrControl_cancelPressedEdge != 0 && DAT_00e2a698 == 0) {
 
                     FUN_00440550(36);
                     swrObjHang_InitTrackSprites_delta(hang, false);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -82,6 +82,8 @@ void read_settings_ini() {
     }
 
     imgui_state.enable_fog = GetPrivateProfileIntW(L"settings", L"enable_fog", 1, ini_path.c_str());
+    imgui_state.enable_gamepad_nav =
+        GetPrivateProfileIntW(L"settings", L"enable_gamepad_nav", 1, ini_path.c_str());
 }
 
 void save_settings_ini() {
@@ -91,6 +93,8 @@ void save_settings_ini() {
                                std::to_wstring(imgui_state.anisotropy).c_str(), ini_path.c_str());
     WritePrivateProfileStringW(L"settings", L"enable_fog", imgui_state.enable_fog ? L"1" : L"0",
                                ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"enable_gamepad_nav",
+                               imgui_state.enable_gamepad_nav ? L"1" : L"0", ini_path.c_str());
 }
 
 const char *swrModel_NodeTypeStr(uint32_t nodeType) {
@@ -332,6 +336,11 @@ void opengl_render_imgui() {
             save_settings_ini();
         }
         if (ImGui::Checkbox("Enable fog", &imgui_state.enable_fog)) {
+            save_settings_ini();
+        }
+        if (ImGui::Checkbox("Gamepad navigation (D-pad menus, START pause/skip, "
+                            "BACK cycle HUD)",
+                            &imgui_state.enable_gamepad_nav)) {
             save_settings_ini();
         }
         ImGui::TreePop();

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -33,6 +33,7 @@ typedef struct ImGuiState {
     int msaa_samples = 1;
     int anisotropy = 8;
     bool enable_fog = true;
+    bool enable_gamepad_nav = true;
 
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "./game_deltas/swrModel_delta.h"
 #include "./game_deltas/swrSpline_delta.h"
 #include "./game_deltas/swrObjJdge_delta.h"
+#include "./game_deltas/swrGamepadNav_delta.h"
 
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
@@ -951,6 +952,11 @@ extern "C" int stdDisplay_Update_Hook() {
     imgui_Update();// Added
     end_texture_replacement();
 
+#if ENABLE_GAMEPAD_NAV
+    // Latch the controller's D-pad / START / BACK state for the gamepad-nav hooks.
+    swrGamepadNav_Poll();
+#endif
+
     std::memset(replacedTries, 0, std::size(replacedTries));
     for (auto &[key, value]: additionnalReplacedTries) {
         value = 0;
@@ -968,6 +974,11 @@ extern "C" void init_renderer_hooks() {
     // ========================================
     // Hooks required for renderer replacement
     // ========================================
+
+#if ENABLE_GAMEPAD_NAV
+    // Feed the gamepad's D-pad / START / BACK into the game's menu + in-race input.
+    swrGamepadNav_RegisterHooks();
+#endif
 
     // main
     hook_function("WinMain", (uint32_t) WinMain_ADDR, (uint8_t *) WinMain_delta);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -977,7 +977,14 @@ extern "C" void init_renderer_hooks() {
 
 #if ENABLE_GAMEPAD_NAV
     // Feed the gamepad's D-pad / START / BACK into the game's menu + in-race input.
-    swrGamepadNav_RegisterHooks();
+    hook_function("swrUI_ProcessMouse", (uint32_t) swrUI_ProcessMouse_ADDR,
+                  (uint8_t *) swrUI_ProcessMouse_delta);
+    hook_function("swrUI_UpdatePlayerMenuInput", (uint32_t) swrUI_UpdatePlayerMenuInput_ADDR,
+                  (uint8_t *) swrUI_UpdatePlayerMenuInput_delta);
+    hook_function("updateInRaceInputBitsets", (uint32_t) updateInRaceInputBitsets_ADDR,
+                  (uint8_t *) updateInRaceInputBitsets_delta);
+    hook_function("swrObjHang_UpdateTauntScene", (uint32_t) swrObjHang_UpdateTauntScene_ADDR,
+                  (uint8_t *) swrObjHang_UpdateTauntScene_delta);
 #endif
 
     // main

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -28,6 +28,7 @@
 #define isTrackPlayable_ADDR (0x00440aa0)
 #define VerifySelectedTrack_ADDR (0x00440af0)
 #define swrObjHang_IsCameraMoving_ADDR (0x00440b50)
+#define updateInRaceInputBitsets_ADDR (0x00440df0)
 #define swrObjJudge_PollPause_ADDR (0x00445680)
 #define GetPauseState_ADDR (0x00445690)
 #define requestPause_ADDR (0x004456B0)
@@ -66,6 +67,7 @@
 #define swrObjHang_LoadAllPilotSprites_ADDR (0x00457bd0)
 #define swrObjHang_InitTrackSprites_ADDR (0x004584a0)
 #define swrObjHang_F4_ADDR (0x0045a040)
+#define swrUI_UpdatePlayerMenuInput_ADDR (0x0045a460)
 #define swrObjHang_Init_ADDR (0x0045ab50)
 #define swrObjHang_AssignRacerCameras_ADDR (0x0045b210)
 #define swrObjHang_StartRace_ADDR (0x0045b290)
@@ -259,6 +261,10 @@ int isTrackUnlocked(char circuitId, char trackId);
 bool isTrackPlayable(swrObjHang* hang, char circuitIdx, char trackIdx);
 int VerifySelectedTrack(swrObjHang* hang, int selectedTrackIdx);
 
+// Build the per-player rising-edge / held / released in-race input bitsets
+// (inRaceLocalPlayerInputBitset1/2/3) from the raw per-action input bytes.
+void updateInRaceInputBitsets(void);
+
 void swrObjJudge_PollPause();
 int GetPauseState();
 int requestPause();
@@ -337,6 +343,11 @@ void swrObjHang_LoadAllPilotSprites(void);
 void swrObjHang_InitTrackSprites(swrObjHang* hang, int initTracks);
 
 int swrObjHang_F4(swrObjHang* hang, int* subEvents, int* p3, void* p4, int p5);
+
+// Build a local player's menu (UI) input bitsets (swrUI_localPlayersInputPressedBitset /
+// DownBitset) for this frame by edge-detecting the player's held in-race input
+// (inRaceLocalPlayerInputBitset3) -- the front-end menus navigate from these.
+void swrUI_UpdatePlayerMenuInput(int player);
 
 // Galaxy-map / planet-select hologram screen.
 // One-time init of the whole swrObjHang object: resets the working game data to defaults,


### PR DESCRIPTION
Modern XInput controllers already work for the stick + face buttons via the game's DirectInput layer, but the **D-pad, START, and BACK** were never mapped to anything. This adds a small XInput bridge in `dinput_hook` that reads them and feeds the game's *own* input paths — no binding-table changes.

What it does:
- **D-pad** navigates every menu — the swrUI page screens (splash/mode-select/options) via `swrUI_HandleKeyEvent` (the keyboard's own path), and the hangar front-end + in-race pause menu via the input bitsets they already read.
- **START** pauses/resumes a race and skips cutscenes (FMV movies + the in-engine cantina taunt scene).
- **BACK** cycles the HUD (the keyboard Caps-Lock function).

All in the delta layer (mostly one new `swrGamepadNav_delta.cpp`), toggleable in the ImGui settings (`enable_gamepad_nav`, INI-persisted) behind the `ENABLE_GAMEPAD_NAV` flag. Verified in-game. Sibling to the rumble PR #114 but independent (no shared files).

Along the way I named a few symbols that were `FUN_`/`DAT_` (`swrUI_UpdatePlayerMenuInput`, `swrUI_AccumulateMenuInputBit`, `swrControl_cancelPressedEdge`) — best-effort, happy to rename to match your DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)