### PR TITLE
swrSprite: reimplement swrSprite_AssignTextureToId

### DIFF
--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -124,7 +124,7 @@ void swrSprite_AssignTextureToId(swrSpriteTexture* spriteTex, int id, int from_t
         }
         texItems = texItems + 1;
         texIsTGA = texIsTGA + 1;
-    } while ((int)texItems < 0x4d8110); // swrSpriteTexItems Array End
+    } while (texItems < swrSpriteTexItems + (sizeof(swrSpriteTexItems) / sizeof(swrSpriteTexItems[0])));
 }
 
 // 0x00417010
@@ -186,7 +186,7 @@ void swrSprite_FreeSprites(void)
         *texIsTGA = 0;
         texItems = texItems + 1;
         texIsTGA = texIsTGA + 1;
-    } while ((int)texItems < 0x4d8110); // swrSpriteTexItems Array End
+    } while (texItems < swrSpriteTexItems + (sizeof(swrSpriteTexItems) / sizeof(swrSpriteTexItems[0])));
 }
 
 // 0x00417150 TODO: Crashes on release, works fine on debug

--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -110,7 +110,21 @@ void swrSprite_ClearSprites(swrUI_unk* swrui_unk)
 // 0x00416fd0
 void swrSprite_AssignTextureToId(swrSpriteTexture* spriteTex, int id, int from_tga)
 {
-    HANG("TODO, easy");
+    swrSpriteTexItem* texItems;
+    int* texIsTGA;
+
+    texIsTGA = swrSpriteTexIsTGA;
+    texItems = swrSpriteTexItems;
+    do {
+        if (texItems->texture == NULL) {
+            texItems->texture = spriteTex;
+            texItems->id = id;
+            *texIsTGA = from_tga;
+            return;
+        }
+        texItems = texItems + 1;
+        texIsTGA = texIsTGA + 1;
+    } while ((int)texItems < 0x4d8110); // swrSpriteTexItems Array End
 }
 
 // 0x00417010


### PR DESCRIPTION
One of the `HANG("TODO, easy")` stubs.

`swrSprite_AssignTextureToId` (0x416fd0) finds the first free `swrSpriteTexItems` slot (`texture == NULL`) and records the texture, its sprite id, and the TGA-source flag in the parallel `swrSpriteTexIsTGA` array. Uses the same array walk (and `0x4d8110` end bound) as the existing `swrSprite_FreeSprites` in this file.

Disasm-verified, no new globals. Builds + links.