### PR TITLE
swrObj: fix swrObjJdge_F4 build break (unk1c4 -> aiSpeedSetting)

### DIFF
--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -317,7 +317,7 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
         jdge->num_laps = subEvents[9];
         jdge->best_lap_time_ms = *(float*) (p3 + 0x28);
         jdge->recordLap3_ms = *(float*) (p3 + 0x2c);
-        jdge->unk1c4 = subEvents[0xc];
+        jdge->aiSpeedSetting = subEvents[0xc];
         if (subEvents[0xd] == 1)
             GameSettingFlags |= 0x4000;
         else


### PR DESCRIPTION
Master currently fails to compile `src/Swr/swrObj.c`:

```
swrObj.c:320: error: 'swrObjJdge' has no member named 'unk1c4'; did you mean 'unk174'?
```

The `swrObjJdge_F4` race-config (`'Begn'`) handler still writes `jdge->unk1c4`, but that field (offset `0x1c4`) was renamed to `aiSpeedSetting` in d858bad (AI difficulty reimpl) and this consumer wasn't updated. It's the same field — `subEvents[0xc]` is the AI Speed setting pulled from the race config — so this just points the write at the current name.

One-line change. Full `dinput.dll` build links clean with it applied (WinLibs GCC 13.2).