### PR TITLE
imgui: remove orphaned imgui_state.logs.clear() (fixes full build)

### DIFF
--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -707,9 +707,6 @@ void opengl_render_imgui() {
     if (ImGui::Button("Show Log"))
         imgui_state.show_logs = true;
 
-    imgui_state.logs.clear();
-
-
     if (ImGui::TreeNodeEx("highlight textures from map")) {
         ImGui::Checkbox("Show texture hovered by mouse cursor",
                         &imgui_state.enable_picking_texture_when_hovering);


### PR DESCRIPTION
PR #133 swapped the old string-buffer log for the floating `DebugLog` window (`g_debug_log`) and removed the `ImGuiState::logs` member, but left an orphaned `imgui_state.logs.clear();` behind in `opengl_render_imgui()`.

It's unconditional (not behind `NDEBUG`), so a full `-DRENDERER_REPLACEMENT=ON` build fails:

```
imgui_utils.cpp: error: 'ImGuiState' {aka 'struct ImGuiState'} has no member named 'logs'
```

CI is green only because it builds the no-ImGui config. One-line removal; the "Show Log" button and the `g_debug_log` window are untouched. Verified with a full WinLibs build.