### PR TITLE
swrUI: reimplement swrUI_GetById

### DIFF
--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -105,7 +105,31 @@ void swrUI_SetColorUnk2(swrUI_unk* ui, uint8_t r, uint8_t g, uint8_t b, uint8_t 
 // 0x00414d90
 swrUI_unk* swrUI_GetById(swrUI_unk* ui, int id)
 {
-    HANG("TODO, easy");
+    if (ui == NULL) {
+        ui = swrUI_unk_ptr;
+    }
+    if (ui->id == id) {
+        return ui;
+    }
+
+    // Walk the element's child list (siblings linked via next2). List-item
+    // widgets (class 0xc) are skipped; any other child with its own children
+    // is searched recursively first, then matched directly.
+    for (swrUI_unk* child = ui->next; child != NULL; child = child->next2) {
+        if (child->widget_class == 0xc) {
+            continue;
+        }
+        if (child->next != NULL) {
+            swrUI_unk* found = swrUI_GetById(child, id);
+            if (found != NULL) {
+                return found;
+            }
+        }
+        if (child->id == id) {
+            return child;
+        }
+    }
+    return NULL;
 }
 
 // 0x00414e30


### PR DESCRIPTION
Reimplements `swrUI_GetById` (0x00414d90) -- the recursive widget-tree lookup that resolves a UI element by id. It was the top remaining stub leaf in the planner (39 callers).

Starts from the passed root (or the global `swrUI_unk_ptr` when NULL), returns it if the id matches, otherwise walks the child list (siblings linked via `next2`), skipping list-item widgets (class `0xc`) and recursing into any child that has its own children before matching directly.

Verified byte-faithful against the disasm. Uses only already-named `swrUI_unk` fields and globals -- no new symbols. Builds + links clean.