### PR TITLE
swrObj: reimplement swrObj_Free

### DIFF
--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -115,7 +115,13 @@ int requestPause()
 // 0x00450e30
 void swrObj_Free(swrObj* obj)
 {
-    HANG("TODO, easy");
+    int subEvents[8];
+
+    if (obj != NULL && (obj->flags & 0x100) == 0) {
+        subEvents[0] = 0x46726565; // 'Free'
+        swrEvent_DispatchSubEvents(obj, subEvents);
+        *((uint8_t*)&obj->flags + 1) |= 1; // mark freed (flags |= 0x100)
+    }
 }
 
 // 0x00451cd0


### PR DESCRIPTION
Reverse-hook reimpl of `swrObj_Free` (`0x00450e30`), verified faithful against the disassembly.

If the object isn't already marked freed (flags bit `0x100`), it dispatches a `'Free'` sub-event to the object and then sets the freed bit. The compiler folds the `& 0x100` check and the set into the same byte test/or on `flags+1` that the original uses.

Builds + links clean.