### PR TITLE
rdProcEntry: reimplement rdProcEntry_SetCurrentColor

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1103,6 +1103,9 @@ swrUI_designHeightRecip 0x004acce0 double # sprite Y scale reciprocal, used in s
 swrText_designWidthRecip 0x004ac628 double # text X scale reciprocal, used in rdProcEntry_Add2DQuad2
 swrText_designHeightRecip 0x004ac630 double # text Y scale reciprocal, used in rdProcEntry_Add2DQuad2
 
+# color-byte to normalized-float scale (1/255), used by rdProcEntry_SetCurrentColor
+oneOver255f 0x004acca0 float
+
 # swrUI menu page stack (push/pop navigation) and focus
 swrUI_focusedElement 0x004d8794 swrUI_unk* # element currently receiving key events
 swrUI_pageStackDepth 0x004d87a4 int # top index into swrUI_pageStack

--- a/src/Swr/swrRender.c
+++ b/src/Swr/swrRender.c
@@ -181,7 +181,10 @@ void SetAlternativeLightColorsAndDirection2(int light_index, BOOL light_type2, s
 // 0x0044E290
 void rdProcEntry_SetCurrentColor(int a1, int a2, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-    HANG("TODO");
+    rdProcEntry_CurrentColor.x = (float) r * oneOver255f;
+    rdProcEntry_CurrentColor.y = (float) g * oneOver255f;
+    rdProcEntry_CurrentColor.z = (float) b * oneOver255f;
+    rdProcEntry_CurrentColor.w = (float) a * oneOver255f;
 }
 
 // 0x00483840


### PR DESCRIPTION
Sets the current vertex color used by the swrText / swrSprite draw paths.

Normalizes the four 8-bit RGBA args to floats into `rdProcEntry_CurrentColor` (x/y/z/w) via the 1/255 color scale at 0x4acca0, now named `oneOver255f` (the only reference is this function). The two leading `int` params are unused by the original (kept as `a1`/`a2`).

Disasm-verified, one new global. Builds + links.