### PR TITLE
swrText: reimplement swrText_GetStringWidth and swrText_GetStringHeight

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -175,6 +175,14 @@ lensFlareSpriteIds 0x004B94E0 int[16]
 
 currentSpriteColor 0x004BFA0C uint8_t[4]
 
+# extended-character (code > 0x96) compose tables read by swrText_GetStringWidth/Height/DrawString.
+# A code's row index = swrText_extCharComposeIndex[code - 0x97] (0xff means no entry); that row in
+# swrText_extCharComposePairs is {extGlyphSlot, baseChar}. baseChar 0xff => use the font's extended
+# glyph table at extGlyphSlot, else fall through to the normal glyph for baseChar. Sizes are bounded
+# by the layout (pairs end where the index table begins at 0x4bfa59); exact extents unverified.
+swrText_extCharComposePairs 0x004bfa10 uint8_t[72]
+swrText_extCharComposeIndex 0x004bfa59 uint8_t[105]
+
 eventManagerMain 0x004bfec0 swrEventManager**
 swrObjHang_unused_state 0x004bfec8 swrObjHang_STATE = -1
 swrObjHang_unused_unk 0x004bfecc int = -1

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -273,6 +273,103 @@ void swrText_ShowTimedMessage(char* text, float duration)
     }
 }
 
+// Width of the first line of text (stops at a "~n" newline marker); honors "~" format codes.
+// 0x0042de30
+int swrText_GetStringWidth(char* text, swrFont* font)
+{
+    int width = 0;
+    int done = 0;
+    int i = 0;
+
+    do {
+        uint8_t c = text[i];
+        if (c == 0)
+            done = 1;
+        if (c == '~') {
+            i++;
+            if (text[i] == 'n')
+                done = 1;
+            else
+                c = ((text[i] != '~') - 1) & 0x7e; // "~~" -> literal '~'; any other "~x" code -> skipped
+        }
+        if (c != 0 && !done) {
+            swrTextGlyph* glyph = NULL;
+            if (c == '_')
+                c = ' ';
+            // fold lowercase to uppercase when the font has no lowercase glyphs
+            if (c > 0x60 && c < 0x7b && font->lastChar < 0x61)
+                c -= 0x20;
+            // extended (accented) characters are composed via the lookup tables
+            if (c > 0x96 && font->extGlyphs != NULL && swrText_extCharComposeIndex[c - 0x97] != 0xff) {
+                int row = swrText_extCharComposeIndex[c - 0x97] * 2;
+                int slot = swrText_extCharComposePairs[row];
+                c = swrText_extCharComposePairs[row + 1];
+                if (c == 0xff) {
+                    glyph = &font->extGlyphs[slot];
+                    c = 0;
+                }
+            }
+            if (font->glyphs != NULL && font->firstChar <= c && c <= font->lastChar)
+                glyph = &font->glyphs[c - font->firstChar];
+            if (glyph != NULL)
+                width += glyph->advance;
+        }
+        i++;
+    } while (!done);
+
+    return width;
+}
+
+// Average glyph height across the glyphs in the string.
+// 0x0042df70
+int swrText_GetStringHeight(char* text, swrFont* font)
+{
+    int totalHeight = 0;
+    int count = 0;
+    int done = 0;
+    int i = 0;
+
+    do {
+        uint8_t c = text[i];
+        if (c == 0)
+            done = 1;
+        if (c == '~') {
+            i++;
+            if (text[i] == 'n')
+                done = 1;
+            else
+                c = ((text[i] != '~') - 1) & 0x7e;
+        }
+        if (c != 0 && !done) {
+            swrTextGlyph* glyph = NULL;
+            if (c == '_')
+                c = ' ';
+            if (c > 0x60 && c < 0x7b && font->lastChar < 0x61)
+                c -= 0x20;
+            if (c > 0x96 && font->extGlyphs != NULL && swrText_extCharComposeIndex[c - 0x97] != 0xff) {
+                int row = swrText_extCharComposeIndex[c - 0x97] * 2;
+                int slot = swrText_extCharComposePairs[row];
+                c = swrText_extCharComposePairs[row + 1];
+                if (c == 0xff) {
+                    glyph = &font->extGlyphs[slot];
+                    c = 0;
+                }
+            }
+            if (font->glyphs != NULL && font->firstChar <= c && c <= font->lastChar)
+                glyph = &font->glyphs[c - font->firstChar];
+            if (glyph != NULL) {
+                totalHeight += glyph->height;
+                count++;
+            }
+        }
+        i++;
+    } while (!done);
+
+    if (count != 0)
+        return totalHeight / count;
+    return 0;
+}
+
 // 0x00450280
 void DrawTextEntries()
 {

--- a/src/Swr/swrText.h
+++ b/src/Swr/swrText.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+#include "types.h"
+
 #define swrText_FormatPodName_ADDR (0x004208e0)
 
 #define swrText_ParseRacerTab_ADDR (0x00421120)
@@ -77,9 +79,9 @@ void swrText_SetFont(int fontIndex);
 // Bind the GL material for one of the font's glyph pages (page < font page count).
 void swrText_BindFontPage(void* font, int page);
 // Width of the first line of text (stops at a "~n" newline marker); honors "~" format codes.
-int swrText_GetStringWidth(char* text, void* font);
+int swrText_GetStringWidth(char* text, swrFont* font);
 // Average glyph height across the glyphs in the string.
-int swrText_GetStringHeight(char* text, void* font);
+int swrText_GetStringHeight(char* text, swrFont* font);
 // Look up one glyph's advance width + height for the font; writes -1 if the glyph is absent.
 void swrText_GetCharSize(char c, void* font, int* outWidth, int* outHeight);
 // Render a string: walks "~" format codes (0-9 = palette color, c = center, r = right-align,

--- a/src/types.h
+++ b/src/types.h
@@ -3081,6 +3081,33 @@ extern "C"
         char a;
     } swrTextEntryInfo; // sizeof(0x8)
 
+    // One bitmap glyph (0x10 bytes). Only the advance + height are consumed by the metric
+    // helpers (swrText_GetStringWidth / swrText_GetStringHeight / swrText_GetCharSize); the
+    // remaining bytes hold the UV / page metadata used by swrText_SetupGlyph.
+    typedef struct swrTextGlyph
+    {
+        short unk00; // 0x00
+        short advance; // 0x02 horizontal advance width, in pixels
+        char unk04[0xa]; // 0x04 UV / page metadata
+        short height; // 0x0e glyph height, in pixels
+    } swrTextGlyph; // sizeof(0x10)
+
+    // Bitmap font built by swrText_InitFonts (5 unique structs, stride 0x68, referenced through
+    // the 7-entry font table). firstChar..lastChar bound the main glyph table; character codes
+    // above 0x96 are remapped to the extended (accented) glyph table via the compose tables.
+    typedef struct swrFont
+    {
+        char unk00[4]; // 0x00
+        int pageCount; // 0x04 number of glyph-page materials
+        swrMaterial* pages[20]; // 0x08 glyph-page materials (pageCount used; converted in place by swrText_InitFonts)
+        char unk58[2]; // 0x58
+        uint8_t firstChar; // 0x5a first character code present in the glyph table
+        uint8_t lastChar; // 0x5b last character code present in the glyph table
+        swrTextGlyph* glyphs; // 0x5c main glyph table, indexed by (code - firstChar)
+        swrTextGlyph* extGlyphs; // 0x60 extended (accented) glyph table
+        char unk64[4]; // 0x64
+    } swrFont; // sizeof(0x68)
+
     typedef struct TrackInfo
     {
         INGAME_MODELID trackID;


### PR DESCRIPTION
Reverse-hook reimpls of the two glyph-metric helpers (`0x0042de30` / `0x0042df70`), verified faithful against the disassembly.

Brings along the types + globals they need:
- `swrFont` (0x68) + `swrTextGlyph` (0x10) structs in `types.h` — layout from `swrText_InitFonts` (5 font structs, stride 0x68) plus the field offsets already documented in `swrText.h` (advance @0x02, height @0x0e, firstChar @0x5a, lastChar @0x5b, glyph tables @0x5c / @0x60).
- Retypes both prototypes `void*` -> `swrFont*`.
- Names the two extended-char (code > 0x96) compose tables: `swrText_extCharComposePairs` (0x4bfa10) and `swrText_extCharComposeIndex` (0x4bfa59). The decompiler's `0x4bf9c2` base is back-computed and lands inside the last font struct; the real index data starts at `0x4bf9c2 + 0x97 = 0x4bfa59`, indexed `[code - 0x97]`, which folds back to `0x4bf9c2` in codegen.

Table byte values weren't directly readable in my setup, so the table sizes are inferred from the layout gap (noted in `data_symbols.syms`); the reimpl only depends on their addresses + indexing, which the disasm confirms.

Builds + links clean.