### PR TITLE
swrSprite: reimplement swrSprite_DisplayCursor

### DIFF
--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -6,6 +6,7 @@
 #include "swrUI.h"
 
 #include <Engine/rdMaterial.h>
+#include <Win95/stdConsole.h>
 
 extern swrSpriteTexture* FUN_00445b40();
 
@@ -35,7 +36,19 @@ void swrSprite_SetCursorVisibility(int visible)
 // 0x00408220
 void swrSprite_DisplayCursor(void)
 {
-    HANG("TODO, easy");
+    int x;
+    int y;
+
+    if (swrSprite_mouseVisible < 1) {
+        swrSprite_SetVisible(swrUISprite_d_cursor_rgb_0, 0);
+    } else if (stdConsole_GetCursorPos(&x, &y) != 0) {
+        swrSprite_SetPos(swrUISprite_d_cursor_rgb_0, x, y);
+        swrSprite_SetDim(swrUISprite_d_cursor_rgb_0, 1.0f, 1.0f);
+        swrSprite_SetColor(swrUISprite_d_cursor_rgb_0, 0xff, 0xff, 0xff, 0xff);
+        swrSprite_SetVisible(swrUISprite_d_cursor_rgb_0, 1);
+        swrSprite_SetFlag(swrUISprite_d_cursor_rgb_0, 0x800);
+        swrSprite_SetFlag(swrUISprite_d_cursor_rgb_0, 0x10000);
+    }
 }
 
 // 0x004114d0


### PR DESCRIPTION
The last of the `HANG("TODO, easy")` stubs.

`swrSprite_DisplayCursor` (0x408220) hides the cursor sprite (`swrUISprite_d_cursor_rgb_0`) while the mouse isn't visible; otherwise it moves the sprite to the current `stdConsole_GetCursorPos` position and shows it (unit size, opaque white, plus the two render flags).

The two `swrSprite_SetFlag` values (0x800 / 0x10000) are left as raw literals - they have no flag enum yet and the `swrSprite.flags` doc only guesses at their meaning ("Additive Blending ?", "Changes Idx ?"); this matches the existing raw `0x8000` usage in swrUI.c. Disasm-verified, no new globals. Builds + links.