### PR TITLE
fix(input): don't crash on launch when a non-game HID device is attached

### DIFF
--- a/dinput_hook/game_deltas/stdControl_delta.c
+++ b/dinput_hook/game_deltas/stdControl_delta.c
@@ -1,10 +1,10 @@
-#if ENABLE_GLFW_INPUT_HANDLING
 #include "stdControl_delta.h"
 
 #include "globals.h"
 
 #include <macros.h>
 
+#if ENABLE_GLFW_INPUT_HANDLING
 #include <GLFW/glfw3.h>
 
 // 0x00485360
@@ -35,6 +35,50 @@ void stdControl_ReadControls_delta(void) {
 int stdControl_SetActivation_delta(int bActive) {
     stdControl_bControlsActive = bActive;
 
+    return 0;
+}
+#else
+#include <Win95/DirectX.h>
+#include <Win95/Window.h>
+#include <Platform/stdControl.h>
+
+// 0x00485360
+// The original passes dwDevType=0 to EnumDevices, so DirectInput walks every attached
+// device -- including non-game HID devices (e.g. some USB headsets). Enumerating one of
+// those crashes the game on launch (a long-standing vanilla bug; this path was never
+// reimplemented). Enumerate only the device classes the game actually uses
+// (keyboard/mouse/joystick) so unrelated HID devices are never touched. The sub-steps
+// are HANG stubs in src, so they call the original game functions via their _ADDR.
+int stdControl_Startup_delta(void) {
+    if (stdControl_g_bStartup)
+        return 1;
+
+    HINSTANCE hinst = ((HINSTANCE(*)(void)) Window_GetHINSTANCE_ADDR)();
+    // DirectInputCreateA is __stdcall (callee cleans the stack); the cast must match or
+    // the stack is corrupted on return.
+    HRESULT hr = ((HRESULT(__stdcall *)(HINSTANCE, DWORD, LPDIRECTINPUTA *, LPUNKNOWN))
+                      DirectX_DirectInputCreateA_ADDR)(hinst, 0x0500 /* DInput v5 */,
+                                                       &iDirectInputA_ptr, NULL);
+    if (hr != S_OK)
+        return 1;
+
+    DirectInputNbKeyboard = 0;
+    DirectInputNbMouses = 0;
+    stdControl_numJoystickDevices = 0;
+
+    IDirectInputA *di = iDirectInputA_ptr;
+    LPDIENUMDEVICESCALLBACKA cb =
+        (LPDIENUMDEVICESCALLBACKA) DirectInput_EnumDevice_Callback_ADDR;
+    di->lpVtbl->EnumDevices(di, DIDEVTYPE_KEYBOARD, cb, NULL, DIEDFL_ATTACHEDONLY);
+    di->lpVtbl->EnumDevices(di, DIDEVTYPE_MOUSE, cb, NULL, DIEDFL_ATTACHEDONLY);
+    di->lpVtbl->EnumDevices(di, DIDEVTYPE_JOYSTICK, cb, NULL, DIEDFL_ATTACHEDONLY);
+
+    ((void (*)(void)) stdControl_InitKeyboard_ADDR)();
+    ((void (*)(void)) stdControl_InitJoysticks_ADDR)();
+    ((void (*)(void)) stdControl_InitMouse_ADDR)();
+    ((void (*)(void)) stdControl_Reset_ADDR)();
+
+    stdControl_g_bStartup = 1;
     return 0;
 }
 #endif

--- a/dinput_hook/game_deltas/stdControl_delta.h
+++ b/dinput_hook/game_deltas/stdControl_delta.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#if ENABLE_GLFW_INPUT_HANDLING
 #include "types.h"
 
 int stdControl_Startup_delta(void);
 
+#if ENABLE_GLFW_INPUT_HANDLING
 void stdControl_ReadControls_delta(void);
 
 int stdControl_SetActivation_delta(int bActive);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1135,10 +1135,11 @@ extern "C" void init_renderer_hooks() {
     hook_function("std3D_PurgeTextureCache", (uint32_t) 0x0048bb50,
                   (uint8_t *) std3D_PurgeTextureCache_delta);
 
-#if ENABLE_GLFW_INPUT_HANDLING
-    // stdControl
+    // stdControl: enumerate only game device classes so a non-game HID device
+    // (e.g. some USB headsets) can't crash DirectInput startup on launch.
     hook_function("stdControl_Startup", (uint32_t) 0x00485360,
                   (uint8_t *) stdControl_Startup_delta);
+#if ENABLE_GLFW_INPUT_HANDLING
     hook_function("stdControl_ReadControls", (uint32_t) 0x00485630,
                   (uint8_t *) stdControl_ReadControls_delta);
     hook_function("stdControl_SetActivation", (uint32_t) 0x00485a30,

--- a/src/types_directx.h
+++ b/src/types_directx.h
@@ -599,6 +599,12 @@ typedef enum DIDEVTYPE // DIDEVTYPE for version 5
     DIDEVTYPE_JOYSTICK = 4,
 } DIDEVTYPE;
 
+typedef enum DIEDFL // EnumDevices dwFlags
+{
+    DIEDFL_ALLDEVICES = 0x00000000,
+    DIEDFL_ATTACHEDONLY = 0x00000001,
+} DIEDFL;
+
 typedef struct DIDEVICEINSTANCEA
 {
     DWORD dwSize;


### PR DESCRIPTION
Fixes a launch crash that triggers when a non-game HID device (some USB headsets, etc.) is plugged in.

`stdControl_Startup` enumerates DirectInput with `dwDevType=0` (all attached devices), so DirectInput walks unrelated HID devices and crashes during init. This path was never reimplemented (`DirectInput_EnumDevice_Callback` is still a `HANG` stub), so vanilla's bug runs unguarded.

The non-GLFW `stdControl_Startup_delta` now enumerates only the keyboard/mouse/joystick classes, so unrelated HID devices are never touched. Sub-steps call the original game funcs via `_ADDR` (`DirectInputCreateA` is `__stdcall` — the cast has to match or the stack corrupts). Also added a small `DIEDFL` flags enum for the `EnumDevices` dwFlags.

Verified in-game: with an offending USB headset attached it now launches fine; previously a guaranteed crash on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)