### PR TITLE
swrUtils: reimplement swrUtils_Rand

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -668,6 +668,9 @@ swrGui_Stopped 0x0050cb64 int
 swr_FastMode 0x0050cb68 int
 swr_fixedDeltaTimeSecs 0x0050cb70 double
 
+swrUtils_randState 0x0050cb7c int
+swrUtils_randInitialized 0x0050cb80 uint8_t
+
 cman_unk_mat44 0x0050cb88 rdMatrix44
 poddConnectionMesh_sinLookupTable 0x0050CBC8 float[64]
 poddConnectionMesh_sinLookupTableInitialized 0x0050CCC8 BOOL

--- a/src/General/utils.c
+++ b/src/General/utils.c
@@ -1,6 +1,9 @@
 #include "utils.h"
 
+#include "globals.h"
 #include "../macros.h"
+
+#include <limits.h>
 
 // 0x0045cf00 TODO: crashes on release build, works fine on debug
 float swrUtils_RandFloat(void)
@@ -12,6 +15,19 @@ float swrUtils_RandFloat(void)
 // 0x004816b0
 int swrUtils_Rand(void) // randInt
 {
-    HANG("TODO, easy");
-    return 0;
+    // self-seeding linear congruential generator (ANSI constants)
+    if (!swrUtils_randInitialized) {
+        swrUtils_randState = 0x2750250;
+        swrUtils_randInitialized = 1;
+    }
+    int value = swrUtils_randState * 0x41c64e6d + 0x3039;
+    swrUtils_randState = value;
+    // -INT_MIN overflows, so the most-negative state maps to 0 instead of abs()
+    if (value == INT_MIN) {
+        return 0;
+    }
+    if (value < 0) {
+        value = -value;
+    }
+    return value;
 }


### PR DESCRIPTION
Reimplements `swrUtils_Rand` (0x004816b0) -- the integer RNG (`randInt`) that was still a `HANG("TODO, easy")` stub.

It's a self-seeding LCG with the ANSI constants: seeds `randState` to `0x2750250` on first call, then `state = state * 0x41c64e6d + 0x3039` and returns the abs() of the result (the most-negative state maps to 0 to dodge the `-INT_MIN` overflow). Verified byte-faithful against the disassembly.

Adds the two backing globals (`swrUtils_randState` @ 0x0050cb7c, `swrUtils_randInitialized` @ 0x0050cb80) to `data_symbols.syms`.

Builds + links clean.