### PR TITLE
MP: player names above pods (+ overhead-labels toggle)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -518,6 +518,7 @@ swrLoader_spline_file 0x0050c090 FILE*
 swrLoader_texture_file 0x0050c094 FILE*
 swrLoader_model_file 0x0050c098 FILE*
 
+swrText_halfScale 0x0050c0ac uint8_t # 1 = render text at half scale (the 0.5 at 0x004ac64c); set by the "~F" code in swrText_RenderString, read by rdProcEntry_Add2DQuad2
 currentTextPosX 0x0050C0B8 int16_t
 currentTextPosY 0x0050C0BA int16_t
 previousTextPosX 0x0050C0BC int16_t

--- a/dinput_hook/game_deltas/swrPlayerHUD_delta.cpp
+++ b/dinput_hook/game_deltas/swrPlayerHUD_delta.cpp
@@ -1,0 +1,185 @@
+#include "swrPlayerHUD_delta.h"
+
+#include <windows.h>
+#include <filesystem>
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+#include <macros.h>
+#include <Swr/swrPlayerHUD.h>
+#include <Swr/swrText.h>
+#include <Swr/swrMultiplayer.h>
+#include <globals.h>
+}
+
+#include "../hook_helper.h"
+#include "../imgui_utils.h" // imgui_state.show_pod_names (the debug-menu toggle)
+
+// ===========================================================================================
+// Multiplayer: player names above pods.
+//
+// The HUD already draws a small label above each racer (the race position number) via
+// swrPlayerHUD_RenderDistanceText -> swrText_CreateTextEntry2, doing all the world->screen
+// projection, distance fade, occlusion (don't show through track geometry) and splitscreen-pass
+// handling. We want the same labels in multiplayer but showing the human player's name instead of
+// the number -- so rather than re-implement that projection (and its ~13 tuning constants), we
+// reuse it verbatim and only swap the drawn string (and scale/nudge its draw position).
+//
+// swrPlayerHUD_RenderDistanceText_delta wraps the renderer: in single-player it just calls the
+// original (numbers over AI untouched); in multiplayer it builds a per-slot name label, sets a
+// redirect flag, runs the original, then clears the flag. While the flag is set,
+// swrText_CreateTextEntry2_delta (which the original calls for each visible, non-occluded racer)
+// maps the draw back to its racer slot by the screen position the renderer just stored, swaps in
+// that slot's name and adjusts the draw x/y.
+//
+// Slot mapping: the sprite slot is the racer entity's obj.id; in multiplayer the swrScores[] index
+// is the player number (see swrObjHang_BuildRosterMultiplayer), so swrScores[N] -> obj_test_ptr ->
+// obj.id maps player N to its slot, and swrMultiplayer_GetPlayerNameAscii(N) is its name.
+//
+// Size + placement: all of the game's text fonts are the same height, so "~F0" (which renders a
+// font at half scale, the 0.5 factor at 0x004ac64c) shrinks the name. "~c" centres it -- it works
+// at half scale because it shifts the anchor by GetStringWidth/2 in the same virtual space the
+// glyphs render in, so the shift and the rendered width scale together. "~F0" also scales the glyph
+// *position* by 0.5 (the same 0.5 factor applied to the glyph x in rdProcEntry_Add2DQuad2), landing
+// the label at half the intended screen coordinate; we undo that by scaling the draw position by
+// 200%.
+//
+// Whether the labels render at all is the "Overhead racer labels" debug-menu toggle
+// (imgui_state.show_pod_names, persisted to SW_RACER_RE.ini as show_pod_names); off hides them in
+// both SP and MP. The remaining placement knobs live in SW_RACER_RE.ini [settings] (edit + relaunch,
+// no rebuild):
+//   name_label_pos_pct  (default 200) percent to scale the draw x/y by (undoes the 0.5 scale)
+//   name_label_offset_x (default 0)   pixels to nudge right (negative = left), after the scale
+//   name_label_offset_y (default 0)   pixels to nudge down (negative = up), after the scale
+// ===========================================================================================
+
+typedef void(swrPlayerHUD_RenderDistanceText_t)(void *viewport, bool secondaryPass);
+typedef char *(swrMultiplayer_GetPlayerNameAscii_t)(int playerIndex);
+typedef int(swrMultiplayer_GetRacerId_t)(int playerIndex);
+typedef void(swrText_RenderEntries1_t)(void);
+
+#define HUD_NAME_MAX_RACERS 20 // swrScores[20] / player_sprite arrays are sized 20
+#define HUD_NAME_MAX_PODS 23   // swrRacer_PodData[23] (character-name fallback bound)
+#define HUD_NAME_FONT 0        // full-alphabet font; "~F0" renders it at half scale
+
+static char g_slotName[HUD_NAME_MAX_RACERS][40]; // "~F0~c~s" + name, indexed by sprite slot (obj.id)
+static bool g_mpNameRedirect = false;
+static bool g_mpNameSecondaryPass = false;
+
+static int g_labelPosPct = 200;
+static int g_labelOffsetX = 0;
+static int g_labelOffsetY = 0;
+
+static int read_ini_int(const wchar_t *key, int fallback, const wchar_t *ini) {
+    wchar_t buf[32];
+    if (GetPrivateProfileStringW(L"settings", key, L"", buf, (DWORD) std::size(buf), ini) == 0)
+        return fallback; // key absent -> default
+    return _wtoi(buf);    // _wtoi handles a leading '-' (GetPrivateProfileIntW does not)
+}
+
+static void load_label_settings_once() {
+    static bool loaded = false;
+    if (loaded)
+        return;
+    loaded = true;
+
+    wchar_t module_path[1024];
+    GetModuleFileNameW(nullptr, module_path, (DWORD) std::size(module_path));
+    const std::wstring ini =
+        (std::filesystem::path(module_path).parent_path() / "SW_RACER_RE.ini").wstring();
+
+    g_labelPosPct = read_ini_int(L"name_label_pos_pct", 200, ini.c_str());
+    g_labelOffsetX = read_ini_int(L"name_label_offset_x", 0, ini.c_str());
+    g_labelOffsetY = read_ini_int(L"name_label_offset_y", 0, ini.c_str());
+
+    fprintf(hook_log, "[mpnames] pos_pct=%d offset_x=%d offset_y=%d\n", g_labelPosPct, g_labelOffsetX,
+            g_labelOffsetY);
+    fflush(hook_log);
+}
+
+void swrPlayerHUD_RenderDistanceText_delta(void *viewport, bool secondaryPass) {
+    if (!imgui_state.show_pod_names) {
+        // Toggle off: draw nothing (no overhead labels in SP or MP). Skipping the original is safe
+        // -- player_sprite_pixel_pos is only consumed by swrPlayerHUD_SampleOcclusion, which feeds
+        // back into this same renderer.
+        return;
+    }
+
+    if (multiplayer_enabled == 0) {
+        // Single-player: position numbers over AI, unchanged.
+        hook_call_original((swrPlayerHUD_RenderDistanceText_t *) swrPlayerHUD_RenderDistanceText_ADDR,
+                           viewport, secondaryPass);
+        return;
+    }
+
+    load_label_settings_once();
+
+    for (int slot = 0; slot < HUD_NAME_MAX_RACERS; slot++)
+        g_slotName[slot][0] = '\0';
+
+    for (int player = 0; player < HUD_NAME_MAX_RACERS; player++) {
+        if (swrScores[player].identifier == 0) // empty roster slot
+            continue;
+        swrRace *racer = swrScores[player].obj_test_ptr;
+        if (!racer)
+            continue;
+        const int slot = racer->obj.id;
+        if (slot < 0 || slot >= HUD_NAME_MAX_RACERS)
+            continue;
+
+        const char *name =
+            ((swrMultiplayer_GetPlayerNameAscii_t *) swrMultiplayer_GetPlayerNameAscii_ADDR)(player);
+        if (name && name[0]) {
+            snprintf(g_slotName[slot], sizeof(g_slotName[slot]), "~F%d~c~s%s", HUD_NAME_FONT, name);
+        } else {
+            // No player name for this slot: fall back to the character name.
+            const int podIndex =
+                ((swrMultiplayer_GetRacerId_t *) swrMultiplayer_GetRacerId_ADDR)(player);
+            if (podIndex >= 0 && podIndex < HUD_NAME_MAX_PODS) {
+                char podName[32];
+                swrText_FormatPodName(podIndex, podName, sizeof(podName));
+                snprintf(g_slotName[slot], sizeof(g_slotName[slot]), "~F%d~c~s%s", HUD_NAME_FONT,
+                         podName);
+            }
+        }
+    }
+
+    g_mpNameSecondaryPass = secondaryPass;
+    g_mpNameRedirect = true;
+    hook_call_original((swrPlayerHUD_RenderDistanceText_t *) swrPlayerHUD_RenderDistanceText_ADDR,
+                       viewport, secondaryPass);
+    g_mpNameRedirect = false;
+}
+
+void swrText_CreateTextEntry2_delta(int16_t screen_x, int16_t screen_y, char r, char g, char b,
+                                    char a, char *screenText) {
+    if (g_mpNameRedirect) {
+        // The renderer stored this racer's screen position into the sprite-position arrays for the
+        // current pass right before calling us, so match it back to the slot (and thus the name).
+        const int *px =
+            g_mpNameSecondaryPass ? player_sprite_pixel_pos_x2 : player_sprite_pixel_pos_x;
+        const int *py =
+            g_mpNameSecondaryPass ? player_sprite_pixel_pos_y2 : player_sprite_pixel_pos_y;
+        for (int slot = 0; slot < HUD_NAME_MAX_RACERS; slot++) {
+            if (px[slot] == screen_x && py[slot] == screen_y && g_slotName[slot][0]) {
+                // Scale the draw position by pos_pct (200% undoes the ~F 0.5 position scale); "~c"
+                // in the string handles centring. Then apply the fine-tune offsets.
+                screen_x = (int16_t) ((int) screen_x * g_labelPosPct / 100 + g_labelOffsetX);
+                screen_y = (int16_t) ((int) screen_y * g_labelPosPct / 100 + g_labelOffsetY);
+                screenText = g_slotName[slot];
+                break;
+            }
+        }
+    }
+
+    hook_call_original(swrText_CreateTextEntry2, screen_x, screen_y, r, g, b, a, screenText);
+}
+
+void swrText_RenderEntries1_delta(void) {
+    hook_call_original((swrText_RenderEntries1_t *) swrText_RenderEntries1_ADDR);
+    // Our half-size labels use the "~F" code, which leaves swrText_halfScale set after the last one
+    // renders (swrText_RenderString only resets it per string). Clear it so the minimap text drawn
+    // after this batch -- which doesn't go through RenderString -- isn't shrunk too.
+    swrText_halfScale = 0;
+}

--- a/dinput_hook/game_deltas/swrPlayerHUD_delta.cpp
+++ b/dinput_hook/game_deltas/swrPlayerHUD_delta.cpp
@@ -1,9 +1,6 @@
 #include "swrPlayerHUD_delta.h"
 
-#include <windows.h>
-#include <filesystem>
 #include <cstdio>
-#include <cstdlib>
 
 extern "C" {
 #include <macros.h>
@@ -47,11 +44,7 @@ extern "C" {
 //
 // Whether the labels render at all is the "Overhead racer labels" debug-menu toggle
 // (imgui_state.show_pod_names, persisted to SW_RACER_RE.ini as show_pod_names); off hides them in
-// both SP and MP. The remaining placement knobs live in SW_RACER_RE.ini [settings] (edit + relaunch,
-// no rebuild):
-//   name_label_pos_pct  (default 200) percent to scale the draw x/y by (undoes the 0.5 scale)
-//   name_label_offset_x (default 0)   pixels to nudge right (negative = left), after the scale
-//   name_label_offset_y (default 0)   pixels to nudge down (negative = up), after the scale
+// both SP and MP. Label placement is baked in as constants below (HUD_NAME_POS_PCT / OFFSET_*).
 // ===========================================================================================
 
 typedef void(swrPlayerHUD_RenderDistanceText_t)(void *viewport, bool secondaryPass);
@@ -63,40 +56,14 @@ typedef void(swrText_RenderEntries1_t)(void);
 #define HUD_NAME_MAX_PODS 23   // swrRacer_PodData[23] (character-name fallback bound)
 #define HUD_NAME_FONT 0        // full-alphabet font; "~F0" renders it at half scale
 
+// Label placement, baked in (was INI-tunable during bring-up; final values per review).
+#define HUD_NAME_POS_PCT 200 // % scale on the draw x/y (undoes the ~F 0.5 position scale)
+#define HUD_NAME_OFFSET_X 0  // px nudge right after the scale (negative = left)
+#define HUD_NAME_OFFSET_Y 0  // px nudge down after the scale (negative = up)
+
 static char g_slotName[HUD_NAME_MAX_RACERS][40]; // "~F0~c~s" + name, indexed by sprite slot (obj.id)
 static bool g_mpNameRedirect = false;
 static bool g_mpNameSecondaryPass = false;
-
-static int g_labelPosPct = 200;
-static int g_labelOffsetX = 0;
-static int g_labelOffsetY = 0;
-
-static int read_ini_int(const wchar_t *key, int fallback, const wchar_t *ini) {
-    wchar_t buf[32];
-    if (GetPrivateProfileStringW(L"settings", key, L"", buf, (DWORD) std::size(buf), ini) == 0)
-        return fallback; // key absent -> default
-    return _wtoi(buf);    // _wtoi handles a leading '-' (GetPrivateProfileIntW does not)
-}
-
-static void load_label_settings_once() {
-    static bool loaded = false;
-    if (loaded)
-        return;
-    loaded = true;
-
-    wchar_t module_path[1024];
-    GetModuleFileNameW(nullptr, module_path, (DWORD) std::size(module_path));
-    const std::wstring ini =
-        (std::filesystem::path(module_path).parent_path() / "SW_RACER_RE.ini").wstring();
-
-    g_labelPosPct = read_ini_int(L"name_label_pos_pct", 200, ini.c_str());
-    g_labelOffsetX = read_ini_int(L"name_label_offset_x", 0, ini.c_str());
-    g_labelOffsetY = read_ini_int(L"name_label_offset_y", 0, ini.c_str());
-
-    fprintf(hook_log, "[mpnames] pos_pct=%d offset_x=%d offset_y=%d\n", g_labelPosPct, g_labelOffsetX,
-            g_labelOffsetY);
-    fflush(hook_log);
-}
 
 void swrPlayerHUD_RenderDistanceText_delta(void *viewport, bool secondaryPass) {
     if (!imgui_state.show_pod_names) {
@@ -112,8 +79,6 @@ void swrPlayerHUD_RenderDistanceText_delta(void *viewport, bool secondaryPass) {
                            viewport, secondaryPass);
         return;
     }
-
-    load_label_settings_once();
 
     for (int slot = 0; slot < HUD_NAME_MAX_RACERS; slot++)
         g_slotName[slot][0] = '\0';
@@ -165,8 +130,8 @@ void swrText_CreateTextEntry2_delta(int16_t screen_x, int16_t screen_y, char r, 
             if (px[slot] == screen_x && py[slot] == screen_y && g_slotName[slot][0]) {
                 // Scale the draw position by pos_pct (200% undoes the ~F 0.5 position scale); "~c"
                 // in the string handles centring. Then apply the fine-tune offsets.
-                screen_x = (int16_t) ((int) screen_x * g_labelPosPct / 100 + g_labelOffsetX);
-                screen_y = (int16_t) ((int) screen_y * g_labelPosPct / 100 + g_labelOffsetY);
+                screen_x = (int16_t) ((int) screen_x * HUD_NAME_POS_PCT / 100 + HUD_NAME_OFFSET_X);
+                screen_y = (int16_t) ((int) screen_y * HUD_NAME_POS_PCT / 100 + HUD_NAME_OFFSET_Y);
                 screenText = g_slotName[slot];
                 break;
             }

--- a/dinput_hook/game_deltas/swrPlayerHUD_delta.h
+++ b/dinput_hook/game_deltas/swrPlayerHUD_delta.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+
+extern "C" {
+#include <Swr/swrModel.h>     // swrText_CreateTextEntry2 prototype + _ADDR
+#include <Swr/swrPlayerHUD.h> // swrPlayerHUD_RenderDistanceText_ADDR
+}
+
+// Multiplayer: draw each player's name above their pod instead of the vanilla position number.
+// Single-player is untouched (the wrapper only redirects when multiplayer_enabled).
+void swrPlayerHUD_RenderDistanceText_delta(void *viewport, bool secondaryPass);
+void swrText_CreateTextEntry2_delta(int16_t screen_x, int16_t screen_y, char r, char g, char b,
+                                    char a, char *screenText);
+void swrText_RenderEntries1_delta(void);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -86,6 +86,9 @@ void read_settings_ini() {
         GetPrivateProfileIntW(L"settings", L"ai_full_lod", 1, ini_path.c_str());
     set_ai_full_lod(imgui_state.ai_full_lod);
 
+    imgui_state.show_pod_names =
+        GetPrivateProfileIntW(L"settings", L"show_pod_names", 1, ini_path.c_str());
+
     g_window_mode =
         GetPrivateProfileIntW(L"settings", L"window_mode", WINDOW_MODE_WINDOWED, ini_path.c_str());
     if (g_window_mode < WINDOW_MODE_WINDOWED || g_window_mode > WINDOW_MODE_FULLSCREEN)
@@ -105,6 +108,9 @@ void save_settings_ini() {
 
     WritePrivateProfileStringW(L"settings", L"ai_full_lod", imgui_state.ai_full_lod ? L"1" : L"0",
                                ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"show_pod_names",
+                               imgui_state.show_pod_names ? L"1" : L"0", ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"window_mode", std::to_wstring(g_window_mode).c_str(),
                                ini_path.c_str());
@@ -534,6 +540,11 @@ void opengl_render_imgui() {
 
         if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
             set_ai_full_lod(imgui_state.ai_full_lod);
+        }
+
+        if (ImGui::Checkbox("Overhead racer labels (MP names / SP place)",
+                            &imgui_state.show_pod_names)) {
+            save_settings_ini();
         }
 
         static const char *window_mode_items[] = {"Windowed", "Borderless", "Fullscreen"};

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -33,6 +33,7 @@ typedef struct ImGuiState {
     int anisotropy = 8;
     bool enable_fog = true;
     bool ai_full_lod = true;// force every racer (incl. AI) onto the full pod model (no LOD pop-in)
+    bool show_pod_names = true;// draw the overhead racer labels (MP player names / SP place numbers)
 
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include "./game_deltas/swrSpline_delta.h"
 #include "./game_deltas/swrObjJdge_delta.h"
 #include "./game_deltas/swrMultiplayer_delta.h"
+#include "./game_deltas/swrPlayerHUD_delta.h"
 #include "./game_deltas/swrObjHang_delta.h"
 #include "./game_deltas/swrRace_delta.h"
 
@@ -1258,6 +1259,20 @@ extern "C" void init_renderer_hooks() {
     // Multiplayer fix: restore racer-selection input after a race (both host and clients).
     hook_function("swrObjHang_F0", (uint32_t) swrObjHang_F0, (uint8_t *) swrObjHang_F0_ADDR);
     hook_replace(swrObjHang_F0, swrObjHang_F0_delta);
+
+    // Multiplayer: draw player names above pods instead of the position number. The wrapper on
+    // swrPlayerHUD_RenderDistanceText (hooked by address; not reimplemented) reuses the game's own
+    // projection/occlusion/fade and only redirects the text it draws -- via swrText_CreateTextEntry2
+    // -- to the racer's name. Single-player is untouched (redirect only when multiplayer_enabled).
+    hook_function("swrPlayerHUD_RenderDistanceText", (uint32_t) swrPlayerHUD_RenderDistanceText_ADDR,
+                  (uint8_t *) swrPlayerHUD_RenderDistanceText_delta);
+    // swrText_CreateTextEntry2 is reimplemented (already registered in hook_generated.c), so a plain
+    // hook_replace overrides it -- same as the other reimplemented-function deltas above.
+    hook_replace(swrText_CreateTextEntry2, swrText_CreateTextEntry2_delta);
+    // Clear the "~F" half-scale flag after the text batch so the minimap text the half-size player
+    // labels would otherwise leave shrunk renders at full size.
+    hook_function("swrText_RenderEntries1", (uint32_t) swrText_RenderEntries1_ADDR,
+                  (uint8_t *) swrText_RenderEntries1_delta);
 
     // Record each pod's cable-curve state per frame so the GL walk can bend the cables
     // (the game's cable deformer only touches the rd3d mesh the replacement doesn't use).


### PR DESCRIPTION

<img width="744" height="534" alt="image" src="https://github.com/user-attachments/assets/aeb2b78b-5c07-4d2c-b2c0-71f17de1ab95" />


Closes part of #143 ("names above opponents").

In multiplayer, the small label the HUD already draws over each pod now shows the **human player's name** instead of the race-position number. Single-player position numbers over AI are untouched.

### How
Rather than re-implement the world->screen projection (and its ~13 tuning constants), it wraps `swrPlayerHUD_RenderDistanceText` and only swaps the string it draws:
- SP (`multiplayer_enabled == 0`): calls the original verbatim, numbers unchanged.
- MP: builds a per-slot name label (`swrScores[N]` index == player number -> `obj.id` slot -> `swrMultiplayer_GetPlayerNameAscii`), sets a redirect flag, runs the original, then clears it. While set, `swrText_CreateTextEntry2` maps each draw back to its slot by the screen position the renderer just stored and swaps in the name. Blank player name falls back to the character name.
- Labels render at half size via the `~F0` text code and are centred with `~c`; the draw position is scaled 200% to undo `~F`'s 0.5 position offset.

### Toggle
Adds an **"Overhead racer labels"** debug-menu checkbox (`show_pod_names`, persisted to `SW_RACER_RE.ini`) that gates the labels in both SP and MP.

### Cleanup
- Names the swrText half-scale flag `0x0050c0ac` -> `swrText_halfScale` in `data_symbols.syms`; the delta clears it (so the minimap text after the label batch isn't shrunk) via the named global.

Verified in-game on **two machines** (host + client): names show centred and half-size over the correct pods, SP numbers unaffected, minimap text unaffected.