### PR TITLE
swrEvent: name Broadcast, BroadcastFiltered, FindNearestObjects

### DIFF
--- a/src/Swr/swrEvent.h
+++ b/src/Swr/swrEvent.h
@@ -143,6 +143,9 @@ swrEventManager eventManagerMain[][9] = {
 
 #define swrEvent_GetItem_ADDR (0x00450b30)
 
+#define swrEvent_BroadcastFiltered_ADDR (0x00450b90)
+#define swrEvent_Broadcast_ADDR (0x00450be0)
+
 #define swrEvent_DispatchSubEvents_ADDR (0x00450c00)
 
 #define swrEvent_CallF4_ADDR (0x00450c50)
@@ -152,6 +155,8 @@ swrEventManager eventManagerMain[][9] = {
 #define swrEvent_AllocObj_ADDR (0x00450d20)
 
 #define swrEvent_FreeObjs_ADDR (0x00450db0)
+
+#define swrEvent_FindNearestObjects_ADDR (0x00450e70)
 
 void  swrEvent_AllocateAndLoadObjs(int event, int count);
 void swrEvent_ClearObjs(int event);
@@ -172,6 +177,9 @@ int swrEvent_GetEventCount(int event);
 
 void* swrEvent_GetItem(int event, int index);
 
+void swrEvent_BroadcastFiltered(int event, int filter, int* data);
+void swrEvent_Broadcast(int event, int* data);
+
 void swrEvent_DispatchSubEvents(void* obj, int* subEvents); // int[2]
 
 void swrEvent_CallF4(int event, void* forward_param);
@@ -181,5 +189,7 @@ void* swrEvent_SetObjs(int event, int count, void* obj);
 void* swrEvent_AllocObj(int event);
 
 void swrEvent_FreeObjs(int event);
+
+int swrEvent_FindNearestObjects(int event, rdVector3* pos, float maxDistSq, void* excludeObj, int maxResults, float* outDistances, rdVector3* outDeltas, void** outObjects);
 
 #endif // SWREVENT_H


### PR DESCRIPTION
Names three previously-`FUN_` event functions from the decompilation, declaration-only (`_ADDR` + prototype), spliced into the address-sorted block.

- `swrEvent_BroadcastFiltered` (0x00450b90)
- `swrEvent_Broadcast` (0x00450be0) - thin wrapper that broadcasts with the "All!" filter
- `swrEvent_FindNearestObjects` (0x00450e70) - nearest-N event-object query by squared distance

🤖 Generated with [Claude Code](https://claude.com/claude-code)