### PR TITLE
swrSprite: reimplement swrSprite_SetVisible

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -495,6 +495,7 @@ swrScene_animations_count 0x0050b5ec int
 
 rdVector_sound_pos 0x0050b5f0 rdVector4
 
+swrSprite_unk_visible 0x0050b700 int
 swrSprite_unk1_r 0x0050b704 char
 swrSprite_unk1_g 0x0050b705 char
 swrSprite_unk1_b 0x0050b706 char

--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -337,9 +337,27 @@ void swrSprite_DrawSprites(int x)
 }
 
 // 0x004285d0
-void swrSprite_SetVisible(short id, int visible) // Guess, but I believe accurate
+void swrSprite_SetVisible(short id, int visible)
 {
-    HANG("TODO, easy");
+    if (id == -0xc9) {
+        swrSprite_unk_visible = visible != 0;
+        return;
+    }
+    if (id == -0x67) {
+        swrSprite_unk1_a = -(visible != 0);
+        return;
+    }
+    if (id == -0x68) {
+        swrSprite_unk2_a = -(visible != 0);
+        return;
+    }
+    if (-1 < id) {
+        if (visible != 0) {
+            swrSprite_array[id].flags = swrSprite_array[id].flags | 0x20;
+            return;
+        }
+        swrSprite_array[id].flags = swrSprite_array[id].flags & 0xffffffdf;
+    }
 }
 
 // 0x00428660


### PR DESCRIPTION
Reverse-hook reimpl of `swrSprite_SetVisible` (0x004285d0), verified against the disassembly.

For a real sprite id it toggles the `0x20` visible flag in `swrSprite_array`. The sentinel ids route to the special overlay globals: `-103`/`-104` set the `unk1`/`unk2` alpha, and `-201` sets the overlay visibility flag. Names that last flag `swrSprite_unk_visible` (`0x0050b700`), read by `swrSprite_DrawSprites` to gate drawing the id `-201` overlay sprite.

Builds + links clean.