### PR TITLE
fix: lap times show 00.00 on normal races (100-lap regression)

### DIFF
--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -262,7 +262,7 @@ void swrText_CreateTimeEntryPrecise_delta(int x, int y, int unused, int r, int g
 #define SCORE_LAP2       0x64 // float, slot 1 (we mirror the last completed lap time here)
 #define SCORE_TOTAL_TIME 0x74 // float
 #define SCORE_CUR_LAP    0x78 // int, completed-lap count for this racer
-#define JDGE_NUM_RACERS  0x1ac
+#define JDGE_NUM_RACERS  0x1bc // swrObjJdge::num_players (total racers, local + AI); 0x1ac is planetId
 #define JDGE_NUM_LAPS    0x1c8
 
 #define LAP_RACER_MAX 24


### PR DESCRIPTION
The 100-lap PR (#97) de-indexed the score's per-lap split array and reconstructs each lap's time in `swrObjJdge_F2_delta`, which loops over the racers in the score array. The loop bound `JDGE_NUM_RACERS` was `0x1ac` -- but that's `swrObjJdge::planetId`, not the racer count. `num_players` is `0x1bc`.

So reconstruction only ran for racers whose score index was `< planetId`. Any racer at index `>= planetId` got skipped -- the local player on low-`planetId` tracks, or every racer when `planetId == 0` -- leaving `g_lastLap` / `g_lapTimes` at zero. Net effect: the in-race "LAP TIME" flash and the `<=5`-lap results screen both show **00.00**. The total race timer was fine because it reads the live score (`+0x74`) directly, not the reconstruction -- which is why only lap times broke.

One-char fix: `0x1ac` -> `0x1bc`. Offset double-checked against `swrRace_InRaceTimer`, which reads `jdge+0x1bc` as the "POS x/N" total-racer count and `jdge+0x1c8` as `num_laps`. Builds + links clean.
