### PR TITLE
rdCache: reimplement rdCache_Flush and rdCache_FlushAlpha

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -840,6 +840,9 @@ rdCache_frameNum 0x00deb0ec int
 rdCache_numUsedVertices 0x00deb0f0 int
 rdCache_numUsedTexVertices 0x00deb0f4 int
 rdCache_numUsedIntensities 0x00deb0f8 int
+rdCache_numUsedAlphaVertices 0x00deb0fc int
+rdCache_numUsedAlphaTexVertices 0x00deb100 int
+rdCache_numUsedAlphaIntensities 0x00deb104 int
 
 rdMaterial_pMaterialsLoader 0x00deb108 void*
 rdMaterial_pMaterialUnloader 0x00deb10c void*

--- a/src/Raster/rdCache.c
+++ b/src/Raster/rdCache.c
@@ -1,5 +1,8 @@
 #include "rdCache.h"
 
+#include "globals.h"
+#include "Platform/std3D.h"
+
 #include <macros.h>
 
 // 0x0048db40
@@ -41,13 +44,50 @@ RdCacheProcEntry* rdCache_GetAlphaProcEntry(void)
 // 0x0048dce0
 void rdCache_Flush(void)
 {
-    HANG("TODO");
+    if (rdCache_numProcFaces != 0) {
+        std3D_StartScene();
+        switch (rdroid_g_curGeometryMode) {
+        case RD_GEOMETRY_NONE:
+            break;
+        case RD_GEOMETRY_VERTEX:
+        case RD_GEOMETRY_WIREFRAME:
+            rdCache_SendWireframeFaceListToHardware(rdCache_numProcFaces, rdCache_aProcFaces);
+            break;
+        default:
+            rdCache_SendFaceListToHardware(rdCache_numProcFaces, rdCache_aProcFaces);
+        }
+        rdCache_drawnFaces += rdCache_numProcFaces;
+        rdCache_numProcFaces = 0;
+        rdCache_numUsedVertices = 0;
+        rdCache_numUsedTexVertices = 0;
+        rdCache_numUsedIntensities = 0;
+        std3D_EndScene();
+    }
 }
 
 // 0x0048dd80
 size_t rdCache_FlushAlpha(void)
 {
-    HANG("TODO");
+    size_t numFaces = rdCache_numAlphaProcFaces;
+
+    if (rdCache_numAlphaProcFaces != 0) {
+        switch (rdroid_g_curGeometryMode) {
+        case RD_GEOMETRY_NONE:
+            break;
+        case RD_GEOMETRY_VERTEX:
+        case RD_GEOMETRY_WIREFRAME:
+            rdCache_SendWireframeFaceListToHardware(rdCache_numAlphaProcFaces, rdCache_aAlphaProcFaces);
+            break;
+        default:
+            rdCache_SendFaceListToHardware(rdCache_numAlphaProcFaces, rdCache_aAlphaProcFaces);
+        }
+        rdCache_numAlphaProcFaces = 0;
+        rdCache_drawnFaces += numFaces;
+        rdCache_numUsedAlphaVertices = 0;
+        rdCache_numUsedAlphaTexVertices = 0;
+        rdCache_numUsedAlphaIntensities = 0;
+    }
+    return numFaces;
 }
 
 // OpenJKDF2 Modified


### PR DESCRIPTION
Reverse-hook reimpls of the cached proc-face flush pair (`0x0048dce0` / `0x0048dd80`), verified faithful against the disassembly.

Each flushes the cached faces to hardware via the wireframe/solid path chosen by `rdroid_g_curGeometryMode`, accumulates `rdCache_drawnFaces`, and resets the cache counters. `rdCache_Flush` brackets the draw with `std3D_StartScene`/`EndScene`; `rdCache_FlushAlpha` doesn't (matches the asm).

Names the three alpha-side used-element counters that the alpha flush resets — address-adjacent to the existing named non-alpha trio (`rdCache_numUsed{Vertices,TexVertices,Intensities}` at `0xdeb0f0/f4/f8`):

- `rdCache_numUsedAlphaVertices` `0x00deb0fc`
- `rdCache_numUsedAlphaTexVertices` `0x00deb100`
- `rdCache_numUsedAlphaIntensities` `0x00deb104`

Builds + links clean.