### PR TITLE
fix: keep // 0xADDR hook annotations directly above their signature

### DIFF
--- a/.github/workflows/integrity_check.yml
+++ b/.github/workflows/integrity_check.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           python scripts\Ghidra\CheckHeaderDuplicates.py
           python scripts\Ghidra\check_data_symbols_dups.py
+          python scripts\check_hook_annotations.py
 
       - name: Download WinLibs GCC 13.2.0
         shell: pwsh

--- a/scripts/check_hook_annotations.py
+++ b/scripts/check_hook_annotations.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Check that every "// 0xADDR" reverse-hook (and "// 0xADDR HOOK" forward-hook) comment
+sits DIRECTLY above the function signature it annotates.
+
+GenerateHooks.py recognizes a hook annotation, then expects the VERY NEXT line to be the
+function signature. If a description comment (or a blank line) sits between the "// 0xADDR"
+line and the signature, GenerateHooks silently drops the function from the hook table -- the
+reimpl still compiles, but it is no longer registered / tracked as a hook.
+
+This catches that before it ships. Run from the repo root:
+    python scripts/check_hook_annotations.py
+Exits non-zero (and lists each offender as file:line) if any annotation is misplaced.
+"""
+import os
+import re
+import sys
+
+# Mirror GenerateHooks.py exactly: addresses are 8 hex digits, recognition needs trailing
+# whitespace (the line's newline counts), and the signature must be on the immediate next line.
+HOOK_RE = re.compile(r"//\s*(0x[0-9A-Fa-f]{8})\s+HOOK\s*")
+NO_HOOK_RE = re.compile(r"//\s*(0x[0-9A-Fa-f]{8})\s+")
+COMMENT_RE = re.compile(r"^\s*(//|/\*)")
+FUNCTION_RE = re.compile(r"(\w+)(?=\()")
+
+SRC = "src"
+
+
+def find_misplaced():
+    bad = []
+    for dir_path, _, file_names in os.walk(SRC):
+        if "generated" in dir_path.replace("\\", "/").split("/"):
+            continue
+        for name in sorted(file_names):
+            if not name.endswith(".c"):
+                continue
+            path = os.path.join(dir_path, name).replace("\\", "/")
+            # readlines() keeps the trailing newline, matching GenerateHooks' \s+ behavior.
+            lines = open(path, encoding="ascii", errors="replace").readlines()
+            for i, line in enumerate(lines):
+                if not (HOOK_RE.search(line) or NO_HOOK_RE.search(line)):
+                    continue
+                nxt = lines[i + 1] if i + 1 < len(lines) else "\n"
+                # GenerateHooks captures the function only if the next line is the signature.
+                if COMMENT_RE.search(nxt) or FUNCTION_RE.search(nxt) is None:
+                    sig = None
+                    for j in range(i + 1, min(i + 12, len(lines))):
+                        s = lines[j].strip()
+                        if s == "" or COMMENT_RE.search(lines[j]):
+                            continue
+                        m = FUNCTION_RE.search(lines[j])
+                        sig = m.group(1) if m else s[:48]
+                        break
+                    bad.append((path, i + 1, line.strip(), sig))
+    return bad
+
+
+def main():
+    bad = find_misplaced()
+    if not bad:
+        print("OK: every // 0xADDR annotation is directly above its signature.")
+        return 0
+    print("FAIL: %d hook annotation(s) NOT directly above a signature "
+          "(GenerateHooks.py would drop these functions):\n" % len(bad))
+    for path, lineno, annotation, sig in bad:
+        print("  %s:%d  %s  -> %s" % (path, lineno, annotation, sig or "(no signature found)"))
+    print("\nFix: move the description above the // 0xADDR line (or delete a stray/orphan "
+          "annotation) so the address sits on the line directly above the function.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Dss/sithMulti.c
+++ b/src/Dss/sithMulti.c
@@ -43,8 +43,6 @@ HRESULT sithMulti_CreatePlayerFromConfig(int param_1)
     return 0;
 }
 
-// 0x00404a20
-
 // 0x0041b8f0
 int sithMulti_RunCallback(tSithMessage* message)
 {

--- a/src/General/stdColor.c
+++ b/src/General/stdColor.c
@@ -3,8 +3,8 @@
 #include "types.h"
 #include "macros.h"
 
-// 0x0048d1c0
 // void __cdecl stdColor_ColorConvertOneRow(BYTE *pDestRow, ColorInfo *pDestInfo, BYTE *pSrcRow, ColorInfo *pSrcInfo, int width, int bColorKey, LPDDCOLORKEY pColorKey)
+// 0x0048d1c0
 void stdColor_ColorConvertOneRow(char* destRow, ColorInfo* destInfo, char* srcRow, ColorInfo* srcInfo, int width, int colorKey, void* PcolorKey)
 {
     HANG("TODO");

--- a/src/Primitives/rdModel.c
+++ b/src/Primitives/rdModel.c
@@ -47,8 +47,8 @@ void rdModel3_DrawHNode(rdModel3HNode* pNode)
     HANG("TODO");
 }
 
-// 0x0048f210
 // Prototype differ from both jkdf and Indy with 2 additional parameters
+// 0x0048f210
 void rdModel3_DrawMesh(rdModel3Mesh* pMesh, rdMatrix34* pOrient, rdMatrix34* pOrient2, int numVerts2)
 {
     HANG("TODO");

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -1582,11 +1582,11 @@ void swrModel_LoadPuppet(MODELID model, INGAME_MODELID index, int a3, float a4)
     HANG("TODO");
 }
 
-// 0x00441040
 // Is the plane-hit point inside triangle a,b,c? Tests that the three edge-cross products
 // (hitPoint->vertex x edge) agree in sign on their dominant axis. Quirk preserved from the asm:
 // the dominant component is read signed for X/Y but absolute for Z (the original abs's n.z in
 // place), so a Z-dominant axis always takes the ">= 0" branch.
+// 0x00441040
 int swrModel_PointInTriangle(float* origin, float* a, float* b, float* c,
                              rdVector3* edgeAB, rdVector3* edgeBC, rdVector3* edgeCA)
 {
@@ -1634,10 +1634,10 @@ int swrModel_PointInTriangle(float* origin, float* a, float* b, float* c,
     return 0;
 }
 
-// 0x00442470
 // Ray-plane intersection. plane = {normal.xyz, offset}; ray = {origin[3], dir[3], maxDist}.
 // Returns the hit distance t (and writes the point to outPoint), or -1 on a miss: ray parallel
 // to the plane (|normal.dir| < 1e-4), behind the origin, or past maxDist.
+// 0x00442470
 float IntersectRayPlane(float* plane, float* ray, rdVector3* outPoint)
 {
     float denom = plane[0] * ray[3] + plane[1] * ray[4] + plane[2] * ray[5];
@@ -1654,10 +1654,10 @@ float IntersectRayPlane(float* plane, float* ray, rdVector3* outPoint)
     return t;
 }
 
-// 0x00442550
 // Tests one triangle (plane + verts a,b,c) against the active ray; on a closer in-triangle hit,
 // records distance/point/node/normal into the swrModel_collision* result globals. Honours the
 // front/back accept flags (a back-face hit flips the recorded normal to oppose the ray).
+// 0x00442550
 void swrModel_CollideRayTriangle(float* plane, float* a, float* b, float* c, float* ray)
 {
     float facing = plane[0] * ray[3] + plane[1] * ray[4] + plane[2] * ray[5];
@@ -1718,9 +1718,9 @@ static int faceBBoxOverlapsRay(const rdVector3* verts, int count)
     return 1;
 }
 
-// 0x00442720
 // Per-face hook for indexed primitives: gathers the 3/4 verts via the index list, broad-phase
 // culls against the ray bbox, then ray-tests each triangle (a quad is split into two).
+// 0x00442720
 void swrModel_MeshCollisionFaceCallbackIndexed(swrModel_CollisionVertex* vertices, int16_t primitive_type, uint16_t* indices)
 {
     rdVector3 v[4];
@@ -1749,9 +1749,9 @@ void swrModel_MeshCollisionFaceCallbackIndexed(swrModel_CollisionVertex* vertice
     }
 }
 
-// 0x00442C30
 // Per-face hook for non-indexed primitives (verts are sequential). Same broad-phase cull + per-
 // triangle ray test as the indexed variant.
+// 0x00442C30
 void swrModel_MeshCollisionFaceCallback(swrModel_CollisionVertex* vertices, int16_t primitive_type)
 {
     rdVector3 v[4];

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -179,8 +179,8 @@ char* swrText_Translate(char* text)
     return text;
 }
 
-// 0x004214c0
 // Decode C-string escape sequences from src into dest; returns the decoded length.
+// 0x004214c0
 int swrText_UnescapeString(char* dest, char* src)
 {
     char* out = dest;

--- a/src/stdPlatform.c
+++ b/src/stdPlatform.c
@@ -36,8 +36,8 @@ void stdPlatform_Shutdown(void)
     stdPlatform_hostServices_initialized = 0;
 }
 
-// 0x00484780
 // Called as a macro using errorPrint, __FILE__, __LINE__, "msg", ...
+// 0x00484780
 int stdPlatform_DebugLog(void* log_function, char* compile_filepath, int line_nb, char* msg, ...)
 {
     HANG("TODO");


### PR DESCRIPTION
`GenerateHooks.py` registers a hook by matching the `// 0xADDR` comment and then reading the **very next line** as the signature. If a description comment (or a blank line) sits between the annotation and the signature, the function is silently dropped from the hook table — it still compiles, but it's no longer registered/tracked as a (reverse) hook.

Found **10 cases across 6 files** in that state. This moves each annotation back onto the line directly above its signature (description stays just above it), and removes one **stray duplicate** `// 0x00404a20` in `sithMulti.c`: that address already annotates `sithMulti_CreatePlayerFromConfig` a few lines above, and the stray copy sat above a blank line annotating nothing (`sithMulti_RunCallback` just below it stays correctly hooked via its own `0x0041b8f0`).

Comments only — the disassembly is unchanged. After the fix all affected functions register correctly (verified by regenerating `hook_generated.c`).

Affected: `stdPlatform_DebugLog`, `stdColor_ColorConvertOneRow`, `rdModel3_DrawMesh`, `swrModel_PointInTriangle`, `IntersectRayPlane`, `swrModel_CollideRayTriangle`, `swrModel_MeshCollisionFaceCallbackIndexed`, `swrModel_MeshCollisionFaceCallback`, `swrText_UnescapeString` (+ the `sithMulti.c` duplicate).

Also adds `scripts/check_hook_annotations.py` to catch regressions — mirrors the existing dup-check scripts and exits non-zero on any misplaced annotation, so it could be wired into `integrity-check`.

Builds + links clean.