### PR TITLE
swrMultiplayer: reimplement the player-name getters

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1254,7 +1254,7 @@ swrScene_animations 0x00e9edc0 swrModel_Animation*[300] # related to models
 stdPlatform_hostServices 0x00e9f280 HostServices
 
 rootPathName 0x00e9f300 char[80]
-unicode_unk 0x00e9f3c4 wchar_t[32]
+swrMultiplayer_playerNames 0x00e9f3c4 wchar_t[32] # base of the per-player unicode name table (see swrMultiplayer_GetPlayerName)
 
 sithPlayer_g_aPlayers 0x00e9f448 SithPlayer[1] # how many players ?
 

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -424,6 +424,9 @@ sithMessage_g_inputstream 0x004e9eb0 unsigned int
 
 time_buffer 0x004e9f20 char[256]
 
+# scratch buffer holding the most-recently-requested player name in ASCII (swrMultiplayer_GetPlayerNameAscii)
+swrMultiplayer_asciiNameBuffer 0x004ead88 char[32]
+
 multiplayer_isHost 0x004eb1c8 int
 
 swrMultiplayer_networkTick 0x004eb1e0 int

--- a/src/Swr/swrMultiplayer.c
+++ b/src/Swr/swrMultiplayer.c
@@ -3,6 +3,7 @@
 #include "globals.h"
 #include "macros.h"
 
+#include <General/stdString.h>
 #include <Platform/wuRegistry.h>
 #include <Win95/stdComm.h>
 #include <Dss/sithMulti.h>
@@ -11,6 +12,19 @@
 void swrMultiplayer_SetInMultiplayer(int bInMultiplayer)
 {
     multiplayer_in_mp = bInMultiplayer;
+}
+
+// 0x0041bcc0
+wchar_t* swrMultiplayer_GetPlayerName(int playerIndex)
+{
+    return unicode_unk + playerIndex * 0x58;
+}
+
+// 0x0041bce0
+char* swrMultiplayer_GetPlayerNameAscii(int playerIndex)
+{
+    stdString_WcharToChar(swrMultiplayer_asciiNameBuffer, unicode_unk + playerIndex * 0x58, 0x20);
+    return swrMultiplayer_asciiNameBuffer;
 }
 
 // 0x0041bd50

--- a/src/Swr/swrMultiplayer.c
+++ b/src/Swr/swrMultiplayer.c
@@ -8,6 +8,9 @@
 #include <Win95/stdComm.h>
 #include <Dss/sithMulti.h>
 
+// Stride in wchar_t between consecutive players in the swrMultiplayer_playerNames table.
+#define swrMultiplayer_PLAYER_NAME_STRIDE 0x58
+
 // 0x00412640
 void swrMultiplayer_SetInMultiplayer(int bInMultiplayer)
 {
@@ -17,13 +20,13 @@ void swrMultiplayer_SetInMultiplayer(int bInMultiplayer)
 // 0x0041bcc0
 wchar_t* swrMultiplayer_GetPlayerName(int playerIndex)
 {
-    return unicode_unk + playerIndex * 0x58;
+    return swrMultiplayer_playerNames + playerIndex * swrMultiplayer_PLAYER_NAME_STRIDE;
 }
 
 // 0x0041bce0
 char* swrMultiplayer_GetPlayerNameAscii(int playerIndex)
 {
-    stdString_WcharToChar(swrMultiplayer_asciiNameBuffer, unicode_unk + playerIndex * 0x58, 0x20);
+    stdString_WcharToChar(swrMultiplayer_asciiNameBuffer, swrMultiplayer_playerNames + playerIndex * swrMultiplayer_PLAYER_NAME_STRIDE, 0x20);
     return swrMultiplayer_asciiNameBuffer;
 }
 

--- a/src/Swr/swrMultiplayer.h
+++ b/src/Swr/swrMultiplayer.h
@@ -293,7 +293,7 @@ int swrMultiplayer_BuildRaceSetupUI(void);     // window 0x186b8
 int swrMultiplayer_BuildRacerListUI(void);     // window 0x30d41
 
 // --- chat (text entry + send + receive) ---
-// wchar player-name pointer in the unicode name table (stride 0x58).
+// Pointer to a player's name in swrMultiplayer_playerNames (per-player stride swrMultiplayer_PLAYER_NAME_STRIDE).
 wchar_t* swrMultiplayer_GetPlayerName(int playerIndex);
 // ASCII copy of a player's name (wchar -> char).
 char* swrMultiplayer_GetPlayerNameAscii(int playerIndex);


### PR DESCRIPTION
Two leaves from the multiplayer roster.

- `swrMultiplayer_GetPlayerName` (0x41bcc0) - returns a pointer to a player's wide display name. Reuses the existing `unicode_unk` global (the roster name field), indexed by the 0xb0 per-player stride. Zero new globals.
- `swrMultiplayer_GetPlayerNameAscii` (0x41bce0) - converts that name to ASCII into a scratch buffer, now named `swrMultiplayer_asciiNameBuffer` (0x4ead88, char[32] matching the 0x20 convert limit).

Both disasm-verified (the `i * 0x58` wchar offset is the 0xb0 byte stride). Builds + links.

While mapping this I confirmed the SWR per-player slot layout (base 0xe9f3c0, stride 0xb0: name1 @ +0x04, name2 @ +0x44, flags @ +0x84 with bit0 = active, dpid @ +0x88). The existing `sithPlayer_g_aPlayers` symbol sits at +0x88 of that slot with the JK `SithPlayer` typedef, which is why its layout "doesn't fit" - happy to follow up with a proper SWR player struct if you'd like.