### PR TITLE
swrUI: reimplement the list/element accessor family

### DIFF
--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -26,6 +26,13 @@ swrUI_unk* swrUI_GetUI1(void)
     return swrUI_unk_ptr;
 }
 
+// 0x00411490
+void swrUI_EnableElement(swrUI_unk* ui)
+{
+    if (ui != NULL)
+        ui->flags = ui->flags & ~swrUI_DISABLED;
+}
+
 // 0x004114b0
 void swrUI_DisableElement(swrUI_unk* ui)
 {
@@ -70,6 +77,33 @@ swrUI_unk* swrUI_FindChildByText(swrUI_unk* list, char* text)
         } while (child != NULL);
     }
     return NULL;
+}
+
+// 0x004137a0
+swrUI_unk* swrUI_GetSelectedItem(swrUI_unk* list)
+{
+    swrUI_unk* item;
+
+    for (item = list->next; item != NULL; item = item->next2) {
+        if (item->item_flags & swrUI_ITEM_SELECTED)
+            return item;
+    }
+    return NULL;
+}
+
+// 0x004137d0
+int swrUI_CountSelectableItems(swrUI_unk* ui)
+{
+    swrUI_unk* item;
+    int count;
+
+    count = 0;
+    for (item = ui->next; item != NULL; item = item->next2) {
+        // widget_class low byte with bits 0x4|0x8 set marks a selectable list item
+        if (((uint8_t)item->widget_class & 0xc) == 0xc)
+            count++;
+    }
+    return count;
 }
 
 // 0x00413fa0

--- a/src/types.h
+++ b/src/types.h
@@ -1264,7 +1264,7 @@ extern "C"
         swrSprite_BBox bbox;
         unsigned int unk0_flag;
         char unk4f4[20]; // 0x4f4: value-text* @0x4f8, value @0x4fc, list first-visible idx @0x504
-        unsigned int item_flags; // 0x508 list-item state (selected 0x80000)
+        swrUI_ITEM_FLAG item_flags; // 0x508 list-item state (swrUI_ITEM_SELECTED 0x80000)
         char unk50c[40]; // 0x50c scroll layout: left/top/right/bottom @0x50c-0x518, sel text/idx @0x51c/0x520, row spacing @0x524
         int max_length; // 0x534 text-entry max input length (swrUI_SetMaxLength)
         char unk538[4232];

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -888,6 +888,11 @@ typedef enum swrUI_FLAG
     swrUI_LEFT_RIGHT_UNK = 0x20000, // LEFT_TO_RIGHT or RIGHT_TO_LEFT ?
 } swrUI_FLAG;
 
+typedef enum swrUI_ITEM_FLAG
+{
+    swrUI_ITEM_SELECTED = 0x80000, // list item is the current selection (swrUI_GetSelectedItem)
+} swrUI_ITEM_FLAG;
+
 typedef enum swrConfig_DEVICE
 {
     swrConfig_DEVICE_JOYSTICK = 0,


### PR DESCRIPTION
Continues the widget-accessor reimpl batch (#169). Three small leaves the dependency planner surfaced as high-leverage frontier functions:

- `swrUI_EnableElement` (0x411490) - inverse of the merged `swrUI_DisableElement`; clears `swrUI_DISABLED`.
- `swrUI_GetSelectedItem` (0x4137a0) - returns the first list child with the selected bit set.
- `swrUI_CountSelectableItems` (0x4137d0) - counts children whose `widget_class & 0xc == 0xc`.

All three disasm-verified against the originals. Note `GetSelectedItem`/`CountSelectableItems` deliberately have no list/ui null-check - the binary dereferences directly, so I matched that.

Also names the list-item selected bit as `swrUI_ITEM_SELECTED` (0x80000) in a new `swrUI_ITEM_FLAG` enum and types `swrUI_unk.item_flags` accordingly. `widget_class & 0xc` is left as a raw mask since `widget_class` is a class-id (already compared with `== 0xc` / `== 10` elsewhere), not a flag field.

Builds + links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)