### PR TITLE
Bind HD pod replacement to the owning racer entity

### DIFF
--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -14,6 +14,7 @@
 
 #include "replacements.h"
 #include "renderer_utils.h"
+#include "node_utils.h"
 #include "texture_replacement.h"
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
@@ -702,6 +703,25 @@ void opengl_render_imgui() {
     if (imgui_state.show_replacementTries) {
         ImGui::Text("%s\n", imgui_state.replacementTries.c_str());
         imgui_state.replacementTries.clear();
+    }
+
+    // Phase 0 readout (HD_REPLACEMENT_ROADMAP): the live pod-node -> racer-entity map. In a race this
+    // should list one entry per racer, each resolving to a distinct pod MODELID + owning entity, with
+    // exactly the local player(s) flagged LOCAL (flags0 & 0x20). Confirms the resolver populates.
+    if (currentPlayer_Test != nullptr) {
+        if (ImGui::TreeNodeEx(
+                ("Pod node owners: " + std::to_string(pod_node_owners.size())).c_str())) {
+            swrRace *p1 = (firstLocalPlayer != nullptr) ? firstLocalPlayer->obj_test_ptr : nullptr;
+            for (const PodNodeOwner &o: pod_node_owners) {
+                std::optional<MODELID> id = find_model_id_for_node((const swrModel_Node *) o.begin);
+                const char *name = id.has_value() ? modelid_cstr[id.value()] : "?";
+                bool isLocal = (o.entity->flags0 & 0x20) != 0;
+                ImGui::Text("%-26s %p f0=%08X %s%s", name, (void *) o.entity,
+                            (unsigned) o.entity->flags0, isLocal ? "LOCAL" : "AI",
+                            (o.entity == p1) ? " (P1)" : "");
+            }
+            ImGui::TreePop();
+        }
     }
 
     if (ImGui::Button("Show Log"))

--- a/dinput_hook/node_utils.cpp
+++ b/dinput_hook/node_utils.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include <swr.h>
 #include <Primitives/rdMatrix.h>
 #include <Swr/swrModel.h>
+#include <globals.h>
 }
 #ifndef NDEBUG
 NodeMember node_members[5]{
@@ -87,6 +88,7 @@ int num_sprites_with_flag[32] = {};
 
 swrModel_Node *root_node = nullptr;
 std::vector<AssetPointerToModel> asset_pointer_to_model;
+std::vector<PodNodeOwner> pod_node_owners;
 
 std::optional<MODELID> find_model_id_for_node(const swrModel_Node *node) {
     char *raw_ptr = (char *) node;
@@ -101,6 +103,80 @@ std::optional<MODELID> find_model_id_for_node(const swrModel_Node *node) {
         return std::nullopt;// internal static node
 
     return it->id;
+}
+
+// Non-aborting variant of the lookup above: returns the asset range containing the node, or nullptr
+// for an internal/static node (e.g. the per-racer pod wrapper, which lives in a static pool, not the
+// asset buffer) or a node past all known ranges.
+static const AssetPointerToModel *find_asset_range_for_node(const swrModel_Node *node) {
+    char *raw_ptr = (char *) node;
+    auto it = std::upper_bound(
+        asset_pointer_to_model.begin(), asset_pointer_to_model.end(), raw_ptr,
+        [](char *p, const AssetPointerToModel &elem) { return p < elem.asset_pointer_end; });
+
+    if (it == asset_pointer_to_model.end() || raw_ptr < it->asset_pointer_begin)
+        return nullptr;
+
+    return &*it;
+}
+
+// Walks a node subtree to find the first descendant that lives in an asset buffer range. Used to map
+// a racer's pod wrapper node (a static-pool node, not in any range) down to its pod model, which is.
+// The pod root is the wrapper's direct child, so this resolves at depth 1 in practice; the bounded
+// recursion is just defensive.
+static const swrModel_Node *first_node_in_asset_range(const swrModel_Node *node, int depth) {
+    if (node == nullptr || depth > 6)
+        return nullptr;
+
+    if (find_asset_range_for_node(node) != nullptr)
+        return node;
+
+    // Not in a range: descend. NODE_MESH_GROUP's children union holds meshes, not nodes, so skip it.
+    if (node->type != NODE_MESH_GROUP) {
+        for (uint32_t i = 0; i < node->num_children; i++) {
+            const swrModel_Node *found = first_node_in_asset_range(node->children.nodes[i], depth + 1);
+            if (found != nullptr)
+                return found;
+        }
+    }
+    return nullptr;
+}
+
+void rebuild_pod_node_owners() {
+    pod_node_owners.clear();
+
+    // swrScores[20] is the full roster. A slot is live iff its entity's back-pointer agrees
+    // (score_ptr == &this score) - this rejects empty/stale slots without needing a racer count.
+    for (int i = 0; i < 20; i++) {
+        swrRace *entity = swrScores[i].obj_test_ptr;
+        if (entity == nullptr || entity->score_ptr != &swrScores[i] ||
+            entity->unk1994_node == nullptr)
+            continue;
+
+        const swrModel_Node *pod_root = first_node_in_asset_range(entity->unk1994_node, 0);
+        if (pod_root == nullptr)
+            continue;
+
+        const AssetPointerToModel *range = find_asset_range_for_node(pod_root);
+        if (range == nullptr)
+            continue;
+
+        pod_node_owners.push_back({range->asset_pointer_begin, range->asset_pointer_end, entity});
+    }
+
+    std::sort(pod_node_owners.begin(), pod_node_owners.end(),
+              [](const PodNodeOwner &a, const PodNodeOwner &b) { return a.begin < b.begin; });
+}
+
+swrRace *find_entity_for_node(const swrModel_Node *node) {
+    char *raw_ptr = (char *) node;
+    auto it = std::upper_bound(pod_node_owners.begin(), pod_node_owners.end(), raw_ptr,
+                               [](char *p, const PodNodeOwner &elem) { return p < elem.end; });
+
+    if (it == pod_node_owners.end() || raw_ptr < it->begin)
+        return nullptr;
+
+    return it->entity;
 }
 
 void apply_node_transform(rdMatrix44 &model_mat, const swrModel_Node *node,

--- a/dinput_hook/node_utils.h
+++ b/dinput_hook/node_utils.h
@@ -32,6 +32,15 @@ struct AssetPointerToModel {
     MODELID id;
 };
 
+// Maps a contiguous pod-model asset range to the racer entity that owns it. Each racer loads its own
+// distinct copy of its pod model (swrModel_LoadFromId never caches), so the ranges are disjoint and a
+// node pointer resolves to exactly one owner. Rebuilt per frame from the swrScores[] roster.
+struct PodNodeOwner {
+    char *begin;
+    char *end;
+    swrRace *entity;
+};
+
 extern swrModel_Node *root_node;
 #ifndef NDEBUG
 extern uint32_t banned_sprite_flags;
@@ -40,8 +49,17 @@ extern NodeMember node_members[5];
 extern MaterialMember node_material_members[9];
 #endif
 extern std::vector<AssetPointerToModel> asset_pointer_to_model;
+extern std::vector<PodNodeOwner> pod_node_owners;
 
 std::optional<MODELID> find_model_id_for_node(const swrModel_Node *node);
+
+// Rebuilds pod_node_owners from the live racer roster (swrScores[]). Cheap (<=20 entries); call once
+// per frame before scene traversal while in a race.
+void rebuild_pod_node_owners();
+
+// Resolves a scene node to the racer entity whose pod model owns it, or nullptr if the node is not
+// part of any racer's pod (track/env/internal nodes, or not in a race).
+swrRace *find_entity_for_node(const swrModel_Node *node);
 
 void apply_node_transform(rdMatrix44 &model_mat, const swrModel_Node *node,
                           rdVector3 *viewport_position);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -547,9 +547,18 @@ void debug_render_node(const swrViewport &current_vp, const swrModel_Node *node,
     // inspection hangar is pln_tatooine_part and not a pod ID
     if (node->type == NODE_BASIC && node_model_id.has_value() &&
         (isPodModel(node_model_id.value()) || node_model_id.value() == MODELID_pln_tatooine_part)) {
-        if (try_replace_pod(node_model_id.value(), proj_mat, view_mat, model_mat, envInfos,
-                            false) &&
-            !imgui_state.show_original_and_replacements) {
+        // Resolve the pod node to its owning racer. Non-null only for full-pod racers in a race (the
+        // local player and, with ai_full_lod on, every AI) - draw from THAT entity's own transforms
+        // instead of stamping the single global currentPlayer_Test. This is the fix for the "pile of
+        // pods riding the player". Null in the hangar / for part-LOD AI -> legacy node-path draw.
+        swrRace *pod_owner = find_entity_for_node(node);
+        const bool replaced =
+            pod_owner != nullptr
+                ? try_replace_pod_entity(node_model_id.value(), pod_owner, proj_mat, view_mat,
+                                         envInfos, false)
+                : try_replace_pod(node_model_id.value(), proj_mat, view_mat, model_mat, envInfos,
+                                  false);
+        if (replaced && !imgui_state.show_original_and_replacements) {
             return;
         }
     }
@@ -567,7 +576,7 @@ void debug_render_node(const swrViewport &current_vp, const swrModel_Node *node,
     // Track replacements
     // In race, node 3 is the track, as a NODE_BASIC
     if (node->type == NODE_BASIC && node_model_id.has_value() &&
-        (uint32_t) root_node == 0x00E28980 && isTrackModel(node_model_id.value())) {
+        (uint32_t) root_node == (uint32_t) &someRootNode && isTrackModel(node_model_id.value())) {
         if (try_replace_track(node_model_id.value(), proj_mat, view_mat, envInfos, false) &&
             !imgui_state.show_original_and_replacements) {
             return;
@@ -575,7 +584,7 @@ void debug_render_node(const swrViewport &current_vp, const swrModel_Node *node,
     }
     // Env replacement: Hangar, Cantina, Shop and Scrapyard
     if ((node->type == NODE_TRANSFORMED_WITH_PIVOT) && node_model_id.has_value() &&
-        (uint32_t) root_node == 0x00E2A660 && isEnvModel(node_model_id.value())) {
+        (uint32_t) root_node == (uint32_t) &someUnkRootNode && isEnvModel(node_model_id.value())) {
         if (try_replace_env(node_model_id.value(), proj_mat, view_mat, envInfos, false) &&
             !imgui_state.show_original_and_replacements) {
             return;
@@ -891,6 +900,16 @@ void swrViewport_Render_Hook(int x) {
         member.count.clear();
     }
 #endif
+    // Phase 0 (HD_REPLACEMENT_ROADMAP): refresh the pod-node -> racer-entity map from the live roster
+    // before traversal, so the replacement path can draw each pod from its owning racer's transforms.
+    // In race only (currentPlayer_Test is the in-race signal); harmless to rebuild per viewport.
+    // Outside a race (hangar/menu) clear it, so stale ranges from the last race can't mis-resolve a
+    // hangar pod node to a dangling entity.
+    if (currentPlayer_Test != nullptr)
+        rebuild_pod_node_owners();
+    else
+        pod_node_owners.clear();
+
     debug_render_node(vp, root_node, default_light_index, default_num_enabled_lights, mirrored,
                       proj_mat, view_mat_corrected, model_mat);
     PopDebugGroup();

--- a/dinput_hook/replacements.cpp
+++ b/dinput_hook/replacements.cpp
@@ -773,99 +773,33 @@ bool try_replace_pod(MODELID model_id, const rdMatrix44 &proj_matrix, const rdMa
             cockpit_node_index = 18;
         }
 
-        // In a race. Static pointer
-        if ((uint32_t) root_node == 0x00E28980) {
-            // Blue flash on respawn invincibility / spinout (issue #30). Same flicker is reused for
-            // the mirror reflection below; reset to white at the end so other models are untinted.
-            g_pod_tint = compute_pod_flash_tint(currentPlayer_Test);
+        // Hangar inspection only: in-race pods now draw through try_replace_pod_entity, keyed to the
+        // owning racer. root_node here is the hangar scene; slot 15 holds the selected _pod.
+        if (root_node != nullptr) {
+            swrModel_Node *pod_slot = root_node->children.nodes[15];
+            if (pod_slot != nullptr) {
+                swrModel_Node *node_to_replace = pod_slot->children.nodes[0];
 
-            renderer_drawGLTFPod(proj_matrix, view_matrix, currentPlayer_Test->engineXfR,
-                                 currentPlayer_Test->engineXfL, currentPlayer_Test->cockpitXf,
-                                 replacement.model, envInfos, mirrored, 0);
-
-            // Always clear this visibility flag, to prevent visual issues with the mirrored pod
-            // unset visibility flag for node 1 will remove mirror reflexion
-            root_node->children.nodes[1]->flags_1 &= ~0x2;
-            // Check if on a mirrored face by looking at flags for node 1 0.
-            // If we are, also render the pod upside down somehow
-            if (root_node->children.nodes[1]->children.nodes[0]->flags_1 & 0x2) {
-                // Check if both engines are alive to draw the mirror (spinning causes error)
-                swrModel_Node *engineR_node = root_node->children.nodes[1]
-                                                  ->children.nodes[0]
-                                                  ->children.nodes[0]
-                                                  ->children.nodes[2];
-                swrModel_Node *engineL_node = root_node->children.nodes[1]
-                                                  ->children.nodes[0]
-                                                  ->children.nodes[0]
-                                                  ->children.nodes[3];
-                if (!(!(engineR_node->flags_1 & 0x2) || !(engineL_node->flags_1 & 0x2))) {
-                    // Rotate along Z axis by 180 degrees, and scale all axes by -1 to mirror (prevent non-uniform scale)
-                    // This upper 3x3 matrix is the same as the one in the node 1-0
-                    rdMatrix44 mirrorMatrix = rdMatrix44{
-                        .vA = {1, 0, 0, 0},
-                        .vB = {0, 1, 0, 0},
-                        .vC = {0, 0, -1, 0},
-                        .vD = {0, 0, 0, 1},
-                    };
-
-                    // offset along Z-axis, translate before rotation
-                    const rdVector3 v = rdVector3{0.0, 0.0, -5.0};
-                    const rdVector3 v_transformed = {
-                        mirrorMatrix.vA.x * v.x + mirrorMatrix.vB.x * v.y + mirrorMatrix.vC.x * v.z,
-                        mirrorMatrix.vA.y * v.x + mirrorMatrix.vB.y * v.y + mirrorMatrix.vC.y * v.z,
-                        mirrorMatrix.vA.z * v.x + mirrorMatrix.vB.z * v.y + mirrorMatrix.vC.z * v.z,
-                    };
-                    mirrorMatrix.vD.x += v.x - v_transformed.x;
-                    mirrorMatrix.vD.y += v.y - v_transformed.y;
-                    mirrorMatrix.vD.z += v.z - v_transformed.z;
-
-                    rdMatrix44 engineRMirror = currentPlayer_Test->engineXfR;
-                    rdMatrix_Multiply44(&engineRMirror, &mirrorMatrix, &engineRMirror);
-
-                    rdMatrix44 engineLMirror = currentPlayer_Test->engineXfL;
-                    rdMatrix_Multiply44(&engineLMirror, &mirrorMatrix, &engineLMirror);
-
-                    rdMatrix44 cockpitMirror = currentPlayer_Test->cockpitXf;
-                    rdMatrix_Multiply44(&cockpitMirror, &mirrorMatrix, &cockpitMirror);
-
-                    renderer_drawGLTFPod(proj_matrix, view_matrix, engineRMirror, engineLMirror,
-                                         cockpitMirror, replacement.model, envInfos, mirrored, 0);
+                // resolve matrices transform
+                rdMatrix44 engineR_mat = model_matrix;
+                rdMatrix44 engineL_mat = model_matrix;
+                rdMatrix44 cockpit_mat = model_matrix;
+                {
+                    swrModel_Node *engineR_node = node_to_replace->children.nodes[2];
+                    apply_node_transform(engineR_mat, engineR_node, nullptr);
+                    swrModel_Node *engineL_node = node_to_replace->children.nodes[engineL_node_index];
+                    apply_node_transform(engineL_mat, engineL_node, nullptr);
+                    swrModel_Node *cockpit_node = node_to_replace->children.nodes[cockpit_node_index];
+                    apply_node_transform(cockpit_mat, cockpit_node, nullptr);
                 }
-            }
-        } else {// root_node should be 0x00E2A660
-            // Selecting and Inspecting
-            if (root_node != nullptr) {
-                // Slot 15 selected _pod
-                swrModel_Node *pod_slot = root_node->children.nodes[15];
-                if (pod_slot != nullptr) {
-                    swrModel_Node *node_to_replace = pod_slot->children.nodes[0];
-
-                    // resolve matrices transform
-                    rdMatrix44 engineR_mat = model_matrix;
-                    rdMatrix44 engineL_mat = model_matrix;
-                    rdMatrix44 cockpit_mat = model_matrix;
-                    {
-                        swrModel_Node *engineR_node = node_to_replace->children.nodes[2];
-                        apply_node_transform(engineR_mat, engineR_node, nullptr);
-                        swrModel_Node *engineL_node =
-                            node_to_replace->children.nodes[engineL_node_index];
-                        apply_node_transform(engineL_mat, engineL_node, nullptr);
-                        swrModel_Node *cockpit_node =
-                            node_to_replace->children.nodes[cockpit_node_index];
-                        apply_node_transform(cockpit_mat, cockpit_node, nullptr);
-                    }
-                    renderer_drawGLTFPod(proj_matrix, view_matrix, engineR_mat, engineL_mat,
-                                         cockpit_mat, replacement.model, envInfos, mirrored, 0);
-                }
+                renderer_drawGLTFPod(proj_matrix, view_matrix, engineR_mat, engineL_mat, cockpit_mat,
+                                     replacement.model, envInfos, mirrored, 0);
             }
         }
         PopDebugGroup();
 
-        // Done drawing the pod (incl. mirror): clear the flash tint so other HD models aren't tinted.
-        g_pod_tint = {1.0f, 1.0f, 1.0f};
-
         addImguiReplacementString(std::string(modelid_cstr[model_id]) +
-                                  std::string(" player pod REPLACED \n"));
+                                  std::string(" inspection pod REPLACED \n"));
         replacedTries[model_id] |= replacementFlag::Mirrored | replacementFlag::Normal;
 
         return true;
@@ -873,11 +807,100 @@ bool try_replace_pod(MODELID model_id, const rdMatrix44 &proj_matrix, const rdMa
 
     if (replacedTries[model_id] == 0) {
         addImguiReplacementString(std::string(modelid_cstr[model_id]) +
-                                  std::string(" player pod\n"));
+                                  std::string(" inspection pod\n"));
         replacedTries[model_id] += 1;
     }
 
     return false;
+}
+
+// Phase 1 (HD_REPLACEMENT_ROADMAP): in-race HD pod draw bound to the OWNING racer entity rather than
+// the single global currentPlayer_Test. Called for every full-pod racer (the local player, and with
+// ai_full_lod on every AI), whose engineXf/cockpitXf are written per-entity by swrRace_PoddAnimateEngines.
+// This is what stops the "pile of pods on the player": each pod node resolves to its own racer and
+// draws at that racer's transforms. There is intentionally NO replacedTries guard here - the scene
+// traversal visits each pod node once per frame, so drawing on the visit is naturally one draw per pod.
+bool try_replace_pod_entity(MODELID model_id, swrRace *owner, const rdMatrix44 &proj_matrix,
+                            const rdMatrix44 &view_matrix, EnvInfos envInfos, bool mirrored) {
+    if (!imgui_state.HD_replacement)
+        return false;
+    if (owner == nullptr)
+        return false;
+
+    // Ark bumpy uses his alt pod as main one
+    if (model_id == MODELID_alt_bumpy_roose_pod)
+        model_id = MODELID_bumpy_roose_pod;
+
+    load_replacement_if_missing(model_id);
+
+    ReplacementModel &replacement = replacement_map[model_id];
+    if (!replacement.fileExist)
+        return false;// no HD model: fall through to the vanilla pod mesh
+
+    PushDebugGroup(std::format("Replace pod {}", modelid_cstr[model_id]));
+
+    // Blue flash on respawn invincibility / spinout (issue #30), now per-entity so AI pods flash too.
+    g_pod_tint = compute_pod_flash_tint(owner);
+
+    renderer_drawGLTFPod(proj_matrix, view_matrix, owner->engineXfR, owner->engineXfL,
+                         owner->cockpitXf, replacement.model, envInfos, mirrored, 0);
+
+    // Mirror reflection (Tatooine mirrored faces): the reflection subtree (root node child 1) is the
+    // local player's, so mirror only the local player for now. Per-entity reflections are future work.
+    const bool ownerIsLocal =
+        (firstLocalPlayer != nullptr && owner == firstLocalPlayer->obj_test_ptr);
+    if (ownerIsLocal && root_node != nullptr) {
+        // Always clear this visibility flag, to prevent visual issues with the mirrored pod
+        // unset visibility flag for node 1 will remove mirror reflexion
+        root_node->children.nodes[1]->flags_1 &= ~0x2;
+        // Check if on a mirrored face by looking at flags for node 1 0.
+        // If we are, also render the pod upside down somehow
+        if (root_node->children.nodes[1]->children.nodes[0]->flags_1 & 0x2) {
+            // Check if both engines are alive to draw the mirror (spinning causes error)
+            swrModel_Node *engineR_node =
+                root_node->children.nodes[1]->children.nodes[0]->children.nodes[0]->children.nodes[2];
+            swrModel_Node *engineL_node =
+                root_node->children.nodes[1]->children.nodes[0]->children.nodes[0]->children.nodes[3];
+            if (!(!(engineR_node->flags_1 & 0x2) || !(engineL_node->flags_1 & 0x2))) {
+                // Rotate along Z axis by 180 degrees, and scale all axes by -1 to mirror (prevent non-uniform scale)
+                // This upper 3x3 matrix is the same as the one in the node 1-0
+                rdMatrix44 mirrorMatrix = rdMatrix44{
+                    .vA = {1, 0, 0, 0},
+                    .vB = {0, 1, 0, 0},
+                    .vC = {0, 0, -1, 0},
+                    .vD = {0, 0, 0, 1},
+                };
+
+                // offset along Z-axis, translate before rotation
+                const rdVector3 v = rdVector3{0.0, 0.0, -5.0};
+                const rdVector3 v_transformed = {
+                    mirrorMatrix.vA.x * v.x + mirrorMatrix.vB.x * v.y + mirrorMatrix.vC.x * v.z,
+                    mirrorMatrix.vA.y * v.x + mirrorMatrix.vB.y * v.y + mirrorMatrix.vC.y * v.z,
+                    mirrorMatrix.vA.z * v.x + mirrorMatrix.vB.z * v.y + mirrorMatrix.vC.z * v.z,
+                };
+                mirrorMatrix.vD.x += v.x - v_transformed.x;
+                mirrorMatrix.vD.y += v.y - v_transformed.y;
+                mirrorMatrix.vD.z += v.z - v_transformed.z;
+
+                rdMatrix44 engineRMirror = owner->engineXfR;
+                rdMatrix_Multiply44(&engineRMirror, &mirrorMatrix, &engineRMirror);
+
+                rdMatrix44 engineLMirror = owner->engineXfL;
+                rdMatrix_Multiply44(&engineLMirror, &mirrorMatrix, &engineLMirror);
+
+                rdMatrix44 cockpitMirror = owner->cockpitXf;
+                rdMatrix_Multiply44(&cockpitMirror, &mirrorMatrix, &cockpitMirror);
+
+                renderer_drawGLTFPod(proj_matrix, view_matrix, engineRMirror, engineLMirror,
+                                     cockpitMirror, replacement.model, envInfos, mirrored, 0);
+            }
+        }
+    }
+
+    // Done drawing the pod (incl. mirror): clear the flash tint so other HD models aren't tinted.
+    g_pod_tint = {1.0f, 1.0f, 1.0f};
+    PopDebugGroup();
+    return true;
 }
 
 bool try_replace_AIPod(MODELID model_id, const rdMatrix44 &proj_matrix,

--- a/dinput_hook/replacements.h
+++ b/dinput_hook/replacements.h
@@ -7,6 +7,8 @@ extern "C" {
 #include <Swr/swrModel.h>
 }
 
+struct swrRace;
+
 extern uint8_t replacedTries[323];// 323 MODELIDs
 extern std::map<MODELID, uint8_t> additionnalReplacedTries;
 extern const char *modelid_cstr[];
@@ -29,6 +31,12 @@ bool try_replace(MODELID model_id, const rdMatrix44 &proj_matrix, const rdMatrix
 
 bool try_replace_pod(MODELID model_id, const rdMatrix44 &proj_matrix, const rdMatrix44 &view_matrix,
                      const rdMatrix44 &model_matrix, EnvInfos envInfos, bool mirrored);
+
+// In-race HD pod draw bound to the racer entity that owns the pod node (resolved via
+// find_entity_for_node), instead of the single global currentPlayer_Test. Draws from owner's own
+// engineXf/cockpitXf, so every full-pod racer (player + ai_full_lod AI) renders at its own position.
+bool try_replace_pod_entity(MODELID model_id, swrRace *owner, const rdMatrix44 &proj_matrix,
+                            const rdMatrix44 &view_matrix, EnvInfos envInfos, bool mirrored);
 
 bool try_replace_AIPod(MODELID model_id, const rdMatrix44 &proj_matrix,
                        const rdMatrix44 &view_matrix, const rdMatrix44 &model_matrix,


### PR DESCRIPTION
﻿The HD pod replacer drew every pod from the single global `currentPlayer_Test`. With `ai_full_lod` on (every AI becomes a full `_pod`), each AI pod hit the player draw path and got stamped on the local player - a pile of HD pods riding you. Latent with one replacement model; shows up with a full set.

This resolves each pod node to its owning racer via the `swrScores[]` roster (each racer loads a distinct pod copy and keeps its own pod node in `unk1994_node`) and draws from that entity's own `engineXf`/`cockpitXf`. The per-MODELID `replacedTries` dedup is dropped for pods (the traversal visits each pod node once), so N racers draw at their own positions; the respawn blue-flash tint is per-entity now, so AI pods flash too.

`try_replace_pod` is reduced to hangar inspection only, which drops the dead `currentPlayer_Test` in-race branch and a raw address literal; the env/track scene-root checks use the named `someRootNode`/`someUnkRootNode` globals.

Playtested on a 12-racer grid with full-LOD AI + multiple HD pods: each draws on its own pod, no pile. Hangar inspection still fine. Includes a small Pod node owners ImGui dev readout - easy to drop if you would rather not have it.

Separate known issue (not this PR): the Tatooine pod reflection drops out after ~5s - confirmed to be the game dropping the reflection-subtree visibility (vanilla GL breaks the same way), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
