### PR TITLE
scripts: add a data_symbols.syms duplicate checker + fix 7 existing duplicate addresses

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -266,7 +266,7 @@ swrObjJdge_finishTriggered 0x004c5294 int
 
 miniMapAlpha 0x004C5298 float
 
-ai_level 0x004c707c float
+swrRace_AILevel 0x004c707c float
 ai_spread 0x004c7080 float
 
 Main_sound_3dimpact 0x004c7aa8 int = -1
@@ -276,8 +276,6 @@ Main_sound_doppler_scale 0x004c7d74 float = 1.0
 Main_sound_rolloff 0x004c7d78 float = 0.15
 Main_sound_gain 0x004c7d7c float = 1.0
 Sound_A3Dinitted 0x004c7d80 int = 1
-
-swrRace_AILevel 0x004c707c int
 
 swrRace_DeathSpeedMin 0x004c7bb8 float = 325.00
 swrRace_DeathSpeedDrop 0x004c7bbc float = 140.0
@@ -356,15 +354,10 @@ swrSpriteTexItems 0x004d7c68 swrSpriteTexItem[149]
 
 swrUI_unk4_ptr 0x004d878c swrUI_unk*
 swrUI_unk5_ptr 0x004d8790 swrUI_unk*
-swrUI_unk6_ptr 0x004d8794 swrUI_unk*
 
 multiplayer_in_mp 0x004d87a0 int
 
 SpritesLoaded 0x004d879c int
-
-swrUI_unk_array 0x004d8110 swrUI_unk*[20]
-
-swrUI_unk_array_count 0x004d87a4 int
 
 swr_unk_array2 0x004e9918 int[256]
 swrCallback_multiplayer 0x004e9d18 tSithCallback*[100]
@@ -1014,7 +1007,7 @@ swrText_designWidthRecip 0x004ac628 double # text X scale reciprocal, used in rd
 swrText_designHeightRecip 0x004ac630 double # text Y scale reciprocal, used in rdProcEntry_Add2DQuad2
 
 # swrUI menu page stack (push/pop navigation) and focus
-swrUI_focusedElement 0x004d8794 void* # element currently receiving key events
+swrUI_focusedElement 0x004d8794 swrUI_unk* # element currently receiving key events
 swrUI_pageStackDepth 0x004d87a4 int # top index into swrUI_pageStack
 swrUI_pageStack 0x004d8110 void* # swrUI_unk* pageStack[21]
 
@@ -1221,7 +1214,6 @@ fogEnd 0x00ec857c float
 
 rdCamera_mat 0x00ec8580 rdMatrix34
 
-screen_height 0x00ec85e8 int
 rdCamera_main_ptr 0x00ec85ec rdCamera*
 
 stdDisplayWindow_g 0x00ec85fc StdVideoMode
@@ -1235,7 +1227,6 @@ swrConfig_VIDEO_ENGINEEXHAUST 0x00ec86b4 int
 swrConfig_VIDEO_TEXTURE_RES 0x00ec86b8 int
 swrConfig_VIDEO_MODEL_DETAIL 0x00ec86bc int
 swrConfig_VIDEO_DRAWDISTANCE 0x00ec86c0 int
-screen_width 0x00ec86c4 int
 
 tagRect 0x00ec86d0 LECRECT
 
@@ -1247,7 +1238,7 @@ g_mouse_x 0x00ec874c int
 g_mouse_x2 0x00ec8750 int
 
 g_mouse_y 0x00ec8754 int
-g_mouse_y2 0x00ec8754 int
+g_mouse_y2 0x00ec8758 int
 
 Deadzone 0x00ec876c float
 swrConfig_mouseNbButtons 0x00ec8770 int

--- a/dinput_hook/game_deltas/DirectX_delta.c
+++ b/dinput_hook/game_deltas/DirectX_delta.c
@@ -53,8 +53,8 @@ size_t depth_data_size = 0;
 // 0x00431C40
 void DirectDraw_LockZBuffer_delta(uint32_t *bytes_per_depth_value, LONG *pitch, LPVOID *data,
                                   float *near_, float *far_) {
-    int w = screen_width;
-    int h = screen_height;
+    int w = swrDisplay_screenWidth;
+    int h = swrDisplay_screenHeight;
     // allocate one line more for scratch memory
     const size_t new_depth_data_size = w * (h + 1) * 2;
     if (new_depth_data_size != depth_data_size) {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -818,8 +818,8 @@ void swrViewport_Render_Hook(int x) {
     const int default_light_index = 0;
     const int default_num_enabled_lights = 1;
 
-    int w = screen_width;
-    int h = screen_height;
+    int w = swrDisplay_screenWidth;
+    int h = swrDisplay_screenHeight;
 
     const bool fog_enabled = (GameSettingFlags & 0x40) == 0;
     if (fog_enabled)

--- a/dinput_hook/renderer_utils.cpp
+++ b/dinput_hook/renderer_utils.cpp
@@ -262,7 +262,7 @@ extern "C" void renderer_drawRenderList(int verticesCount, LPD3DTLVERTEX aVertic
     glUseProgram(shader.handle);
 
     rdMatrix44 projectionMatrix;
-    renderer_setOrtho(&projectionMatrix, 0, screen_width, screen_height, 0, 0, -1);
+    renderer_setOrtho(&projectionMatrix, 0, swrDisplay_screenWidth, swrDisplay_screenHeight, 0, 0, -1);
 
     glUniformMatrix4fv(shader.proj_matrix_pos, 1, GL_FALSE, &projectionMatrix.vA.x);
 
@@ -1900,7 +1900,7 @@ void draw_test_scene() {
     moveCamera();
 
     float fov = 45.0;
-    float aspect_ratio = float(screen_width) / float(screen_height);
+    float aspect_ratio = float(swrDisplay_screenWidth) / float(swrDisplay_screenHeight);
 
     static rdMatrix44 proj_mat;
     renderer_perspective(&proj_mat, fov * 3.141592 / 180, aspect_ratio, 0.01, 1000.0);

--- a/scripts/Ghidra/check_data_symbols_dups.py
+++ b/scripts/Ghidra/check_data_symbols_dups.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Check data_symbols.syms for duplicate names or addresses.
+
+Duplicates make importDataSymbols.py create clashing Ghidra labels and overlapping
+data definitions, so we reject them before they land. Run standalone (NOT inside
+Ghidra):
+
+    python scripts/Ghidra/check_data_symbols_dups.py [path/to/data_symbols.syms]
+
+Exits non-zero and prints every offending entry if any duplicate is found, so it
+can gate a pre-PR check or CI; exits 0 when clean. Parsing mirrors
+importDataSymbols.py: lines shorter than 2 chars, '//' lines and '#' lines are
+skipped, trailing // or # comments are stripped, and a valid entry needs at least
+'name 0xADDR type'.
+"""
+import sys
+from collections import defaultdict
+
+
+def parse(path):
+    """Return a list of (lineno, name, addr_int, stripped_line) symbol entries."""
+    entries = []
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw
+            if len(line) < 2:
+                continue
+            if line[:2] == "//":
+                continue
+            if line[:1] == "#":
+                continue
+            line = line.split("//")[0]
+            line = line.split("#")[0]
+            pieces = line.split()
+            if len(pieces) < 3:
+                continue
+            name = pieces[0]
+            try:
+                addr_int = int(pieces[1], 16)
+            except ValueError:
+                print("WARN line {}: cannot parse address {!r}: {}".format(
+                    lineno, pieces[1], raw.strip()))
+                continue
+            entries.append((lineno, name, addr_int, raw.strip()))
+    return entries
+
+
+def main(argv):
+    path = argv[1] if len(argv) > 1 else "data_symbols.syms"
+    entries = parse(path)
+
+    by_name = defaultdict(list)
+    by_addr = defaultdict(list)
+    for lineno, name, addr, raw in entries:
+        by_name[name].append((lineno, addr, raw))
+        by_addr[addr].append((lineno, name, raw))
+
+    dup_names = {n: v for n, v in by_name.items() if len(v) > 1}
+    dup_addrs = {a: v for a, v in by_addr.items() if len(v) > 1}
+
+    if dup_names:
+        print("DUPLICATE NAMES ({}):".format(len(dup_names)))
+        for name, occ in sorted(dup_names.items()):
+            print("  {} appears {} times:".format(name, len(occ)))
+            for lineno, addr, raw in occ:
+                print("    line {}: {}".format(lineno, raw))
+
+    if dup_addrs:
+        print("DUPLICATE ADDRESSES ({}):".format(len(dup_addrs)))
+        for addr, occ in sorted(dup_addrs.items()):
+            names = {n for _, n, _ in occ}
+            kind = "same name" if len(names) == 1 else "CONFLICTING names"
+            print("  0x{:08x} appears {} times ({}):".format(addr, len(occ), kind))
+            for lineno, name, raw in occ:
+                print("    line {}: {}".format(lineno, raw))
+
+    if dup_names or dup_addrs:
+        print("\nFAIL: {} duplicate name(s), {} duplicate address(es).".format(
+            len(dup_names), len(dup_addrs)))
+        return 1
+
+    print("OK: {} symbols, no duplicate names or addresses.".format(len(entries)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -149,7 +149,7 @@ swrUI_unk* swrUI_GetUI5(void)
 // 0x00415000
 swrUI_unk* swrUI_GetUI6(void)
 {
-    return swrUI_unk6_ptr;
+    return swrUI_focusedElement;
 }
 
 // 0x00415010

--- a/src/Win95/stdConsole.c
+++ b/src/Win95/stdConsole.c
@@ -16,7 +16,7 @@ int stdConsole_GetCursorPos(int* out_x, int* out_y)
         res = GetCursorPos(&point);
         if (res != 0)
         {
-            if (screen_width == 0x200)
+            if (swrDisplay_screenWidth == 0x200)
             {
                 *out_x = point.x + (point.x >> 2);
                 *out_y = point.y + (point.y >> 2);
@@ -33,9 +33,9 @@ int stdConsole_GetCursorPos(int* out_x, int* out_y)
 // 0x00408360
 void stdConsole_SetCursorPos(int X, int Y)
 {
-    if (screen_width == 0x200)
+    if (swrDisplay_screenWidth == 0x200)
     {
-        SetCursorPos((X << 9) / 0x280, (Y * screen_height) / 0x1e0);
+        SetCursorPos((X << 9) / 0x280, (Y * swrDisplay_screenHeight) / 0x1e0);
         return;
     }
     SetCursorPos(X, Y);


### PR DESCRIPTION
Adds `scripts/Ghidra/check_data_symbols_dups.py` -- the dup-check tool you asked for on #107. It parses `data_symbols.syms` the same way `importDataSymbols.py` does and exits non-zero on any duplicate name or address (those make the importer create clashing Ghidra labels + overlapping data defs).

Running it flagged 7 addresses each defined under two names; fixed them all:

- `ai_level` / `swrRace_AILevel` -> one entry, `swrRace_AILevel` typed **float** (it's clamped to [0.2, 2.0] as a float in `swrRace.c`)
- `swrUI_unk_array` / `swrUI_unk_array_count` / `swrUI_unk6_ptr` -> the resolved `swrUI_pageStack` / `swrUI_pageStackDepth` / `swrUI_focusedElement` (retyped `focusedElement` to `swrUI_unk*` so `swrUI_GetUI6` returns it directly)
- `screen_width` / `screen_height` -> `swrDisplay_screenWidth` / `swrDisplay_screenHeight` (renamed the renderer + stdConsole call sites)
- `g_mouse_y2` was duplicating `g_mouse_y`'s address; corrected to `0x00ec8758` (the previous-frame Y written by `swrUI_UpdateMouseState`)

Checker now reports 0 dups; full dll build links clean.