### PR TITLE
Add FPS limiter and FPS overlay

### DIFF
--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -80,6 +80,22 @@ void read_settings_ini() {
         imgui_state.anisotropy = anisotropy;
     }
 
+    imgui_state.target_fps =
+        GetPrivateProfileIntW(L"settings", L"target_fps", 0, ini_path.c_str());
+    if (imgui_state.target_fps != 0) {
+        if (imgui_state.target_fps < 10) {
+            imgui_state.target_fps = 10;
+        } else if (imgui_state.target_fps > 200) {
+            imgui_state.target_fps = 200;
+        }
+    }
+
+    imgui_state.show_fps_overlay =
+        GetPrivateProfileIntW(L"settings", L"show_fps_overlay", 0, ini_path.c_str());
+
+    imgui_state.show_fps_graph =
+        GetPrivateProfileIntW(L"settings", L"show_fps_graph", 1, ini_path.c_str());
+
     imgui_state.enable_fog = GetPrivateProfileIntW(L"settings", L"enable_fog", 1, ini_path.c_str());
 
     imgui_state.ai_full_lod =
@@ -100,6 +116,15 @@ void save_settings_ini() {
                                std::to_wstring(imgui_state.msaa_samples).c_str(), ini_path.c_str());
     WritePrivateProfileStringW(L"settings", L"anisotropy",
                                std::to_wstring(imgui_state.anisotropy).c_str(), ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"target_fps",
+                               std::to_wstring(imgui_state.target_fps).c_str(), ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"show_fps_overlay",
+                               imgui_state.show_fps_overlay ? L"1" : L"0", ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"show_fps_graph",
+                               imgui_state.show_fps_graph ? L"1" : L"0", ini_path.c_str());
+
     WritePrivateProfileStringW(L"settings", L"enable_fog", imgui_state.enable_fog ? L"1" : L"0",
                                ini_path.c_str());
 
@@ -492,13 +517,192 @@ static void pump_hook_log() {
     g_debug_log.Trim();
 }
 
+// Draws white text stamped with a black outline (ImGui has no native outline);
+// `outline` is the stamp radius in pixels.
+static void draw_outlined_text(ImDrawList *draw, ImFont *font, float size, ImVec2 pos,
+                               const char *text, int outline) {
+    for (int dx = -outline; dx <= outline; dx++) {
+        for (int dy = -outline; dy <= outline; dy++) {
+            if (dx != 0 || dy != 0) {
+                draw->AddText(font, size, {pos.x + (float) dx, pos.y + (float) dy},
+                              IM_COL32(0, 0, 0, 255), text);
+            }
+        }
+    }
+    draw->AddText(font, size, pos, IM_COL32(255, 255, 255, 255), text);
+}
+
+// Pinned top-right overlay: a large, outlined FPS number with the frame time
+// beneath it, plus an optional rolling graph of the smoothed frame rate with a
+// horizontal line at its average. Drawn every frame independently of the F5 menu.
+static void draw_fps_overlay() {
+    if (!imgui_state.show_fps_overlay)
+        return;
+
+    const ImGuiIO &io = ImGui::GetIO();
+    const float graph_w = 200.0f;
+    const float margin = 10.0f;
+
+    const ImGuiViewport *viewport = ImGui::GetMainViewport();
+    const ImVec2 anchor = {viewport->WorkPos.x + viewport->WorkSize.x - margin,
+                           viewport->WorkPos.y + margin};
+    ImGui::SetNextWindowPos(anchor, ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+
+    const ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+        ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+        ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoInputs |
+        ImGuiWindowFlags_NoBackground;
+    if (ImGui::Begin("FPS overlay", nullptr, flags)) {
+        ImDrawList *draw = ImGui::GetWindowDrawList();
+        ImFont *font = ImGui::GetFont();
+
+        // Large FPS number, right-aligned within the graph width.
+        char fps_text[32];
+        snprintf(fps_text, sizeof(fps_text), "%.0f FPS", io.Framerate);
+        const float big_size = ImGui::GetFontSize() * 2.0f;
+        const ImVec2 big_dim = font->CalcTextSizeA(big_size, FLT_MAX, 0.0f, fps_text);
+        ImVec2 cursor = ImGui::GetCursorScreenPos();
+        draw_outlined_text(draw, font, big_size, {cursor.x + graph_w - big_dim.x, cursor.y},
+                           fps_text, 2);
+        ImGui::Dummy({graph_w, big_dim.y});
+
+        // Frame time beneath the number.
+        char ms_text[24];
+        snprintf(ms_text, sizeof(ms_text), "%.2f ms", 1000.0f / io.Framerate);
+        const float small_size = ImGui::GetFontSize();
+        const ImVec2 small_dim = font->CalcTextSizeA(small_size, FLT_MAX, 0.0f, ms_text);
+        cursor = ImGui::GetCursorScreenPos();
+        draw_outlined_text(draw, font, small_size, {cursor.x + graph_w - small_dim.x, cursor.y},
+                           ms_text, 1);
+        ImGui::Dummy({graph_w, small_dim.y});
+
+        if (imgui_state.show_fps_graph) {
+            // History of the smoothed frame rate (the value the number shows),
+            // which is far steadier to plot than raw per-frame delta time.
+            static float fps_history[120] = {};
+            static int fps_offset = 0;
+            fps_history[fps_offset] = io.Framerate;
+            fps_offset = (fps_offset + 1) % IM_ARRAYSIZE(fps_history);
+
+            float fps_max = 0.0f, fps_sum = 0.0f;
+            int fps_count = 0;
+            for (float f: fps_history) {
+                if (f <= 0.0f)
+                    continue;
+                fps_max = f > fps_max ? f : fps_max;
+                fps_sum += f;
+                fps_count++;
+            }
+            const float fps_avg = fps_count > 0 ? fps_sum / fps_count : io.Framerate;
+
+            // Fixed 0-based scale, quantized to 30-fps steps so the bounds hold
+            // still instead of rescaling every frame.
+            const float scale_min = 0.0f;
+            const int steps = (int) ((fps_max + 5.0f) / 30.0f) + 1;
+            float scale_max = steps * 30.0f;
+            if (scale_max < 60.0f)
+                scale_max = 60.0f;
+
+            ImGui::PushStyleColor(ImGuiCol_PlotLines, IM_COL32(120, 230, 140, 255));
+            ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 110));
+            ImGui::PlotLines("##fps", fps_history, IM_ARRAYSIZE(fps_history), fps_offset, nullptr,
+                             scale_min, scale_max, {graph_w, 60.0f});
+            ImGui::PopStyleColor(2);
+
+            // Horizontal reference line at the average frame rate.
+            const ImVec2 plot_min = ImGui::GetItemRectMin();
+            const ImVec2 plot_max = ImGui::GetItemRectMax();
+            const float y = plot_max.y - (fps_avg / scale_max) * (plot_max.y - plot_min.y);
+            draw->AddLine({plot_min.x, y}, {plot_max.x, y}, IM_COL32(255, 235, 120, 180), 1.0f);
+        }
+    }
+    ImGui::End();
+}
+
 void opengl_render_imgui() {
+    // The FPS overlay is independent of the F5 debug menu.
+    draw_fps_overlay();
+
     // Toggled with F5
     if (!show_imgui)
         return;
 
-    ImGui::Text("FPS rolling 120 frames: %f (%.3f ms)", ImGui::GetIO().Framerate,
-                (1.0f / ImGui::GetIO().Framerate) * 1000);
+    if (ImGui::TreeNodeEx("FPS")) {
+        if (ImGui::Checkbox("Show FPS overlay (top-right)", &imgui_state.show_fps_overlay)) {
+            save_settings_ini();
+        }
+        if (imgui_state.show_fps_overlay) {
+            ImGui::Indent();
+            if (ImGui::Checkbox("Show graph", &imgui_state.show_fps_graph)) {
+                save_settings_ini();
+            }
+            ImGui::Unindent();
+        }
+
+        // Slider runs 10..200 FPS; the far-right notch (past 200) reads "Unlimited"
+        // and is stored as 0 to match the ini's "0 == off" convention. Flanked by
+        // -/+ paddle buttons (hold to repeat) for one-FPS nudges.
+        constexpr int fps_unlimited_pos = 201;
+        int fps_slider = imgui_state.target_fps == 0 ? fps_unlimited_pos : imgui_state.target_fps;
+        const char *fps_fmt = fps_slider >= fps_unlimited_pos ? "Unlimited" : "%d FPS";
+
+        const float fps_btn_w = ImGui::GetFrameHeight();
+        const float fps_spacing = ImGui::GetStyle().ItemInnerSpacing.x;
+        float fps_slider_w = ImGui::CalcItemWidth() - 2.0f * (fps_btn_w + fps_spacing);
+        if (fps_slider_w < 50.0f)
+            fps_slider_w = 50.0f;
+        bool fps_changed = false;
+
+        ImGui::PushButtonRepeat(true);
+        if (ImGui::ArrowButton("##fps_dec", ImGuiDir_Left)) {
+            fps_slider--;
+            fps_changed = true;
+        }
+        ImGui::SameLine(0.0f, fps_spacing);
+        ImGui::SetNextItemWidth(fps_slider_w);
+        if (ImGui::SliderInt("##fps_slider", &fps_slider, 10, fps_unlimited_pos, fps_fmt,
+                             ImGuiSliderFlags_AlwaysClamp)) {
+            fps_changed = true;
+        }
+        ImGui::SameLine(0.0f, fps_spacing);
+        if (ImGui::ArrowButton("##fps_inc", ImGuiDir_Right)) {
+            fps_slider++;
+            fps_changed = true;
+        }
+        ImGui::PopButtonRepeat();
+        ImGui::SameLine(0.0f, fps_spacing);
+        ImGui::TextUnformatted("Frame rate cap");
+
+        if (fps_changed) {
+            fps_slider = fps_slider < 10 ? 10 : fps_slider;
+            fps_slider = fps_slider > fps_unlimited_pos ? fps_unlimited_pos : fps_slider;
+            imgui_state.target_fps = fps_slider >= fps_unlimited_pos ? 0 : fps_slider;
+            save_settings_ini();
+        }
+
+        // Quick-set presets (24..60 fps, step 6), spread evenly across the row.
+        ImGui::TextUnformatted("Quick set:");
+        const int fps_presets[] = {24, 30, 36, 42, 48, 54, 60};
+        const int fps_preset_count = IM_ARRAYSIZE(fps_presets);
+        const float quick_spacing = ImGui::GetStyle().ItemSpacing.x;
+        float quick_w = (ImGui::GetContentRegionAvail().x - quick_spacing * (fps_preset_count - 1)) /
+                        fps_preset_count;
+        if (quick_w < 28.0f)
+            quick_w = 28.0f;
+        for (int i = 0; i < fps_preset_count; i++) {
+            if (i != 0)
+                ImGui::SameLine();
+            char label[8];
+            snprintf(label, sizeof(label), "%d", fps_presets[i]);
+            if (ImGui::Button(label, {quick_w, 0.0f})) {
+                imgui_state.target_fps = fps_presets[i];
+                save_settings_ini();
+            }
+        }
+        ImGui::TreePop();
+    }
+
     if (ImGui::TreeNodeEx("graphics settings")) {
         int max_msaa_samples = 1;
         glGetIntegerv(GL_MAX_SAMPLES, &max_msaa_samples);

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -31,8 +31,11 @@ typedef struct ImGuiState {
 
     int msaa_samples = 1;
     int anisotropy = 8;
+    int target_fps = 0;// frame-rate cap for the GL present path; 0 = unlimited
     bool enable_fog = true;
     bool ai_full_lod = true;// force every racer (incl. AI) onto the full pod model (no LOD pop-in)
+    bool show_fps_overlay = false;// pinned top-right FPS readout + frame-time graph
+    bool show_fps_graph = true;// graph beneath the FPS overlay number
 
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -37,6 +37,7 @@ extern "C" {
 
 #include "n64_shader.h"
 #include "types.h"
+#include <chrono>
 #include <cmath>
 #include <condition_variable>
 #include <cstring>
@@ -1035,6 +1036,69 @@ LRESULT CALLBACK WndProc(HWND wnd, UINT code, WPARAM wparam, LPARAM lparam) {
     return WndProcOrig(wnd, code, wparam, lparam);
 }
 
+// Some toolchains' synchapi.h predates the high-resolution timer flag.
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
+
+// Caps the present rate to target_fps (0 = unlimited). Sleeps the bulk of the
+// frame on a high-resolution waitable timer (Win10 1803+), then busy-waits a
+// short tail for sub-millisecond precision. The timer falls back to a coarse
+// sleep on older systems.
+static void limit_framerate(int target_fps) {
+    using clock = std::chrono::steady_clock;
+    static clock::time_point next_frame = clock::now();
+
+    if (target_fps <= 0) {
+        next_frame = clock::now();
+        return;
+    }
+
+    const auto period = std::chrono::duration_cast<clock::duration>(
+        std::chrono::duration<double>(1.0 / target_fps));
+    next_frame += period;
+
+    const clock::time_point now = clock::now();
+    if (next_frame <= now) {
+        // Already running at or below the cap: don't accumulate debt.
+        next_frame = now;
+        return;
+    }
+
+    // Resolved at runtime: CreateWaitableTimerExW is absent from the toolchain's
+    // headers and missing on pre-Win8 systems, where this stays null and we fall
+    // back to a coarse sleep.
+    static HANDLE timer = []() -> HANDLE {
+        using create_timer_ex_t = HANDLE(WINAPI *)(LPSECURITY_ATTRIBUTES, LPCWSTR, DWORD, DWORD);
+        auto create_timer_ex = reinterpret_cast<create_timer_ex_t>(
+            GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "CreateWaitableTimerExW"));
+        return create_timer_ex ? create_timer_ex(nullptr, nullptr,
+                                                 CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                                                 TIMER_ALL_ACCESS)
+                               : nullptr;
+    }();
+
+    const auto spin_margin = std::chrono::microseconds(500);
+    const auto wait = next_frame - now;
+    if (wait > spin_margin) {
+        const auto coarse = wait - spin_margin;
+        if (timer) {
+            LARGE_INTEGER due;
+            // Relative due time in negative 100ns units.
+            due.QuadPart = -static_cast<LONGLONG>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(coarse).count() / 100);
+            if (SetWaitableTimer(timer, &due, 0, nullptr, nullptr, FALSE)) {
+                WaitForSingleObject(timer, INFINITE);
+            }
+        } else {
+            std::this_thread::sleep_for(coarse);
+        }
+    }
+    while (clock::now() < next_frame) {
+        std::this_thread::yield();
+    }
+}
+
 extern "C" int stdDisplay_Update_Hook() {
     if (swrDisplay_SkipNextFrameUpdate == 1) {
         swrDisplay_SkipNextFrameUpdate = 0;
@@ -1051,6 +1115,8 @@ extern "C" int stdDisplay_Update_Hook() {
     }
     glFinish();
     glfwSwapBuffers(glfwGetCurrentContext());
+
+    limit_framerate(imgui_state.target_fps);
 
     return 0;
 }


### PR DESCRIPTION

<img width="481" height="272" alt="image" src="https://github.com/user-attachments/assets/58afedf5-e845-4d8a-bbf8-263d9c77eda8" />


Adds an optional frame-rate cap and an FPS overlay to the HD renderer (both default off / unobtrusive).

- **Frame rate cap** (`FPS` accordion in the F5 menu): 10-200 FPS or Unlimited, with -/+ paddles and 24-60 quick-set buttons. Paces the GL present via a high-resolution waitable timer + short spin tail. Doubles as a stopgap for high-FPS physics quirks. Persists to the ini.
- **FPS overlay** (top-right): big outlined number + frame time, optional smoothed-FPS graph with a fixed scale and average line. Independent of the F5 debug menu.
- Only active on the OpenGL/HD renderer path (`RENDERER_REPLACEMENT=ON`).

Part of #143.
