### PR TITLE
swrAssetBuffer: name 4 functions (ResetToIndex, CheckOverflow, InvalidateTexturesBelow, GetStats)

### DIFF
--- a/src/Swr/swrAssetBuffer.h
+++ b/src/Swr/swrAssetBuffer.h
@@ -3,18 +3,24 @@
 
 #include "types.h"
 
+#define swrAssetBuffer_ResetToIndex_ADDR (0x00445aa0)
 #define swrAssetBuffer_SetBuffer_ADDR (0x00445b20)
 #define swrAssetBuffer_GetBuffer_ADDR (0x00445b40)
 #define swrAssetBuffer_InBounds_ADDR (0x00445b50)
 #define swrAssetBuffer_GetNewIndex_ADDR (0x00445b60)
-
+#define swrAssetBuffer_CheckOverflow_ADDR (0x00445b90)
 #define swrAssetBuffer_RemainingSize_ADDR (0x00445bf0)
+#define swrAssetBuffer_InvalidateTexturesBelow_ADDR (0x004475d0)
+#define swrAssetBuffer_GetStats_ADDR (0x00448d10)
 
+void swrAssetBuffer_ResetToIndex(int index);
 void swrAssetBuffer_SetBuffer(char* buffer);
 char* swrAssetBuffer_GetBuffer(void);
 BOOL swrAssetBuffer_InBounds(char* ptr);
 int swrAssetBuffer_GetNewIndex(unsigned int offset);
-
+void swrAssetBuffer_CheckOverflow(void);
 int swrAssetBuffer_RemainingSize(void);
+void swrAssetBuffer_InvalidateTexturesBelow(char* ptr);
+void swrAssetBuffer_GetStats(int* out1, int* out2, int* out3);
 
 #endif // SWRASSETBUFFER_H


### PR DESCRIPTION
Names four previously-`FUN_` asset-buffer functions from the decompilation, declaration-only (`_ADDR` + prototype), matching the existing decl-only convention. The new addresses splice into the address-sorted top block; no bodies or globals touched.

- `swrAssetBuffer_ResetToIndex` (0x00445aa0)
- `swrAssetBuffer_CheckOverflow` (0x00445b90)
- `swrAssetBuffer_InvalidateTexturesBelow` (0x004475d0)
- `swrAssetBuffer_GetStats` (0x00448d10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)