### PR TITLE
CI: always put WinLibs on PATH (fix cache-hit 64-bit fallback)

### DIFF
--- a/.github/workflows/integrity_check.yml
+++ b/.github/workflows/integrity_check.yml
@@ -46,6 +46,12 @@ jobs:
 
           Expand-Archive winlibs.zip -DestinationPath C:\winlibs
 
+      # Must run on cache HIT too: the download step above is skipped when the cache is warm, so if
+      # the PATH export lived inside it, `g++` would fall back to the runner's 64-bit C:\mingw64
+      # toolchain and the 32-bit mod would fail to compile (pointer->GLuint casts lose precision).
+      - name: Add WinLibs to PATH
+        shell: pwsh
+        run: |
           $root = Get-ChildItem C:\winlibs -Directory | Select-Object -First 1
 
           "$($root.FullName)\bin" | Out-File `


### PR DESCRIPTION
The integrity-check went red on master and every open PR after the WinLibs/cache rework. The WinLibs i686 GITHUB_PATH export lives inside the cache-miss-only Download WinLibs step, so on a cache hit it is skipped and g++ resolves to the runner pre-installed 64-bit C:\mingw64\bin\g++.exe. The 32-bit mod pointer-to-GLuint casts (e.g. std3D_delta.cpp:197 and :321) then fail to compile with loses-precision errors.

This moves the PATH export to its own unconditional step so WinLibs (32-bit) is on PATH on both cache hit and miss. #139 passed only because it ran on a cold cache (download step executed).

Generated with Claude Code