### PR TITLE
swrSound: reimplement swrSound_UnloadSound and swrSound_RewindChannels

### DIFF
--- a/src/Swr/swrSound.c
+++ b/src/Swr/swrSound.c
@@ -956,6 +956,32 @@ void* swrSound_GetEntry(int index)
     return NULL;
 }
 
+// 0x00422d10
+int swrSound_UnloadSound(swrSoundDescriptor* entry)
+{
+    if ((entry->flags & swrSoundDescriptor_LOADED) == 0)
+        return 0;
+
+    if ((entry->flags & swrSoundDescriptor_STREAMED) == 0) {
+        swrSound_ReleaseSource(entry->source);
+        entry->source = NULL;
+        swrSound_loadedBytes -= entry->dataSize;
+        entry->source = NULL;
+        entry->flags = entry->flags & ~swrSoundDescriptor_LOADED;
+        return 1;
+    }
+
+    if (swrSoundStream_entry == entry) {
+        stdPlatform_hostServices_ptr->fileClose(swrSoundStream_file);
+        swrSoundStream_file = NULL;
+        swrSoundStream_bytesRemaining = 0;
+        swrSoundStream_entry = NULL;
+    }
+    entry->source = NULL;
+    entry->flags = entry->flags & ~swrSoundDescriptor_LOADED;
+    return 1;
+}
+
 // 0x0044a930
 float swrSound_GetSoundLengthSeconds(int soundId)
 {
@@ -1085,6 +1111,22 @@ void swrSound_ResetRequestedVoices(void)
 {
     for (int i = 0; i < 8; i++)
         swrSound_voicesRequested[i].volume = 0;
+}
+
+// Zeroes every requested voice's gain, then rewinds each active non-positional voice to its start
+// (runs only once the sound system is initialized).
+// 0x00449e50
+void swrSound_RewindChannels(void)
+{
+    swrSound* voice;
+
+    if (swrSound_unk_init != 0 && swrSound_Initted != 0) {
+        for (voice = &swrSound_voicesRequested[0]; voice < &swrSound_voicesRequested[8]; voice++) {
+            voice->volume = 0;
+            if (voice->unk08 == 0 && voice->activeSoundId >= 0)
+                swrSound_Rewind(voice->source);
+        }
+    }
 }
 
 // Sets the music fade state machine consumed by swrSound_UpdateMusic each frame:

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -142,7 +142,7 @@ float swrSound_GetSoundLengthSeconds(int soundId);
 int swrSound_LoadSound(void* entry);
 
 // Release a descriptor's A3D source and reclaim its bytes (keeps the descriptor).
-int swrSound_UnloadSound(void* entry);
+int swrSound_UnloadSound(swrSoundDescriptor* entry);
 
 // Unload every loaded sound's audio (keeps descriptors) and reset all channels.
 void swrSound_UnloadAll(void);

--- a/src/types.h
+++ b/src/types.h
@@ -1164,7 +1164,7 @@ extern "C"
     {
         char name[0x20]; // 0x00
         uint32_t index; // 0x20 slot index within the bank
-        uint32_t flags; // 0x24 bit2 = alias of an existing entry, bit3 = large/streamed
+        swrSoundDescriptor_FLAG flags; // 0x24 swrSoundDescriptor_LOADED / _ALIAS / _STREAMED
         uint32_t dataSize; // 0x28 wav data size in bytes
         uint32_t sampleRate; // 0x2c
         uint32_t bits; // 0x30 bits per sample (8 / 16)

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -3662,6 +3662,13 @@ typedef enum SoundPlayFlag
     SOUNDPLAY_PLAYTHIGNONCE = 0x800,
 } SoundPlayFlag;
 
+typedef enum swrSoundDescriptor_FLAG
+{
+    swrSoundDescriptor_LOADED = 0x1, // an A3D source is currently allocated for this entry
+    swrSoundDescriptor_ALIAS = 0x4, // entry aliases an existing bank entry
+    swrSoundDescriptor_STREAMED = 0x8, // large sound streamed from disk
+} swrSoundDescriptor_FLAG;
+
 typedef enum SithPuppetMoveMode
 {
     SITHPUPPET_MOVEMODE_NORMAL = 0,


### PR DESCRIPTION
Two swrSound leaves from the dependency planner's frontier.

- `swrSound_UnloadSound` (0x422d10) - release a bank descriptor's A3D source (or close the stream file, for a streamed entry) and reclaim its loaded bytes. Retypes the `void*` param to `swrSoundDescriptor*` (the bank entry it operates on, stride 0x4c) and names its flag bits via a new `swrSoundDescriptor_FLAG` enum (`LOADED` 0x1 / `ALIAS` 0x4 / `STREAMED` 0x8). The duplicate `source = NULL` store is in the original.
- `swrSound_RewindChannels` (0x449e50) - zero every requested voice's gain, then rewind each active non-positional voice. Iterates `swrSound_voicesRequested`, mirroring the existing `swrSound_ResetRequestedVoices`.

Both disasm-verified, zero new globals. Builds + links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)