### PR TITLE
Add HD font replacement toggle

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -173,6 +173,10 @@ InRaceSpritesEnabled 0x004B94C0 int
 
 lensFlareSpriteIds 0x004B94E0 int[16]
 
+# The 5 bitmap fonts built by swrText_InitFonts, referenced through the 7-entry font table. Each
+# swrFont holds pageCount glyph-page swrMaterial*s at +0x08; the HD-font replacement swaps those.
+swrText_fonts 0x004bf7e0 swrFont[5]
+
 currentSpriteColor 0x004BFA0C uint8_t[4]
 
 # extended-character (code > 0x96) compose tables read by swrText_GetStringWidth/Height/DrawString.

--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -13,6 +13,7 @@
 #include "../custom_tracks.h"
 #include "../nv_dds/nv_dds.h"
 #include "../imgui_utils.h"
+#include "../patch.h"
 
 #include <regex>
 
@@ -21,6 +22,7 @@ extern "C" {
 #include <Swr/swrSprite.h>
 #include <Swr/swrLoader.h>
 #include <Swr/swrAssetBuffer.h>
+#include <Swr/swrText.h>
 }
 
 #include <globals.h>
@@ -104,87 +106,96 @@ int readFontToBuffer(unsigned char *out_buffer, const char *path) {
 // Added loading font from font files, and using 512, 1024 as a resolution
 // Unrolled all static loops
 
-// 0x0042d720
-void swrModel_LoadFonts_delta(void) {
-    int i;
-    swrMaterial **material;
-    swrMaterial **material2;
-    swrMaterial **material3;
-    uint8_t *palette;
+// --- HD font replacement: journaled live toggle (modding API, issue #153) --------------------
+// The vanilla swrText_InitFonts (0x0042d720) and the HD path populate the SAME font-table slots
+// (and write identical font-metadata globals), differing only in which swrMaterial each slot
+// points at. So we keep BOTH font sets resident and flip the toggle by journaling the slot
+// pointers: enable = PatchPointer the HD material over the built-in one (capturing it); disable =
+// UndoOwner("hd_font") restores the built-in. The original is always run first so the built-in
+// materials exist to revert to. This makes the F5 toggle apply live, no restart.
+struct HdFontSlot {
+    swrMaterial **page;// font-table glyph-page slot the converter fills (swrText_fonts[f].pages[p])
+    uint8_t *buffer;   // HD texture data the slot is pointed at before conversion
+};
+static const HdFontSlot kHdFontSlots[] = {
+    {&swrText_fonts[3].pages[0], font_0_0_buffer},
+    {&swrText_fonts[0].pages[0], font_1_0_buffer},
+    {&swrText_fonts[0].pages[1], font_1_1_buffer},
+    {&swrText_fonts[0].pages[2], font_1_2_buffer},// font_1_2 also backs fonts[1]/[2] (font_2_0/3_0)
+    {&swrText_fonts[1].pages[0], font_1_2_buffer},
+    {&swrText_fonts[2].pages[0], font_1_2_buffer},
+    {&swrText_fonts[4].pages[0], font_4_0_buffer},
+};
+static const int kNumHdFontSlots = (int) (sizeof(kHdFontSlots) / sizeof(kHdFontSlots[0]));
+static swrMaterial *g_hdFontMaterial[kNumHdFontSlots];// converted HD materials, built once
+static bool g_hdFontsBuilt = false;
+
+// Read the HD font PNGs and convert them into rdMaterials once, leaving the live font-table slots
+// on their built-in materials. Conversion only ever happens here (at startup or first enable), so
+// the runtime toggle is a pure pointer swap. Returns false if any asset is missing -> HD stays off.
+static bool ensure_hd_fonts_built() {
+    if (g_hdFontsBuilt)
+        return true;
+
+    static const struct {
+        uint8_t *buffer;
+        const char *path;
+    } files[] = {
+        {font_0_0_buffer, "./assets/textures/fonts/font0_0.png"},
+        {font_1_0_buffer, "./assets/textures/fonts/font1_0.png"},
+        {font_1_1_buffer, "./assets/textures/fonts/font1_1.png"},
+        {font_1_2_buffer, "./assets/textures/fonts/font1_2.png"},
+        {font_4_0_buffer, "./assets/textures/fonts/font4_0.png"},
+    };
+    for (const auto &f: files) {
+        if (readFontToBuffer(f.buffer, f.path) != 0) {
+            fprintf(hook_log, "[hd_font] missing %s; keeping built-in fonts.\n", f.path);
+            fflush(hook_log);
+            return false;
+        }
+    }
 
     Original_ConvertTextureDataToRdMaterial converter =
-        (Original_ConvertTextureDataToRdMaterial) 0x00445ee0;
-
-    // Added
-    if (readFontToBuffer(font_0_0_buffer, "./assets/textures/fonts/font0_0.png") != 0) {
-        assert(false && "Could not read font at ./assets/textures/fonts/font0_0.png");
+        (Original_ConvertTextureDataToRdMaterial) swrModel_ConvertTextureDataToRdMaterial_ADDR;
+    uint8_t *palette = nullptr;
+    for (int i = 0; i < kNumHdFontSlots; i++) {
+        swrMaterial **page = kHdFontSlots[i].page;
+        swrMaterial *builtin = *page;                       // built-in material (set by the original)
+        *page = (swrMaterial *) kHdFontSlots[i].buffer;     // point at HD data, then convert in place
+        converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, page, &palette,
+                  1, 0);
+        g_hdFontMaterial[i] = *page;                        // remember the converted HD material
+        *page = builtin;                                    // leave the live slot on the built-in
     }
-
-    if (readFontToBuffer(font_1_0_buffer, "./assets/textures/fonts/font1_0.png") != 0) {
-        assert(false && "Could not read font at ./assets/textures/fonts/font1_0.png");
-    }
-    if (readFontToBuffer(font_1_1_buffer, "./assets/textures/fonts/font1_1.png") != 0) {
-        assert(false && "Could not read font at ./assets/textures/fonts/font1_1.png");
-    }
-    if (readFontToBuffer(font_1_2_buffer, "./assets/textures/fonts/font1_2.png") != 0) {
-        assert(false && "Could not read font at ./assets/textures/fonts/font1_2.png");
-    }
-
-    if (readFontToBuffer(font_4_0_buffer, "./assets/textures/fonts/font4_0.png") != 0) {
-        assert(false && "Could not read font at ./assets/textures/fonts/font4_0.png");
-    }
-
-    fprintf(hook_log, "Loaded all replacement fonts\n");
+    g_hdFontsBuilt = true;
+    fprintf(hook_log, "[hd_font] built %d HD font materials.\n", kNumHdFontSlots);
     fflush(hook_log);
+    return true;
+}
 
-    i = 0;
-    palette = NULL;
+// Live toggle: point the font-table slots at the HD materials (journaled so it reverts cleanly) or
+// restore the built-in materials. Safe any time after swrText_InitFonts_delta has run. Returns
+// false if HD was requested but its assets are missing (caller should clear the toggle).
+extern "C" bool set_hd_fonts(bool on) {
+    if (!on) {
+        UndoOwner("hd_font");
+        return true;
+    }
+    if (!ensure_hd_fonts_built())
+        return false;
+    for (int i = 0; i < kNumHdFontSlots; i++)
+        PatchPointer("hd_font", kHdFontSlots[i].page, (uint32_t) (uintptr_t) g_hdFontMaterial[i]);
+    return true;
+}
 
-    // Notice that font_1_2 is the same as font_2_0 and font_3_0
-
-    (*(swrMaterial **) 0x004bf920) = (swrMaterial *) &(font_0_0_buffer[0]);
-    material = (swrMaterial **) 0x004bf920;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material,
-              &palette, 1, 0);
-
-    (*(swrMaterial **) 0x004bf7e8) = (swrMaterial *) &(font_1_0_buffer[0]);
-    material2 = (swrMaterial **) 0x004bf7e8;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material2,
-              &palette, 1, 0);
-    (*(swrMaterial **) 0x004bf7ec) = (swrMaterial *) &(font_1_1_buffer[0]);
-    material2 = (swrMaterial **) 0x004bf7ec;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material2,
-              &palette, 1, 0);
-    (*(swrMaterial **) 0x004bf7f0) = (swrMaterial *) &(font_1_2_buffer[0]);
-    material2 = (swrMaterial **) 0x004bf7f0;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material2,
-              &palette, 1, 0);
-
-    (*(swrMaterial **) 0x004bf850) = (swrMaterial *) &(font_1_2_buffer[0]);
-    material2 = (swrMaterial **) 0x004bf850;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material2,
-              &palette, 1, 0);
-
-    (*(swrMaterial **) 0x004bf8b8) = (swrMaterial *) &(font_1_2_buffer[0]);
-    material3 = (swrMaterial **) 0x004bf8b8;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material3,
-              &palette, 1, 0);
-
-    (*(swrMaterial **) 0x004bf988) = (swrMaterial *) &(font_4_0_buffer[0]);
-    material2 = (swrMaterial **) 0x004bf988;
-    converter(3, 0, HD_FONT_WIDTH, HD_FONT_HEIGHT, HD_FONT_WIDTH, HD_FONT_HEIGHT, material2,
-              &palette, 1, 0);
-
-    (*(int *) 0x0050c0c0) = 7;
-    (*(int *) 0x00e99720) = 0x004bf918;
-    (*(int *) 0x00e99724) = 0x004bf8b0;
-    (*(int *) 0x00e99728) = 0x004bf848;
-    (*(int *) 0x00e9972c) = 0x004bf8b0;
-    (*(int *) 0x00e99730) = 0x004bf980;
-    (*(int *) 0x00e99734) = 0x004bf918;
-    (*(int *) 0x00e99738) = 0x004bf7e0;
-    (*(int *) 0x0050c0c4) = 0x004bf918;
-    return;
+// 0x0042d720
+void swrText_InitFonts_delta(void) {
+    // Always load the built-in fonts first so their materials exist and the font-table slots hold
+    // valid pointers; the HD swap (if enabled) then journals over those slots so it toggles live.
+    // This runs before read_settings_ini(), so read the persisted toggle directly here.
+    hook_call_original((void (*)(void)) swrText_InitFonts_ADDR);
+    if (read_hd_font_setting() && !set_hd_fonts(true))
+        imgui_state.hd_font = false;// assets missing -> reflect that the built-in fonts are in use
 }
 
 // We don't have the original function decompiled properly yet

--- a/dinput_hook/game_deltas/swrModel_delta.h
+++ b/dinput_hook/game_deltas/swrModel_delta.h
@@ -2,7 +2,7 @@
 
 #include "types.h"
 
-void swrModel_LoadFonts_delta(void);
+void swrText_InitFonts_delta(void);
 
 swrModel_Header *swrModel_LoadFromId_delta(MODELID id);
 

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -44,6 +44,10 @@ extern float cameraSpeed;
 // Defined in main.cpp: writes/reverts the AI full-LOD .text patches (gated by ai_full_lod).
 extern "C" void set_ai_full_lod(bool on);
 
+// Defined in swrModel_delta.cpp: journals the HD<->built-in font swap (gated by hd_font).
+// Returns false if HD was requested but its assets are missing.
+extern "C" bool set_hd_fonts(bool on);
+
 // Registers the built-in overlay panels with the debug-ui shell. Defined at the
 // bottom of this file alongside the panel bodies it splits opengl_render_imgui into.
 static void register_builtin_debug_panels();
@@ -88,6 +92,11 @@ static std::wstring ini_path = [] {
     return (std::filesystem::path(buff).parent_path() / "SW_RACER_RE.ini").wstring();
 }();
 
+bool read_hd_font_setting() {
+    imgui_state.hd_font = GetPrivateProfileIntW(L"settings", L"hd_font", 1, ini_path.c_str());
+    return imgui_state.hd_font;
+}
+
 void read_settings_ini() {
     const UINT msaa_samples =
         GetPrivateProfileIntW(L"settings", L"msaa_samples", 0, ini_path.c_str());
@@ -122,6 +131,8 @@ void read_settings_ini() {
 
     imgui_state.cache_meshes =
         GetPrivateProfileIntW(L"settings", L"cache_meshes", 1, ini_path.c_str());
+
+    read_hd_font_setting();
 
     imgui_state.ai_full_lod =
         GetPrivateProfileIntW(L"settings", L"ai_full_lod", 1, ini_path.c_str());
@@ -171,6 +182,9 @@ void save_settings_ini() {
 
     WritePrivateProfileStringW(L"settings", L"cache_meshes",
                                imgui_state.cache_meshes ? L"1" : L"0", ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"hd_font", imgui_state.hd_font ? L"1" : L"0",
+                               ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"ai_full_lod", imgui_state.ai_full_lod ? L"1" : L"0",
                                ini_path.c_str());
@@ -847,6 +861,11 @@ static void panel_hd_models() {
 
     if (ImGui::Checkbox("Enable HD model replacement.", &imgui_state.HD_replacement))
         save_settings_ini();
+    if (ImGui::Checkbox("Enable HD fonts", &imgui_state.hd_font)) {
+        if (!set_hd_fonts(imgui_state.hd_font))
+            imgui_state.hd_font = false;// HD assets missing -> keep the built-in fonts
+        save_settings_ini();
+    }
     ImGui::Checkbox("Show original on top of replacements.",
                     &imgui_state.show_original_and_replacements);
     ImGui::Checkbox("Show replacement tries", &imgui_state.show_replacementTries);

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -33,6 +33,7 @@ typedef struct ImGuiState {
     bool enable_fog = true;
     bool enable_gamepad_nav = true;
     bool cache_meshes = true;// cache per-mesh GL geometry; static meshes upload once, not every frame
+    bool hd_font = true;// swap the game's built-in fonts for HD replacements (live toggle via journal)
     bool ai_full_lod = true;// force every racer (incl. AI) onto the full pod model (no LOD pop-in)
     bool show_fps_overlay = false;// pinned top-right FPS readout + frame-time graph
     bool show_fps_graph = false;// graph beneath the FPS overlay number (opt-in)
@@ -64,3 +65,7 @@ void imgui_render_node(swrModel_Node *node);
 
 // Floating hook.log viewer; *p_open gates visibility (cleared by the window's [x]).
 void imgui_draw_log_window(bool *p_open);
+
+// Reads the persisted HD-font toggle from the ini into imgui_state.hd_font and
+// returns it. Consulted at font-load time, which runs before read_settings_ini().
+bool read_hd_font_setting();

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1444,10 +1444,11 @@ extern "C" void init_renderer_hooks() {
     hook_function("swrViewport_ProjectToScreen", (uint32_t) swrViewport_ProjectToScreen_ADDR,
                   (uint8_t *) swrViewport_ProjectToScreen_delta);
 
-    // swrModel
-    hook_function("swrModel_LoadFonts", (uint32_t) 0x0042d720,
-                  (uint8_t *) swrModel_LoadFonts_delta);
+    // swrText
+    hook_function("swrText_InitFonts", (uint32_t) swrText_InitFonts_ADDR,
+                  (uint8_t *) swrText_InitFonts_delta);
 
+    // swrModel
     hook_function("swrModel_LoadFromId", (uint32_t) swrModel_LoadFromId, (uint8_t *) 0x00448780);
     hook_replace(swrModel_LoadFromId, swrModel_LoadFromId_delta);
 


### PR DESCRIPTION
Adds an "Enable HD fonts" toggle (F5 menu, under "Enable HD model replacement") so players can swap the game's built-in fonts for the HD replacement set. Defaults on (current behavior), persists to `SW_RACER_RE.ini` (`[settings] hd_font`). Closes the "toggle hd font" item on #143.

**Applies live, no restart** (per your "journaling is up, we can move with this" note). Built on the #209 patch journal:

- `swrText_InitFonts_delta` now always runs the original first, so the built-in font materials load and the font-table slots hold valid pointers.
- It then builds the HD materials once (kept resident) and, if enabled, `PatchPointer`s the HD materials over the 7 font-table slots tagged `"hd_font"`.
- The F5 checkbox flips it live: enable journals the swap, disable is `UndoOwner("hd_font")` which restores the built-ins. Texture conversion only ever runs at load, so the runtime toggle is a pure (atomic) pointer swap.
- The vanilla `swrText_InitFonts` and the HD path write identical font-metadata globals, so only the 7 material-slot pointers need journaling.
- If the HD font assets are missing, the toggle now fails gracefully and keeps the built-in fonts (no more `assert`).

While here: the delta was named `swrModel_LoadFonts_delta` but hooks `swrText_InitFonts` - renamed it to match, and swapped the raw `0x0042d720` literal in its registration for `swrText_InitFonts_ADDR`.

Rebased onto current master. Built + linked clean (WinLibs i686 GCC 13.2); the three integrity-check scripts pass locally. Playtested: default HD, toggle off -> vanilla fonts live, back on -> HD live, rapid toggling stable, normal boot unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)