### PR TITLE
Correct swrObjcMan camera-shake fields + spinout flag comments

### DIFF
--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -330,7 +330,7 @@ void swrRace_DeathSpeed(swrRace* player, float a, float b);
 // for the frame, clamped to +/-maxTurnRate. (annodue: CalcTargetTurnRate)
 void swrRace_CalcTargetTurnRate(swrRace* player);
 // Shows/hides the engine model nodes during a left/right spinout or explosion
-// (keys off flags2 0x8000/0x10000).
+// (keys off flags1 0x8000/0x10000).
 void swrRace_UpdateSpinoutNodes(swrRace* player);
 // Ground-contact / vertical-motion integrator: applies gravity, follows terrain
 // and the track spline for hover height, sets groundToPodMeasure (also returned).
@@ -366,7 +366,7 @@ void swrRace_HandleRespawnFlag(swrRace* player);
 void swrRace_PlayEngineSounds(swrRace* player, float param_2);
 // Tilts the engine transforms from pitch (0x2fc) and tilt angle (0x204).
 void swrRace_TiltEngines(swrRace* player);
-// Spins the engine transforms during a spinout/explosion (flags2 0x8000/0x10000).
+// Spins the engine transforms during a spinout/explosion (flags1 0x8000/0x10000).
 void swrRace_AnimateSpinoutEngines(swrRace* player);
 // Engine secondary motion: idle sway plus reaction to collision velocity.
 void swrRace_AnimateEngineWobble(swrRace* player);

--- a/src/types.h
+++ b/src/types.h
@@ -986,11 +986,15 @@ extern "C"
         rdVector3 unk368;
         rdVector3 unk374;
         rdVector3 unk380;
-        rdVector3 unk38c;
+        // Camera-shake ("earthquake") state, set by the 'Shak' sub-event (swrObjcMan_F4)
+        // and animated each frame by swrObjcMan_F3: .x = current offset (a triangle wave F3
+        // adds to the camera Z), .y = oscillation speed, .z = amplitude bound. .z is also the
+        // active flag -- non-zero only while a quake trigger (swrObjTrig type 0x69/0x138) runs.
+        rdVector3 camShake; // 0x38c
         float unk398_ms;
-        float camShakeOffset;
-        float camShakeSpeed;
-        float camShakeOffsetMax;
+        float unk39c;
+        float unk3a0;
+        float unk3a4;
     } swrObjcMan; // sizeof(0x3a8)
 
     typedef struct swrEventManager
@@ -1024,8 +1028,8 @@ extern "C"
         {
             struct swrObj_CmanMessageShak
             {
-                float unk4;
-                float unk8;
+                float offsetMax; // 0x4 -> camShake.z (amplitude bound; enabling value)
+                float speed;     // 0x8 -> camShake.y (oscillation speed)
             } cmanShak;
             struct swrObj_CmanMessageDeth
             {


### PR DESCRIPTION
Small header/doc corrections found while reverse-engineering the in-race "earthquake" (camera shake).

**swrObjcMan camera shake** — the shake state is the `rdVector3` at `+0x38c`, not the floats at `+0x39c`:
- `swrObjcMan_F4`'s `'Shak'` handler writes `+0x38c` (`.z` = amplitude bound, `.y` = speed, `.x` = offset reset to 0)
- `swrObjcMan_F3` oscillates `+0x38c` each frame and adds `.x` to the camera Z

So `+0x38c` becomes `camShake`, and the misnamed `camShakeOffset/Speed/OffsetMax` at `+0x39c/0x3a0/0x3a4` (off by `0x10`, no code touches them) go back to `unk`. Also named the `'Shak'` message payload fields.

**Spinout flag comments** — `swrRace_UpdateSpinoutNodes` and `swrRace_AnimateSpinoutEngines` comments said the spinout bits are in `flags2`; both functions actually read `flags1` (`0x8000` left / `0x10000` right). Corrected.

Header/doc only, no behavior change. Full `dinput.dll` build is green.