### PR TITLE
swrCam: reimplement swrCam_CamState_InitMainMat4

### DIFF
--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -894,5 +894,8 @@ void swrScene_SetObjectsLoaded(void)
 // 0x00428A60
 void swrCam_CamState_InitMainMat4(uint16_t index, uint16_t val1, rdMatrix44* mat, uint16_t val2)
 {
-    HANG("TODO");
+    int entry = (int16_t) index;
+    unkCameraArray[entry].sourceType = val2;
+    unkCameraArray[entry].behaviorType = val1;
+    unkCameraArray[entry].matrixSource = mat;
 }


### PR DESCRIPTION
Reimplements `swrCam_CamState_InitMainMat4` (0x00428A60): seeds an `unkCameraArray` entry with its behavior/source types and the source matrix pointer (the per-camera state later consumed by `swrViewport_UpdateCameras`). Verified byte-faithful against the disasm.

Uses only already-named globals and `swrCamera_unk` fields -- no new symbols. Builds + links clean.