### PR TITLE
swrObjHang: reimplement the hangar-2 state setters

### DIFF
--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -21,15 +21,16 @@
 void swrObjHang_SetHangar2State(swrObjHang_STATE state)
 {
     if (g_objHang2 != NULL)
-    {
-        HANG("TODO, easy");
-    }
+        swrObjHang_SetMenuState(g_objHang2, state);
 }
 
 // 0x004336a0
 void swrObjHang_SetHangar2Splash(void)
 {
-    HANG("TODO, easy");
+    if (g_objHang2 == NULL)
+        swrObjHang_SetMenuState(NULL, swrObjHang_STATE_SPLASH);
+    else if (g_objHang2->menuScreen != swrObjHang_STATE_SPLASH)
+        swrObjHang_SetMenuState(g_objHang2, swrObjHang_STATE_SPLASH);
 }
 
 // 0x004336f0


### PR DESCRIPTION
Two of the `HANG("TODO, easy")` stubs.

- `swrObjHang_SetHangar2State` (0x4336d0) - forwards to `swrObjHang_SetMenuState(g_objHang2, state)` when the second hangar instance exists.
- `swrObjHang_SetHangar2Splash` (0x4336a0) - sets the splash screen on `g_objHang2` (or with a NULL instance), skipping the call when it's already on `swrObjHang_STATE_SPLASH`.

Disasm-verified, no new globals. Builds + links.