### PR TITLE
swrObj: reimplement the local-player and pause-state accessors

### DIFF
--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -103,7 +103,7 @@ void swrObjJudge_PollPause()
 // 0x00445690
 int GetPauseState()
 {
-    HANG("TODO");
+    return pauseState;
 }
 
 // 0x004456B0
@@ -252,7 +252,16 @@ void swrObjJdge_Clear(swrObjJdge* jdge, int event)
 // 0x0045D350
 int NumLocalPlayers()
 {
-    HANG("TODO");
+    if (firstLocalPlayer == NULL) {
+        return 0;
+    }
+    if (secondLocalPlayer == NULL) {
+        return 1;
+    }
+    if (thirdLocalPlayer == NULL) {
+        return 2;
+    }
+    return (fourthLocalPlayer != NULL) + 3;
 }
 
 // 0x0045D390
@@ -262,9 +271,18 @@ double swrRace_GetLapProgressIfAvailable()
 }
 
 // 0x0045D3D0
-int GetLocalPlayerNumberFromScore(swrScore*)
+int GetLocalPlayerNumberFromScore(swrScore* score)
 {
-    HANG("TODO");
+    if (firstLocalPlayer == score) {
+        return 0;
+    }
+    if (secondLocalPlayer == score) {
+        return 1;
+    }
+    if (thirdLocalPlayer == score) {
+        return 2;
+    }
+    return fourthLocalPlayer == score ? 3 : -1;
 }
 
 // 0x0045E120

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -442,7 +442,7 @@ void swrObjJdge_Clear(swrObjJdge* jdge, int event);
 
 int NumLocalPlayers();
 double swrRace_GetLapProgressIfAvailable();
-int GetLocalPlayerNumberFromScore(swrScore*);
+int GetLocalPlayerNumberFromScore(swrScore* score);
 
 int KeyDownForPlayer1Or2(int);
 


### PR DESCRIPTION
Reimplements three small `HANG("TODO")` leaf accessors in `swrObj.c` that a lot of callers route through (the planner ranked `NumLocalPlayers` as the top remaining stub leaf after the swrModel node accessors):

- `NumLocalPlayers` -> count of non-null `firstLocalPlayer`..`fourthLocalPlayer` (0-4)
- `GetLocalPlayerNumberFromScore` -> slot index 0-3 matching a `swrScore*`, else -1
- `GetPauseState` -> `pauseState`

All verified byte-faithful against the disasm. They read only already-named globals and have no call dependencies, so nothing downstream is required. Also named the previously anonymous `swrScore*` param (`score`). Builds + links clean.