### PR TITLE
swrSound: reimplement the sfx playback path + streamed-music controller

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -93,6 +93,7 @@ Main_sound 0x004b6d20 int = 1
 Main_sound_gain_adjust 0x004b6d24 float
 swrRace_voices_enabled 0x004b6d28 int = 1
 Main_sound_unk 0x004b6d2c int = 1
+swrSound_bank 0x004b6d34 void* # ptr to the sound-bank descriptor (+0x20 = entry count, +0x28 = entries base, 0x4c bytes each); swrSound_GetEntry
 
 unknownError_buffer 0x004b75f8 char[1024]
 Main_fullscreen_unk 0x004b79f8 int = 1
@@ -123,14 +124,31 @@ swrSound_sfxRemap7 0x004b83f0 int16_t[168]
 swrSound_sfxCategoryPrefixes 0x004b86c8 char*[8]
 swrSound_sfxVariantPrefixes 0x004b86e8 char*[23]
 
+# swrSound_PlaySpatialRange temporarily overrides these min/max attenuation distances around PlaySpatial.
+swrSound_spatialMinDist 0x004b8550 float
+swrSound_spatialMaxDist 0x004b8554 float
+
+# Pending delayed sfx armed by swrSound_PlaySfxThenDelayed, fired by swrSound_UpdateDelayedSfx (id == -1 when none).
+swrSound_delayedSfxId 0x004b85d4 int
+swrSound_delayedSfxCategory 0x004b85d8 int
+swrSound_delayedSfxVariant 0x004b85dc int
+
 # Recent-sfx ring (last 3 played sound ids), swrSound_PushRecentSfx / swrSound_WasSfxRecentlyPlayed.
 swrSound_recentSfxRing 0x004b85e0 int16_t[3]
+# Category-2 cooldown source: per-id duration table read by swrSound_MarkSfxPlayed. [0] overlaps the
+# recent-sfx ring tail but is never used (category-2 ids start at 1).
+swrSound_cat2CooldownSource 0x004b85e4 float[57]
+
+# Streamed music controller state (channel 7): queued = track to start, current = track playing now.
+swrSound_queuedMusicId 0x004b8744 int # next track id to start (swrSound_SetMusicFade/SelectTrackMusic -> swrSound_UpdateMusic; -1 = none)
+swrSound_currentMusicId 0x004b8748 int # track id currently streaming; cleared to -1 by swrSound_ResetMusic
 
 # Streamed music + per-track ambient SFX tables. See swrSound.h (swrSound_SelectTrackMusic /
 # swrSound_UpdateEngineAudio) and the swrSfxCue struct in types.h.
 swrMusicTrackTable 0x004b8750 int16_t[8][3]
 swrMusicPlanetIntroTable 0x004b8780 int16_t[8]
 swrSfxPreloadSets 0x004b8fa8 swrSfxCue*[24]
+swrSound_savedTrackMusicId 0x004b9090 int # last track queued by swrSound_SelectTrackMusic; re-queued on restore
 
 swrSprite_SpriteCount 0x004b91b8 int
 swrSprite_unk_x 0x004b91bc float = 16.0
@@ -464,7 +482,10 @@ Window_Active 0x0050b5d0 int
 # write index. swrSound_IsSfxOnCooldown / swrSound_PushRecentSfx.
 swrSound_sfxCategoryCooldown 0x0050b600 float[8]
 swrSound_sfxVariantCooldown 0x0050b620 float[23]
+swrSound_sfxVariantLastCategory 0x0050b680 int[23] # category that last armed each variant cooldown slot (swrSound_MarkSfxPlayed)
 swrSound_recentSfxWriteIndex 0x0050b6dc int16_t
+swrSound_musicFadeMode 0x0050b6e0 int # music fade state machine: 0 stop / 1 arm / 2 fade down / 3 fade up (swrSound_SetMusicFade -> swrSound_UpdateMusic)
+swrSound_musicFadeRate 0x0050b6e8 float # per-second gain delta applied while fading (swrSound_UpdateMusic)
 
 swrMainDisplaySettings_g 0x0050b560 swrMainDisplaySettings
 

--- a/src/Swr/swrSound.c
+++ b/src/Swr/swrSound.c
@@ -2,10 +2,14 @@
 
 #include "types.h"
 #include "globals.h"
+#include "swr.h"      // swr_noop2, playASound
+#include "swrEvent.h" // swrEvent_GetEventCount
+#include "swrObj.h"   // NumLocalPlayers
 
 #include <macros.h>
 
 #include <General/stdHashTable.h>
+#include <General/utils.h> // swrUtils_Rand
 #include <Platform/a3d.h>
 #include <Win95/Window.h>
 
@@ -941,6 +945,211 @@ void swrSound_SetSfxFlag(int index, unsigned int mask)
 void swrSound_ClearSfxFlag(int index, unsigned int mask)
 {
     swrSound_sfxFlags[index] &= ~mask;
+}
+
+// 0x00422a90
+void* swrSound_GetEntry(int index)
+{
+    char* bank = (char*) swrSound_bank;
+    if (-1 < index && index < *(int*) (bank + 0x20))
+        return (void*) (*(int*) (bank + 0x28) + index * 0x4c);
+    return NULL;
+}
+
+// 0x0044a930
+float swrSound_GetSoundLengthSeconds(int soundId)
+{
+    void* entry = swrSound_GetEntry(soundId);
+    if (entry == NULL)
+        return 0.0f;
+    return (float) (*(unsigned int*) ((char*) entry + 0x38) / 1000);
+}
+
+// Arms the per-variant (categories 0-1) or per-category cooldown timer for a just-played sfx, set
+// to the sound's length (+1.0s; category 2 uses its own per-id source +0.25s).
+// 0x00427530
+void swrSound_MarkSfxPlayed(int category, int variant, int soundId, int id)
+{
+    float length = swrSound_GetSoundLengthSeconds(soundId);
+    if (-1 < category) {
+        if (category < 2) {
+            swrSound_sfxVariantCooldown[variant] = length + 1.0f;
+            swrSound_sfxVariantLastCategory[variant] = category;
+            return;
+        }
+        if (category == 2) {
+            swrSound_sfxCategoryCooldown[2] = swrSound_cat2CooldownSource[id] + 0.25f;
+            return;
+        }
+    }
+    swrSound_sfxCategoryCooldown[category] = length + 1.0f;
+}
+
+// A3D 3D-positional playback (distance attenuation, occlusion, panning). Reverse-hook stub for now;
+// reimplemented separately (it pulls in the perspective-projection + occlusion-ray helpers).
+// 0x00426d80
+void swrSound_PlaySpatial(int soundId, short param2, float param3, float gain, rdVector3* position, int param6, unsigned int flags)
+{
+    HANG("TODO");
+}
+
+// 0x00426d10
+void swrSound_PlaySpatialRange(int soundId, short param2, float param3, float gain, rdVector3* position, int param6, unsigned int flags, float minDist, float maxDist)
+{
+    float savedMin = swrSound_spatialMinDist;
+    float savedMax = swrSound_spatialMaxDist;
+    swrSound_spatialMinDist = minDist;
+    swrSound_spatialMaxDist = maxDist;
+    swrSound_PlaySpatial(soundId, param2, param3, gain, position, param6, flags);
+    swrSound_spatialMinDist = savedMin;
+    swrSound_spatialMaxDist = savedMax;
+}
+
+// Resolves and plays a one-shot sfx, throttled: skips it if its category/variant is on cooldown,
+// recently played (except the cat-6 id-0x27 exception), or already live on a voice. Plays 2D
+// (playASound) or 3D-positional (PlaySpatialRange) depending on `position`, then arms the cooldown.
+// 0x00427410
+void swrSound_PlaySfxThrottled(int category, int variant, int id, rdVector3* position)
+{
+    if (0 < swrEvent_GetEventCount('Test')) {
+        if (NumLocalPlayers() == 0)
+            return;
+        if (swrRace_voices_enabled == 0)
+            return;
+    }
+    swr_noop2();
+
+    if (swrSound_IsSfxOnCooldown(category, variant) != 0)
+        return;
+    int resolved = swrSound_ResolveSfxId(category, variant, id);
+    if (resolved == -1)
+        return;
+    if (swrSound_WasSfxRecentlyPlayed(resolved) != 0 && !(category == 6 && id == 0x27))
+        return;
+
+    for (int i = 0; i < 8; i++) {
+        if (swrSound_voicesLive[i].id == resolved &&
+            swrSound_GetWavePosition(swrSound_voicesLive[i].source, NULL) == 1)
+            return; // this sound is already playing
+    }
+
+    swrSound_PushRecentSfx((short) resolved);
+    if (position == NULL)
+        playASound(resolved, 7, 0.25f, 1.0f, 0);
+    else
+        swrSound_PlaySpatialRange(resolved, 7, 0.25f, 1.0f, position, 0, 1, 15.0f, 20000.0f);
+    swrSound_MarkSfxPlayed(category, variant, resolved, id);
+}
+
+// Collects the valid sfx ids among up to 5 candidates and plays one at random (throttled). Returns
+// the chosen id, or -1 if none were valid.
+// 0x00427590
+int swrSound_PlayRandomSfx(int category, int variant, int sfx1, int sfx2, int sfx3, int sfx4, int sfx5, rdVector3* position)
+{
+    int candidates[5];
+    int count = 0;
+    candidates[count] = sfx1;
+    if (swrSound_ResolveSfxId(category, variant, sfx1) != -1) count++;
+    candidates[count] = sfx2;
+    if (swrSound_ResolveSfxId(category, variant, sfx2) != -1) count++;
+    candidates[count] = sfx3;
+    if (swrSound_ResolveSfxId(category, variant, sfx3) != -1) count++;
+    candidates[count] = sfx4;
+    if (swrSound_ResolveSfxId(category, variant, sfx4) != -1) count++;
+    candidates[count] = sfx5;
+    if (swrSound_ResolveSfxId(category, variant, sfx5) != -1) count++;
+
+    if (count == 0)
+        return -1;
+
+    int idx = (int) ((float) swrUtils_Rand() * 4.6566129e-10f * (float) (count + 1));
+    if (idx < 0)
+        idx = 0;
+    int chosen = candidates[idx % count];
+    swrSound_PlaySfxThrottled(category, variant, chosen, position);
+    return chosen;
+}
+
+// 0x004277b0
+void swrSound_PlaySfxThenDelayed(int category, int variant, int id, int delayedCategory, int delayedVariant, int delayedId)
+{
+    swrSound_PlaySfxThrottled(category, variant, id, NULL);
+    swrSound_delayedSfxCategory = delayedCategory;
+    swrSound_delayedSfxVariant = delayedVariant;
+    swrSound_delayedSfxId = delayedId;
+}
+
+// Zeroes the computed gain of every requested-voice slot (the per-frame voice mixer rebuilds them).
+// 0x00449e30
+void swrSound_ResetRequestedVoices(void)
+{
+    for (int i = 0; i < 8; i++)
+        swrSound_voicesRequested[i].volume = 0;
+}
+
+// Sets the music fade state machine consumed by swrSound_UpdateMusic each frame:
+//   0 stop      - clear the queued track, drop the fade target
+//   1 arm       - queue the default theme (0x8f) unless a 'Test' event is active
+//   2 fade down - ramp the music gain at -0.2/s
+//   3 fade up   - ramp the music gain at -2.0/s
+// 0x004277f0
+void swrSound_SetMusicFade(int mode)
+{
+    switch (mode) {
+    case 0:
+        swrSound_musicFadeMode = 0;
+        swrSound_queuedMusicId = -1;
+        return;
+    case 1:
+        swrSound_musicFadeMode = 1;
+        if (swrEvent_GetEventCount('Test') < 1)
+            swrSound_queuedMusicId = 0x8f;
+        return;
+    case 2:
+        swrSound_musicFadeMode = 2;
+        swrSound_musicFadeRate = -0.2f;
+        return;
+    case 3:
+        swrSound_musicFadeMode = 3;
+        swrSound_musicFadeRate = -2.0f;
+        return;
+    }
+}
+
+// Queues the streamed theme for a track (planet/subtrack) from swrMusicTrackTable, saving it so a
+// later restore (restore != 0) can re-queue it. subtrack 3 is the special victory/results cue
+// (planet 1 -> 0x92, planet 4 -> 0x96; other planets keep the current queue).
+// 0x00427ea0
+void swrSound_SelectTrackMusic(int planet, int subtrack, int restore)
+{
+    if (restore == 0) {
+        if (subtrack != 3) {
+            swrSound_savedTrackMusicId = swrMusicTrackTable[planet][subtrack];
+            swrSound_queuedMusicId = swrMusicTrackTable[planet][subtrack];
+            return;
+        }
+        if (planet == 1) {
+            swrSound_savedTrackMusicId = 0x92;
+            swrSound_queuedMusicId = 0x92;
+            return;
+        }
+        if (planet == 4) {
+            swrSound_savedTrackMusicId = 0x96;
+            swrSound_queuedMusicId = 0x96;
+        }
+    }
+    else {
+        swrSound_queuedMusicId = swrSound_savedTrackMusicId;
+    }
+}
+
+// Stops all music: drops the requested voices and clears the current-music and delayed-sfx slots.
+// 0x00427d70
+void swrSound_ResetMusic(void)
+{
+    swrSound_ResetRequestedVoices();
+    swrSound_currentMusicId = -1;
+    swrSound_delayedSfxId = -1;
 }
 
 // 0x00427ad0

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -73,9 +73,11 @@
 // Runtime channel mixer: 8 channels (DAT_00e67e40, stride 0x44). swrSound_Update
 // is the per-frame tick (acquire/position/play/release each channel + listener).
 #define swrSound_ResetChannel_ADDR (0x00449e00)
+#define swrSound_ResetRequestedVoices_ADDR (0x00449e30)
 #define swrSound_RewindChannels_ADDR (0x00449e50)
 #define swrSound_ResetChannels_ADDR (0x00449ea0)
 #define swrSound_Update_ADDR (0x00449ef0)
+#define swrSound_GetSoundLengthSeconds_ADDR (0x0044a930)
 
 #define swrSound_Init_ADDR (0x004848a0)
 #define swrSound_Shutdown_ADDR (0x00484a20)
@@ -131,6 +133,9 @@ void* swrSound_RegisterSound(char* name, int load);
 
 // Return the descriptor at index (bounds-checked), or NULL.
 void* swrSound_GetEntry(int index);
+
+// Length in seconds of a loaded sound (descriptor +0x38 field / 1000), 0 if not loaded.
+float swrSound_GetSoundLengthSeconds(int soundId);
 
 // Load a descriptor's audio into a new A3D source on demand, evicting other
 // sounds first if the byte budget would be exceeded.
@@ -208,6 +213,8 @@ void swrSound_SetMusicFade(int mode);
 void swrSound_ResetMusic(void);
 // Arm the per-planet intro music: sets the current music index from swrMusicPlanetIntroTable[planet].
 unsigned int swrSound_SelectPlanetIntroMusic(unsigned int planet);
+// Zeroes the gain of every requested-voice slot; called by swrSound_ResetMusic.
+void swrSound_ResetRequestedVoices(void);
 
 // Per-frame engine/surface SFX: select and play loop sounds keyed by speed.
 void swrSound_UpdateEngineAudio(int param1, int param2, float* param3);


### PR DESCRIPTION
Follow-up to #116. Adds the play/music functions the race judge (`swrObjJdge_F0`) and the death sequence call:

- **SFX playback**: `PlaySfxThrottled` (resolve + cooldown/recent/live-voice throttle), `PlayRandomSfx`, `PlaySfxThenDelayed`, `MarkSfxPlayed`, `GetSoundLengthSeconds`, and the `PlaySpatialRange` min/max-dist wrapper.
- **Streamed-music controller**: `SetMusicFade` (fade state machine 0-3), `SelectTrackMusic` (per-track theme from `swrMusicTrackTable`, subtrack-3 specials), `ResetMusic`, `ResetRequestedVoices`.

`PlaySpatial` stays a reverse-hook stub for now (it pulls in the projection/occlusion helpers, reimplemented separately). Named the music-state globals.

Full `dinput.dll` build links green; all functions reverse-hooked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)