### PR TITLE
swrSound: reimplement ResolveSfxId + the sfx flag/cooldown/recent leaves

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -106,6 +106,26 @@ swrSound_criticalSection 0x004b7e7e CRITICAL_SECTION
 
 swrModel_GlobalAnimationSpeed 0x004B7FA8 float
 
+# swrSound_ResolveSfxId per-category id-validity tables (id -> int16; a negative entry means
+# "no sfx for this id in this category"). Indexed by the raw id; the .wav filename is then built
+# from the category/variant prefix tables below + the raw id.
+swrSound_sfxRemap0 0x004b7fb0 int16_t[51]
+swrSound_sfxRemap1 0x004b8018 int16_t[38]
+swrSound_sfxRemap2 0x004b8068 int16_t[57]
+swrSound_sfxRemap3 0x004b80e0 int16_t[5]
+swrSound_sfxRemap4 0x004b80f0 int16_t[104]
+swrSound_sfxRemap5 0x004b81c0 int16_t[169]
+swrSound_sfxRemap6 0x004b8318 int16_t[105]
+swrSound_sfxRemap7 0x004b83f0 int16_t[168]
+
+# swrSound_ResolveSfxId sfx-name prefixes. Category prefixes (8: "ui","sp","raac","raig","rali",
+# "gaig","gali","tp") are indexed by category; variant prefixes (categories 0-1 only) by variant.
+swrSound_sfxCategoryPrefixes 0x004b86c8 char*[8]
+swrSound_sfxVariantPrefixes 0x004b86e8 char*[23]
+
+# Recent-sfx ring (last 3 played sound ids), swrSound_PushRecentSfx / swrSound_WasSfxRecentlyPlayed.
+swrSound_recentSfxRing 0x004b85e0 int16_t[3]
+
 # Streamed music + per-track ambient SFX tables. See swrSound.h (swrSound_SelectTrackMusic /
 # swrSound_UpdateEngineAudio) and the swrSfxCue struct in types.h.
 swrMusicTrackTable 0x004b8750 int16_t[8][3]
@@ -439,6 +459,12 @@ Main_settings_debug_hud 0x0050b5c0 int
 swrMainDisplay_windowed 0x0050b5c8 int
 swrDisplay_SkipNextFrameUpdate 0x0050b5cc int
 Window_Active 0x0050b5d0 int
+
+# Sfx cooldown timers (count down each frame; > 0 means still on cooldown) + the recent-sfx ring
+# write index. swrSound_IsSfxOnCooldown / swrSound_PushRecentSfx.
+swrSound_sfxCategoryCooldown 0x0050b600 float[8]
+swrSound_sfxVariantCooldown 0x0050b620 float[23]
+swrSound_recentSfxWriteIndex 0x0050b6dc int16_t
 
 swrMainDisplaySettings_g 0x0050b560 swrMainDisplaySettings
 
@@ -1161,7 +1187,7 @@ rdMatrix44_unk2 0x00e9b9e8 rdMatrix44
 
 sound_3d_gain_adjust 0x00e9e048 float
 
-unk_statuses 0x00e9ed60 int[24] # flags for each int
+swrSound_sfxFlags 0x00e9ed60 int[24] # per-channel sfx status/flag bits (swrSound_{Test,Set,Clear}SfxFlag)
 swrScene_animations 0x00e9edc0 swrModel_Animation*[300] # related to models
 
 stdPlatform_hostServices 0x00e9f280 HostServices

--- a/src/Swr/swrSound.c
+++ b/src/Swr/swrSound.c
@@ -9,6 +9,8 @@
 #include <Platform/a3d.h>
 #include <Win95/Window.h>
 
+#include <stdio.h> // sprintf
+
 #include <string.h>
 
 // 0x00421D90
@@ -802,6 +804,143 @@ int swrSound_ParseWave(stdFile_t file, int* out_param2, int* out_param3, unsigne
 unsigned int swrSound_GetHardwareFlags(void)
 {
     return Sound_A3Dinitted ? a3dCaps_hardware.dwFlags : 0;
+}
+
+// Maps a (category, variant, id) sfx request to a loaded sound's handle. The per-category remap
+// table only validates the id (a negative entry -> no such sfx); the actual ".wav" filename is
+// built from the category prefix (+ a variant prefix for categories 0-1) and the raw id, tried
+// first plain then with an "a" suffix. Returns the sound's handle (swrSound_Find result +0x20)
+// or -1 if unknown / not loaded.
+// 0x00427110
+int swrSound_ResolveSfxId(int category, int variant, int id)
+{
+    if (!swrSound_Initted || id == -1)
+        return -1;
+
+    int16_t remapped;
+    switch (category) {
+    case 0:
+        if (variant < 0 || 0x16 < variant || id < 1 || 0x32 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap0[id];
+        break;
+    case 1:
+        if (variant < 0 || 0x16 < variant || id < 1 || 0x25 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap1[id];
+        break;
+    case 2:
+        if (id < 1 || 0x38 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap2[id];
+        break;
+    case 3:
+        if (id < 1 || 4 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap3[id];
+        break;
+    case 4:
+        if (id < 1 || 0x67 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap4[id];
+        break;
+    case 5:
+        if (id < 1 || 0xa8 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap5[id];
+        break;
+    case 6:
+        if (id < 1 || 0x68 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap6[id];
+        break;
+    case 7:
+        if (id < 1 || 0xa7 < (unsigned int) id)
+            return -1;
+        remapped = swrSound_sfxRemap7[id];
+        break;
+    default:
+        return -1;
+    }
+
+    if (remapped < 0)
+        return -1;
+
+    const char* categoryPrefix = swrSound_sfxCategoryPrefixes[category];
+    char name[64];
+    char* found;
+    if (category < 2) {
+        const char* variantPrefix = swrSound_sfxVariantPrefixes[variant];
+        sprintf(name, "%s%s%.3i.wav", variantPrefix, categoryPrefix, id);
+        found = swrSound_Find(name);
+        if (found == NULL) {
+            sprintf(name, "%s%s%.3ia.wav", variantPrefix, categoryPrefix, id);
+            found = swrSound_Find(name);
+        }
+    } else {
+        sprintf(name, "%s%.3i.wav", categoryPrefix, id);
+        found = swrSound_Find(name);
+        if (found == NULL) {
+            sprintf(name, "%s%.3ia.wav", categoryPrefix, id);
+            found = swrSound_Find(name);
+        }
+    }
+
+    if (found != NULL)
+        return *(int*) (found + 0x20);
+    return -1;
+}
+
+// True while the per-category (or per-variant, for categories 0-1) sfx cooldown timer is still
+// counting down. Throttles repeated one-shot sfx.
+// 0x00427360
+int swrSound_IsSfxOnCooldown(int category, int variant)
+{
+    if (category < 0 || 1 < category) {
+        if (0.0f < swrSound_sfxCategoryCooldown[category])
+            return 1;
+    } else if (0.0f < swrSound_sfxVariantCooldown[variant]) {
+        return 1;
+    }
+    return 0;
+}
+
+// Records a sound id in the 3-entry recent-sfx ring; returns nonzero when the write wraps.
+// 0x004273b0
+int swrSound_PushRecentSfx(short soundId)
+{
+    swrSound_recentSfxRing[swrSound_recentSfxWriteIndex] = soundId;
+    int next = swrSound_recentSfxWriteIndex + 1;
+    swrSound_recentSfxWriteIndex = (short) (next % 3);
+    return next / 3;
+}
+
+// 0x004273e0
+int swrSound_WasSfxRecentlyPlayed(int soundId)
+{
+    for (int i = 0; i < 3; i++) {
+        if (swrSound_recentSfxRing[i] == soundId)
+            return 1;
+    }
+    return 0;
+}
+
+// 0x00427670
+unsigned int swrSound_TestSfxFlag(int index, unsigned int mask)
+{
+    return swrSound_sfxFlags[index] & mask;
+}
+
+// 0x00427690
+void swrSound_SetSfxFlag(int index, unsigned int mask)
+{
+    swrSound_sfxFlags[index] |= mask;
+}
+
+// 0x004276a0
+void swrSound_ClearSfxFlag(int index, unsigned int mask)
+{
+    swrSound_sfxFlags[index] &= ~mask;
 }
 
 // 0x00427ad0


### PR DESCRIPTION
Reimplements **`swrSound_ResolveSfxId`** (0x427110) and the sfx flag/cooldown/recent-play leaves it sits with.

`ResolveSfxId` maps a `(category, variant, id)` sfx request to a loaded sound's handle. Its tail had resisted decompilation (encrypted `.text` + an indirect jumptable) — I recovered it by reading the raw bytes and hand-disassembling. The logic:
- the per-category remap table only **validates** the id (a negative entry = no sfx for that id);
- the `.wav` filename is built from the category prefix (+ a *variant* prefix for categories 0-1) and the **raw id**, tried plain then with an `a` suffix;
- looked up via `swrSound_Find`, returning `found + 0x20` (the handle) or `-1`.

Every bounds check matches the prologue disassembly; register mapping confirmed (`esi`=id, `ebp`=category, `ebx`=variant, `edi`=prefix).

Also reimplements the clean leaves: `IsSfxOnCooldown`, `PushRecentSfx`, `WasSfxRecentlyPlayed`, `TestSfxFlag`, `SetSfxFlag`, `ClearSfxFlag`.

Names the tables/state these touch (8 per-category id-validity tables; category + variant name-prefix tables; the 3-entry recent-sfx ring + its write index; the per-category/variant cooldown timers) and renames the placeholder `unk_statuses` -> `swrSound_sfxFlags`. The cooldown threshold (`0x4ac47c` = 0.0) is inlined.

Build links clean; duplicate-`_ADDR` scan clean. One substitution: standard `sprintf` in place of the game's `stdlib__sprintf` (identical output; not declared in any header).

`MarkSfxPlayed` and the `PlaySfx*` functions are a follow-up — they share a get-sound-length helper (`GetEntry`→`field/1000`) and a category-2 cooldown-source table that aliases the recent-sfx ring, so they're cleaner done together. Happy to match your DB names on any of the new globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
