### PR TITLE
swrUI: reimplement the widget accessor family

### DIFF
--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -26,6 +26,52 @@ swrUI_unk* swrUI_GetUI1(void)
     return swrUI_unk_ptr;
 }
 
+// 0x004114b0
+void swrUI_DisableElement(swrUI_unk* ui)
+{
+    if (ui != NULL)
+        ui->flags = ui->flags | swrUI_DISABLED;
+}
+
+// 0x00411810
+swrUI_unk* swrUI_GetCurrentPage(void)
+{
+    return (swrUI_unk*)(&swrUI_pageStack)[swrUI_pageStackDepth];
+}
+
+// 0x00413090
+void swrUI_SetSpriteColor(swrUI_unk* ui, int slot, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+    if (ui != NULL && slot >= 0 && slot < 20) {
+        ui->ui_elements[slot].r = r;
+        ui->ui_elements[slot].g = g;
+        ui->ui_elements[slot].b = b;
+        ui->ui_elements[slot].a = a;
+    }
+}
+
+// 0x00413500
+void swrUI_SetMaxLength(swrUI_unk* ui, int maxLength)
+{
+    if (ui != NULL)
+        ui->max_length = maxLength;
+}
+
+// 0x004136f0
+swrUI_unk* swrUI_FindChildByText(swrUI_unk* list, char* text)
+{
+    swrUI_unk* child;
+
+    if (list != NULL && text != NULL && (child = list->next) != NULL) {
+        do {
+            if (child->str_allocated != NULL && strcmpi(child->str_allocated, text) == 0)
+                return child;
+            child = child->next2;
+        } while (child != NULL);
+    }
+    return NULL;
+}
+
 // 0x00413fa0
 int swrUI_GetValue(swrUI_unk* ui)
 {

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -882,6 +882,7 @@ typedef enum swrUISprite
 
 typedef enum swrUI_FLAG
 {
+    swrUI_DISABLED = 0x100, // grayed-out / non-interactive (swrUI_DisableElement)
     swrUI_SELECTED = 0x800,
     swrUI_VERTICAL = 0x10000,
     swrUI_LEFT_RIGHT_UNK = 0x20000, // LEFT_TO_RIGHT or RIGHT_TO_LEFT ?


### PR DESCRIPTION
Reverse-hook reimpls of five `swrUI_unk` accessors, verified against the disassembly:

- `swrUI_DisableElement` (0x004114b0) — sets the disabled flag
- `swrUI_GetCurrentPage` (0x00411810) — widget at the top of the page stack
- `swrUI_SetSpriteColor` (0x00413090) — per-slot sprite RGBA
- `swrUI_SetMaxLength` (0x00413500) — text-entry max input length
- `swrUI_FindChildByText` (0x004136f0) — case-insensitive child lookup by text

Also names the disabled bit `swrUI_DISABLED` (0x100) in the `swrUI_FLAG` enum (already documented on the `swrUI_unk.flags` field). All five already had `_ADDR`s + prototypes in `swrUI.h`, so this just fills in the bodies.

Builds + links clean.