### PR TITLE
swrSprite: reimplement swrSprite_setCurrentSpriteColor

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1092,6 +1092,10 @@ rotation_unk 0x00e996cc rdVector3
 
 GameSettingFlags 0x00e996dc int
 
+# 1 when rdProcEntry's current color is already synced to currentSpriteColor; cleared by
+# swrSprite_setCurrentSpriteColor, re-set after swrText_DrawGlyph re-pushes the color
+swrSprite_colorApplied 0x00e99764 int
+
 swrSprite_array 0x00e9ba60 swrSprite[251]
 
 swrDisplay_screenWidth 0x00ec86c4 int # 2D UI framebuffer width, set in swrRender_InitScene

--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -454,7 +454,12 @@ void rdProcEntry_Add2DQuad2(short a1, short a2, short a3, short a4, short a5, sh
 // 0x0042D950
 uint8_t swrSprite_setCurrentSpriteColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-    HANG("TODO");
+    currentSpriteColor[0] = r;
+    currentSpriteColor[1] = g;
+    currentSpriteColor[2] = b;
+    currentSpriteColor[3] = a;
+    swrSprite_colorApplied = 0;
+    return a;
 }
 
 // 0x004321B0


### PR DESCRIPTION
Stores the four RGBA bytes into `currentSpriteColor` and clears the color-sync flag at 0x00e99764, now named `swrSprite_colorApplied`. The flag is 1 while `rdProcEntry`'s current color already matches `currentSpriteColor`; `swrText_DrawGlyph` checks it, re-pushes the color via `rdProcEntry_SetCurrentColor` when it's 0, and re-sets it. Returns the alpha byte (the original leaves it in AL).

Disasm-verified, one new global. Builds + links.