### PR TITLE
feat: log a crash report to hook.log on an unhandled exception

### DIFF
--- a/dinput_hook/main.cpp
+++ b/dinput_hook/main.cpp
@@ -3,6 +3,8 @@
 //
 #include <fstream>
 #include <windows.h>
+#include <cstdio>
+#include <cstring>
 
 #include "./game_deltas/tracks_delta.h"
 #include "renderer_hook.h"
@@ -10,6 +12,72 @@
 #include "custom_tracks.h"
 
 FILE *hook_log = nullptr;
+
+// Crash logger: on an unhandled exception, write the faulting address + the module it lands
+// in, plus a scan of on-stack return addresses (each resolved to module+offset), to
+// hook.log. A crash on a player's machine is then diagnosable from the log they send back
+// (dinput.dll offsets resolve via addr2line; game-exe offsets via the disassembly). It fires
+// only on an actual unhandled crash, so it is free in normal play.
+static void crash_log_addr(void *addr) {
+    HMODULE mod = nullptr;
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           (LPCSTR) addr, &mod) &&
+        mod) {
+        char path[MAX_PATH] = {0};
+        GetModuleFileNameA(mod, path, MAX_PATH);
+        const char *name = strrchr(path, '\\');
+        name = name ? name + 1 : path;
+        fprintf(hook_log, "    %p  %s+0x%lx\n", addr, name,
+                (unsigned long) ((UINT_PTR) addr - (UINT_PTR) mod));
+    } else {
+        fprintf(hook_log, "    %p  (no module)\n", addr);
+    }
+}
+
+static bool crash_addr_is_code(void *addr) {
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(addr, &mbi, sizeof(mbi)) != sizeof(mbi))
+        return false;
+    if (mbi.State != MEM_COMMIT)
+        return false;
+    const DWORD prot = mbi.Protect & 0xff;
+    return prot == PAGE_EXECUTE || prot == PAGE_EXECUTE_READ || prot == PAGE_EXECUTE_READWRITE ||
+           prot == PAGE_EXECUTE_WRITECOPY;
+}
+
+static LONG WINAPI crash_log_filter(EXCEPTION_POINTERS *ep) {
+    if (!hook_log)
+        return EXCEPTION_CONTINUE_SEARCH;
+    const EXCEPTION_RECORD *er = ep->ExceptionRecord;
+    fflush(hook_log);// flush buffered output so the lines leading up to the crash survive
+    fprintf(hook_log, "\n*** unhandled exception: code=0x%08lx addr=%p ***\n", er->ExceptionCode,
+            er->ExceptionAddress);
+    if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
+        fprintf(hook_log, "    access %s at %p\n", er->ExceptionInformation[0] ? "write" : "read",
+                (void *) er->ExceptionInformation[1]);
+    }
+    fprintf(hook_log, "  faulting instruction:\n");
+    crash_log_addr(er->ExceptionAddress);
+    // Heuristic: any committed-executable value on the stack is a likely return address. May
+    // include false positives (data that looks like a code address); the genuine frames form
+    // the call chain.
+    fprintf(hook_log, "  on-stack code addresses:\n");
+    UINT_PTR *sp = (UINT_PTR *) ep->ContextRecord->Esp;
+    int logged = 0;
+    for (int i = 0; i < 8192 && logged < 64; i++) {
+        if (IsBadReadPtr(&sp[i], sizeof(UINT_PTR)))
+            break;
+        const UINT_PTR val = sp[i];
+        if (val > 0x10000 && crash_addr_is_code((void *) val)) {
+            crash_log_addr((void *) val);
+            logged++;
+        }
+    }
+    fprintf(hook_log, "*** end crash report ***\n");
+    fflush(hook_log);
+    return EXCEPTION_CONTINUE_SEARCH;// let WER / the normal crash path proceed
+}
 
 // https://github.com/lcsig/API-Hooking
 DWORD_PTR hookIAT(const char *libName, const char *API_Name, LPVOID newFun) {
@@ -153,6 +221,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
         return TRUE;
 
     hook_log = fopen("hook.log", "wb");
+    SetUnhandledExceptionFilter(crash_log_filter);
 
     fprintf(hook_log, "[DllMain]\n");
     fflush(hook_log);


### PR DESCRIPTION
Adds a lightweight crash logger. On an unhandled exception it appends a report to `hook.log`: the faulting address + the module it lands in, plus a scan of on-stack return addresses resolved to `module+offset`. So when a player hits a CTD, the log they send back pinpoints where it happened -- our `dinput.dll` offsets resolve via `addr2line`, game-exe offsets via the disassembly -- with no debugger needed on their machine.

Installed via `SetUnhandledExceptionFilter`, so it only fires on an actual unhandled crash and costs nothing in normal play. The on-stack scan is a heuristic (any committed-executable value is treated as a likely return address), so it can include false positives, but the genuine frames form the call chain.

Already earned its keep diagnosing a couple of field crashes from users' logs alone (a HID-enumeration CTD and an AMD intro-movie CTD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)