### PR TITLE
Debug overlay: panel registry + Quick Race / Settings / Cheats

### DIFF
--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -1,0 +1,141 @@
+#include "debug_ui.h"
+#include "imgui_utils.h"
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cstdio>
+
+#include <windows.h>
+#include <imgui.h>
+
+// show_imgui (the F5 overlay toggle) and settings_ini_path() come from imgui_utils.h.
+
+#if !defined(NDEBUG)
+bool debug_ui_show_dev_panels = true;
+#else
+bool debug_ui_show_dev_panels = false;
+#endif
+
+static std::vector<DebugPanel *> g_panels;
+
+void debug_ui_register(DebugPanel *panel) {
+    g_panels.push_back(panel);
+}
+
+// Panel names and ini keys are ASCII literals we control, so a byte-wise widen
+// is enough to feed the wide GetPrivateProfile* API (matches the ini path type).
+static std::wstring widen(const char *s) {
+    std::wstring w;
+    for (; *s; s++)
+        w.push_back((wchar_t) (unsigned char) *s);
+    return w;
+}
+
+void debug_ui_load_settings() {
+    const wchar_t *ini = settings_ini_path();
+    debug_ui_show_dev_panels =
+        GetPrivateProfileIntW(L"debug_ui", L"show_dev_panels", debug_ui_show_dev_panels, ini);
+    for (DebugPanel *p: g_panels)
+        p->open = GetPrivateProfileIntW(L"debug_ui_panels", widen(p->name).c_str(), p->open, ini);
+}
+
+static void save_settings() {
+    const wchar_t *ini = settings_ini_path();
+    WritePrivateProfileStringW(L"debug_ui", L"show_dev_panels",
+                               debug_ui_show_dev_panels ? L"1" : L"0", ini);
+    for (DebugPanel *p: g_panels)
+        WritePrivateProfileStringW(L"debug_ui_panels", widen(p->name).c_str(),
+                                   p->open ? L"1" : L"0", ini);
+}
+
+static bool category_visible(const char *category) {
+    for (DebugPanel *p: g_panels)
+        if (std::strcmp(p->category, category) == 0 && (!p->dev_only || debug_ui_show_dev_panels))
+            return true;
+    return false;
+}
+
+// Persist open-state whenever it changes from any source -- a menu toggle, a
+// window's own [x] close button, or the View toggle. Comparing against last
+// frame's snapshot is simpler than threading a dirty flag through every path.
+static void save_if_state_changed() {
+    static int prev_dev = -1;
+    static std::vector<char> prev_open;
+
+    bool changed = (int) debug_ui_show_dev_panels != prev_dev || prev_open.size() != g_panels.size();
+    for (size_t i = 0; !changed && i < g_panels.size(); i++)
+        changed = prev_open[i] != (char) g_panels[i]->open;
+    if (!changed)
+        return;
+
+    prev_dev = debug_ui_show_dev_panels;
+    prev_open.resize(g_panels.size());
+    for (size_t i = 0; i < g_panels.size(); i++)
+        prev_open[i] = (char) g_panels[i]->open;
+    save_settings();
+}
+
+void debug_ui_render() {
+    // Toggled with F5
+    if (!show_imgui)
+        return;
+
+    if (ImGui::BeginMainMenuBar()) {
+        // One menu per category, in first-seen registration order.
+        for (size_t i = 0; i < g_panels.size(); i++) {
+            const char *category = g_panels[i]->category;
+
+            bool already_seen = false;
+            for (size_t j = 0; j < i; j++) {
+                if (std::strcmp(g_panels[j]->category, category) == 0) {
+                    already_seen = true;
+                    break;
+                }
+            }
+            if (already_seen || !category_visible(category))
+                continue;
+
+            if (ImGui::BeginMenu(category)) {
+                for (DebugPanel *p: g_panels) {
+                    if (std::strcmp(p->category, category) != 0)
+                        continue;
+                    if (p->dev_only && !debug_ui_show_dev_panels)
+                        continue;
+                    ImGui::MenuItem(p->name, nullptr, &p->open);
+                }
+                ImGui::EndMenu();
+            }
+        }
+
+        if (ImGui::BeginMenu("View")) {
+            ImGui::MenuItem("Developer panels", nullptr, &debug_ui_show_dev_panels);
+            ImGui::EndMenu();
+        }
+
+        // FPS readout, right-aligned in the bar (was the first line of the monolith).
+        char fps[64];
+        snprintf(fps, sizeof(fps), "%.0f FPS (%.2f ms)", ImGui::GetIO().Framerate,
+                 1000.0f / ImGui::GetIO().Framerate);
+        ImGui::SameLine(ImGui::GetWindowWidth() - ImGui::CalcTextSize(fps).x -
+                        ImGui::GetStyle().ItemSpacing.x * 2);
+        ImGui::TextUnformatted(fps);
+
+        ImGui::EndMainMenuBar();
+    }
+
+    for (DebugPanel *p: g_panels) {
+        if (!p->open)
+            continue;
+        if (p->dev_only && !debug_ui_show_dev_panels)
+            continue;
+
+        if (p->default_w > 0.0f)
+            ImGui::SetNextWindowSize(ImVec2(p->default_w, p->default_h), ImGuiCond_FirstUseEver);
+        if (ImGui::Begin(p->name, &p->open))
+            p->draw();
+        ImGui::End();
+    }
+
+    save_if_state_changed();
+}

--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -85,6 +85,7 @@ static void help_marker(const char *desc) {
 // in the shell rather than being registered from a delta file.
 static bool g_show_imgui_demo = false;
 static bool g_show_imgui_metrics = false;
+static bool g_show_log = false;// floating hook.log window (toggled from the footer)
 
 static void panel_overlay() {
     ImGui::TextUnformatted("Theme:");
@@ -125,6 +126,8 @@ void debug_ui_render() {
         ImGui::Text("%.0f FPS (%.2f ms)", ImGui::GetIO().Framerate,
                     1000.0f / ImGui::GetIO().Framerate);
         ImGui::SameLine();
+        ImGui::TextDisabled("| F5 to show / hide");
+        ImGui::SameLine();
         help_marker("F5 shows / hides this overlay.\n"
                     "Turn on 'Developer mode' (bottom) for the dev-only sections.\n"
                     "Type in the filter to find a section by name.");
@@ -162,22 +165,22 @@ void debug_ui_render() {
             if (already_seen)
                 continue;
 
-            // Skip the whole category if nothing under it is currently visible.
-            bool any_visible = false;
+            // Count the visible sections in this category.
+            int visible = 0;
             for (DebugPanel *p: g_panels) {
                 if (std::strcmp(p->category, category) != 0)
                     continue;
                 if (p->dev_only && !debug_ui_show_dev_panels)
                     continue;
-                if (filter.PassFilter(p->name)) {
-                    any_visible = true;
-                    break;
-                }
+                if (filter.PassFilter(p->name))
+                    visible++;
             }
-            if (!any_visible)
+            if (visible == 0)
                 continue;
 
-            ImGui::SeparatorText(category);
+            // A category header only earns its keep when it groups 2+ sections.
+            if (visible > 1)
+                ImGui::SeparatorText(category);
             for (DebugPanel *p: g_panels) {
                 if (std::strcmp(p->category, category) != 0)
                     continue;
@@ -204,15 +207,17 @@ void debug_ui_render() {
             }
         }
 
-        // Footer: F5 hint + the developer-mode toggle (kept at the bottom so the
+        // Footer: log-window toggle + developer mode (kept at the bottom so the
         // section list stays the focus).
         ImGui::Separator();
-        ImGui::TextDisabled("F5: show / hide debug overlay");
+        ImGui::Checkbox("Show log window", &g_show_log);
+        ImGui::SameLine();
         ImGui::Checkbox("Developer mode", &debug_ui_show_dev_panels);
     }
     ImGui::End();
 
-    // Optional ImGui-owned windows, drawn outside the shell window.
+    // Optional floating windows, drawn outside the shell window.
+    imgui_draw_log_window(&g_show_log);
     if (g_show_imgui_demo)
         ImGui::ShowDemoWindow(&g_show_imgui_demo);
     if (g_show_imgui_metrics)

--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <cfloat>
 
 #include <windows.h>
 #include <imgui.h>
@@ -48,16 +49,9 @@ static void save_settings() {
                                    p->open ? L"1" : L"0", ini);
 }
 
-static bool category_visible(const char *category) {
-    for (DebugPanel *p: g_panels)
-        if (std::strcmp(p->category, category) == 0 && (!p->dev_only || debug_ui_show_dev_panels))
-            return true;
-    return false;
-}
-
-// Persist open-state whenever it changes from any source -- a menu toggle, a
-// window's own [x] close button, or the View toggle. Comparing against last
-// frame's snapshot is simpler than threading a dirty flag through every path.
+// Persist open-state whenever it changes from any source -- a section toggle, an
+// expand/collapse-all, or the dev toggle. Comparing against last frame's snapshot
+// is simpler than threading a dirty flag through every path.
 static void save_if_state_changed() {
     static int prev_dev = -1;
     static std::vector<char> prev_open;
@@ -75,10 +69,56 @@ static void save_if_state_changed() {
     save_settings();
 }
 
+// A "(?)" label that shows a wrapped tooltip on hover (imgui_demo.cpp idiom).
+static void help_marker(const char *desc) {
+    ImGui::TextDisabled("(?)");
+    if (ImGui::BeginItemTooltip()) {
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+        ImGui::TextUnformatted(desc);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+}
+
+// Built-in shell section: ImGui-level conveniences (theme, opacity, the demo and
+// metrics windows). These are overlay chrome, not a game subsystem, so they live
+// in the shell rather than being registered from a delta file.
+static bool g_show_imgui_demo = false;
+static bool g_show_imgui_metrics = false;
+
+static void panel_overlay() {
+    ImGui::TextUnformatted("Theme:");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Dark"))
+        ImGui::StyleColorsDark();
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Light"))
+        ImGui::StyleColorsLight();
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Classic"))
+        ImGui::StyleColorsClassic();
+
+    ImGui::SliderFloat("Overlay opacity", &ImGui::GetStyle().Alpha, 0.3f, 1.0f, "%.2f");
+    ImGui::SliderFloat("UI font scale", &ImGui::GetIO().FontGlobalScale, 0.5f, 2.0f, "%.2f");
+
+    ImGui::Checkbox("Dear ImGui demo window", &g_show_imgui_demo);
+    ImGui::Checkbox("Dear ImGui metrics / debugger", &g_show_imgui_metrics);
+}
+
+static DebugPanel g_panel_overlay = {
+    .category = "Tools", .name = "Overlay", .draw = panel_overlay, .dev_only = true};
+
+void debug_ui_register_builtin_shell_panels() {
+    debug_ui_register(&g_panel_overlay);
+}
+
 void debug_ui_render() {
     // Toggled with F5
     if (!show_imgui)
         return;
+
+    static ImGuiTextFilter filter;
+    int force_open = -1;// set by the expand/collapse-all buttons; -1 = leave as-is
 
     ImGui::SetNextWindowSize(ImVec2(440, 680), ImGuiCond_FirstUseEver);
     if (ImGui::Begin("SWE1R Debug")) {
@@ -86,6 +126,28 @@ void debug_ui_render() {
                     1000.0f / ImGui::GetIO().Framerate);
         ImGui::SameLine();
         ImGui::Checkbox("Developer panels", &debug_ui_show_dev_panels);
+        ImGui::SameLine();
+        help_marker("F5 toggles this window.\n"
+                    "Enable 'Developer panels' for the dev-only sections.\n"
+                    "Type in the filter to find a section by name.");
+
+        // Rolling FPS sparkline (auto-scaled), most recent sample on the right.
+        static float fps_history[120] = {};
+        static int fps_cursor = 0;
+        fps_history[fps_cursor] = ImGui::GetIO().Framerate;
+        fps_cursor = (fps_cursor + 1) % IM_ARRAYSIZE(fps_history);
+        ImGui::PlotLines("##fps", fps_history, IM_ARRAYSIZE(fps_history), fps_cursor, nullptr, 0.0f,
+                         FLT_MAX, ImVec2(-FLT_MIN, 40));
+
+        filter.Draw("Filter", -160.0f);
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Expand all"))
+            force_open = 1;
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Collapse all"))
+            force_open = 0;
+
+        ImGui::Separator();
 
         // One labeled separator per category (first-seen registration order),
         // then a collapsing-header section per panel under it.
@@ -99,7 +161,22 @@ void debug_ui_render() {
                     break;
                 }
             }
-            if (already_seen || !category_visible(category))
+            if (already_seen)
+                continue;
+
+            // Skip the whole category if nothing under it is currently visible.
+            bool any_visible = false;
+            for (DebugPanel *p: g_panels) {
+                if (std::strcmp(p->category, category) != 0)
+                    continue;
+                if (p->dev_only && !debug_ui_show_dev_panels)
+                    continue;
+                if (filter.PassFilter(p->name)) {
+                    any_visible = true;
+                    break;
+                }
+            }
+            if (!any_visible)
                 continue;
 
             ImGui::SeparatorText(category);
@@ -108,10 +185,16 @@ void debug_ui_render() {
                     continue;
                 if (p->dev_only && !debug_ui_show_dev_panels)
                     continue;
+                if (!filter.PassFilter(p->name))
+                    continue;
 
-                // Seed the section's expanded state from the ini on first appearance,
-                // then mirror the live state back so the user's clicks persist.
-                ImGui::SetNextItemOpen(p->open, ImGuiCond_Once);
+                // Expand/collapse-all forces every section this frame; otherwise
+                // seed from the ini on first appearance and mirror the live state
+                // back so the user's clicks persist.
+                if (force_open != -1)
+                    ImGui::SetNextItemOpen(force_open == 1, ImGuiCond_Always);
+                else
+                    ImGui::SetNextItemOpen(p->open, ImGuiCond_Once);
                 p->open = ImGui::CollapsingHeader(p->name);
                 if (p->open) {
                     ImGui::PushID(p->name);
@@ -124,6 +207,12 @@ void debug_ui_render() {
         }
     }
     ImGui::End();
+
+    // Optional ImGui-owned windows, drawn outside the shell window.
+    if (g_show_imgui_demo)
+        ImGui::ShowDemoWindow(&g_show_imgui_demo);
+    if (g_show_imgui_metrics)
+        ImGui::ShowMetricsWindow(&g_show_imgui_metrics);
 
     save_if_state_changed();
 }

--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -125,10 +125,8 @@ void debug_ui_render() {
         ImGui::Text("%.0f FPS (%.2f ms)", ImGui::GetIO().Framerate,
                     1000.0f / ImGui::GetIO().Framerate);
         ImGui::SameLine();
-        ImGui::Checkbox("Developer panels", &debug_ui_show_dev_panels);
-        ImGui::SameLine();
-        help_marker("F5 toggles this window.\n"
-                    "Enable 'Developer panels' for the dev-only sections.\n"
+        help_marker("F5 shows / hides this overlay.\n"
+                    "Turn on 'Developer mode' (bottom) for the dev-only sections.\n"
                     "Type in the filter to find a section by name.");
 
         // Rolling FPS sparkline (auto-scaled), most recent sample on the right.
@@ -205,6 +203,12 @@ void debug_ui_render() {
                 }
             }
         }
+
+        // Footer: F5 hint + the developer-mode toggle (kept at the bottom so the
+        // section list stays the focus).
+        ImGui::Separator();
+        ImGui::TextDisabled("F5: show / hide debug overlay");
+        ImGui::Checkbox("Developer mode", &debug_ui_show_dev_panels);
     }
     ImGui::End();
 

--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 #include <string>
 #include <cstring>
-#include <cstdio>
 
 #include <windows.h>
 #include <imgui.h>
@@ -81,8 +80,15 @@ void debug_ui_render() {
     if (!show_imgui)
         return;
 
-    if (ImGui::BeginMainMenuBar()) {
-        // One menu per category, in first-seen registration order.
+    ImGui::SetNextWindowSize(ImVec2(440, 680), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("SWE1R Debug")) {
+        ImGui::Text("%.0f FPS (%.2f ms)", ImGui::GetIO().Framerate,
+                    1000.0f / ImGui::GetIO().Framerate);
+        ImGui::SameLine();
+        ImGui::Checkbox("Developer panels", &debug_ui_show_dev_panels);
+
+        // One labeled separator per category (first-seen registration order),
+        // then a collapsing-header section per panel under it.
         for (size_t i = 0; i < g_panels.size(); i++) {
             const char *category = g_panels[i]->category;
 
@@ -96,46 +102,28 @@ void debug_ui_render() {
             if (already_seen || !category_visible(category))
                 continue;
 
-            if (ImGui::BeginMenu(category)) {
-                for (DebugPanel *p: g_panels) {
-                    if (std::strcmp(p->category, category) != 0)
-                        continue;
-                    if (p->dev_only && !debug_ui_show_dev_panels)
-                        continue;
-                    ImGui::MenuItem(p->name, nullptr, &p->open);
+            ImGui::SeparatorText(category);
+            for (DebugPanel *p: g_panels) {
+                if (std::strcmp(p->category, category) != 0)
+                    continue;
+                if (p->dev_only && !debug_ui_show_dev_panels)
+                    continue;
+
+                // Seed the section's expanded state from the ini on first appearance,
+                // then mirror the live state back so the user's clicks persist.
+                ImGui::SetNextItemOpen(p->open, ImGuiCond_Once);
+                p->open = ImGui::CollapsingHeader(p->name);
+                if (p->open) {
+                    ImGui::PushID(p->name);
+                    ImGui::Indent();
+                    p->draw();
+                    ImGui::Unindent();
+                    ImGui::PopID();
                 }
-                ImGui::EndMenu();
             }
         }
-
-        if (ImGui::BeginMenu("View")) {
-            ImGui::MenuItem("Developer panels", nullptr, &debug_ui_show_dev_panels);
-            ImGui::EndMenu();
-        }
-
-        // FPS readout, right-aligned in the bar (was the first line of the monolith).
-        char fps[64];
-        snprintf(fps, sizeof(fps), "%.0f FPS (%.2f ms)", ImGui::GetIO().Framerate,
-                 1000.0f / ImGui::GetIO().Framerate);
-        ImGui::SameLine(ImGui::GetWindowWidth() - ImGui::CalcTextSize(fps).x -
-                        ImGui::GetStyle().ItemSpacing.x * 2);
-        ImGui::TextUnformatted(fps);
-
-        ImGui::EndMainMenuBar();
     }
-
-    for (DebugPanel *p: g_panels) {
-        if (!p->open)
-            continue;
-        if (p->dev_only && !debug_ui_show_dev_panels)
-            continue;
-
-        if (p->default_w > 0.0f)
-            ImGui::SetNextWindowSize(ImVec2(p->default_w, p->default_h), ImGuiCond_FirstUseEver);
-        if (ImGui::Begin(p->name, &p->open))
-            p->draw();
-        ImGui::End();
-    }
+    ImGui::End();
 
     save_if_state_changed();
 }

--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -11,11 +11,7 @@
 
 // show_imgui (the F5 overlay toggle) and settings_ini_path() come from imgui_utils.h.
 
-#if !defined(NDEBUG)
-bool debug_ui_show_dev_panels = true;
-#else
 bool debug_ui_show_dev_panels = false;
-#endif
 
 static std::vector<DebugPanel *> g_panels;
 
@@ -140,7 +136,14 @@ void debug_ui_render() {
         ImGui::PlotLines("##fps", fps_history, IM_ARRAYSIZE(fps_history), fps_cursor, nullptr, 0.0f,
                          FLT_MAX, ImVec2(-FLT_MIN, 40));
 
-        filter.Draw("Filter", -160.0f);
+        // Reserve room for the "Filter" label and the two right-hand buttons so
+        // they stay inside the window (a fixed reserve clipped them on the right).
+        const ImGuiStyle &style = ImGui::GetStyle();
+        const float reserve = ImGui::CalcTextSize("Filter").x + style.ItemInnerSpacing.x +
+                              ImGui::CalcTextSize("Expand all").x + style.FramePadding.x * 2.0f +
+                              ImGui::CalcTextSize("Collapse all").x + style.FramePadding.x * 2.0f +
+                              style.ItemSpacing.x * 2.0f;
+        filter.Draw("Filter", -reserve);
         ImGui::SameLine();
         if (ImGui::SmallButton("Expand all"))
             force_open = 1;

--- a/dinput_hook/debug_ui.h
+++ b/dinput_hook/debug_ui.h
@@ -18,16 +18,20 @@ struct DebugPanel {
 };
 
 // Whether developer-only panels are shown. Defaults on in debug builds, off in
-// release so players never see dev clutter. Toggled from the View menu.
+// release so players never see dev clutter. Toggled from the overlay checkbox.
 extern bool debug_ui_show_dev_panels;
 
 // Register a panel. Call once per panel at startup (registration order sets the
-// menu order). The pointer must outlive the program (use a static DebugPanel).
+// section order). The pointer must outlive the program (use a static DebugPanel).
 void debug_ui_register(DebugPanel *panel);
 
-// Restore panel open-state + the developer-panels toggle from SW_RACER_RE.ini.
+// Register the shell's own built-in sections (overlay/ImGui tools). Call once at
+// startup alongside the subsystem panels, before debug_ui_load_settings().
+void debug_ui_register_builtin_shell_panels();
+
+// Restore section expand-state + the developer-panels toggle from SW_RACER_RE.ini.
 // Call once after all panels are registered.
 void debug_ui_load_settings();
 
-// Draw the menu bar and every open panel. Called once per frame from imgui_Update.
+// Draw the overlay window and its sections. Called once per frame from imgui_Update.
 void debug_ui_render();

--- a/dinput_hook/debug_ui.h
+++ b/dinput_hook/debug_ui.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// Panel-registry shell for the ImGui debug/overlay UI. Each subsystem registers
+// its own panel (from its own delta file) instead of splicing into one giant
+// function; the shell draws a menu bar that groups panels by category and opens
+// each one in its own window. This is the fix for the merge-conflict generator
+// that the old monolithic opengl_render_imgui() had become. See DEBUG_UI_ROADMAP.md.
+
+// One registrable overlay panel. The body draws plain ImGui widgets; the shell
+// wraps it in a Begin/End window and persists its open-state. Keep instances
+// static (the registry stores the pointer, not a copy).
+struct DebugPanel {
+    const char *category;// menu grouping, e.g. "Render", "Inspect", "Tools"
+    const char *name;    // window title + menu item (must be unique)
+    void (*draw)();      // panel body: ImGui widgets, no Begin/End of its own
+    bool dev_only;       // hidden from players (see developer-panels toggle)
+    bool open;           // current visibility; restored from the ini at startup
+    float default_w;     // first-use window width  (0 = let ImGui decide)
+    float default_h;     // first-use window height (0 = let ImGui decide)
+};
+
+// Whether developer-only panels are shown. Defaults on in debug builds, off in
+// release so players never see dev clutter. Toggled from the View menu.
+extern bool debug_ui_show_dev_panels;
+
+// Register a panel. Call once per panel at startup (registration order sets the
+// menu order). The pointer must outlive the program (use a static DebugPanel).
+void debug_ui_register(DebugPanel *panel);
+
+// Restore panel open-state + the developer-panels toggle from SW_RACER_RE.ini.
+// Call once after all panels are registered.
+void debug_ui_load_settings();
+
+// Draw the menu bar and every open panel. Called once per frame from imgui_Update.
+void debug_ui_render();

--- a/dinput_hook/debug_ui.h
+++ b/dinput_hook/debug_ui.h
@@ -2,21 +2,19 @@
 
 // Panel-registry shell for the ImGui debug/overlay UI. Each subsystem registers
 // its own panel (from its own delta file) instead of splicing into one giant
-// function; the shell draws a menu bar that groups panels by category and opens
-// each one in its own window. This is the fix for the merge-conflict generator
-// that the old monolithic opengl_render_imgui() had become. See DEBUG_UI_ROADMAP.md.
+// function; the shell draws a single window of collapsing-header sections,
+// grouped by category. This is the fix for the merge-conflict generator that the
+// old monolithic opengl_render_imgui() had become. See DEBUG_UI_ROADMAP.md.
 
-// One registrable overlay panel. The body draws plain ImGui widgets; the shell
-// wraps it in a Begin/End window and persists its open-state. Keep instances
-// static (the registry stores the pointer, not a copy).
+// One registrable overlay panel, rendered as a collapsing-header section. The
+// body draws plain ImGui widgets; the shell owns the surrounding window. Keep
+// instances static (the registry stores the pointer, not a copy).
 struct DebugPanel {
-    const char *category;// menu grouping, e.g. "Render", "Inspect", "Tools"
-    const char *name;    // window title + menu item (must be unique)
-    void (*draw)();      // panel body: ImGui widgets, no Begin/End of its own
+    const char *category;// section grouping, e.g. "Render", "Inspect", "Tools"
+    const char *name;    // collapsing-header label (must be unique)
+    void (*draw)();      // section body: ImGui widgets
     bool dev_only;       // hidden from players (see developer-panels toggle)
-    bool open;           // current visibility; restored from the ini at startup
-    float default_w;     // first-use window width  (0 = let ImGui decide)
-    float default_h;     // first-use window height (0 = let ImGui decide)
+    bool open;           // section expanded; seeded from the ini, then user-driven
 };
 
 // Whether developer-only panels are shown. Defaults on in debug builds, off in

--- a/dinput_hook/game_deltas/Window_delta.c
+++ b/dinput_hook/game_deltas/Window_delta.c
@@ -197,7 +197,7 @@ static void key_callback(GLFWwindow *window, int key, int scancode, int action, 
         // the debug menu dropdown.
         set_window_mode(g_window_mode == WINDOW_MODE_FULLSCREEN ? WINDOW_MODE_WINDOWED
                                                                 : WINDOW_MODE_FULLSCREEN);
-        save_window_mode_setting();
+        persist_settings_ini();
         return;
     }
 
@@ -208,9 +208,10 @@ static void key_callback(GLFWwindow *window, int key, int scancode, int action, 
     if (dik_key == 0)
         return;
 
-    // Toggle imgui with F3
+    // Toggle imgui with F5
     if (key == GLFW_KEY_F5 && action == GLFW_PRESS) {
         show_imgui ^= 1;
+        persist_settings_ini();
     }
 
     const bool pressed = action != GLFW_RELEASE;

--- a/dinput_hook/game_deltas/window_mode.h
+++ b/dinput_hook/game_deltas/window_mode.h
@@ -15,11 +15,12 @@ extern "C" {
 extern int g_window_mode;
 
 // Applies `mode` to the GLFW window and updates g_window_mode. Safe to call once the
-// GLFW window/context exists. Does not persist the choice (see save_window_mode_setting).
+// GLFW window/context exists. Does not persist the choice (see persist_settings_ini).
 void set_window_mode(int mode);
 
-// Persists the current window mode to SW_RACER_RE.ini. Implemented in imgui_utils.cpp.
-void save_window_mode_setting(void);
+// Persists the whole settings block to SW_RACER_RE.ini. C-callable from the window
+// key callbacks (window mode, F5 overlay toggle). Implemented in imgui_utils.cpp.
+void persist_settings_ini(void);
 
 #ifdef __cplusplus
 }

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include <Swr/swrSound.h>
 #include <Swr/swrObj.h>
 #include <Swr/swrEvent.h>
+#include <Swr/swrText.h>
 }
 
 extern rdVector3 debugCameraPos;
@@ -842,6 +843,31 @@ static void panel_pod_readout() {
     ImGui::Text("Respawn invuln: %.2f", pod->respawnInvincibilityTimer);
 }
 
+// The game's name strings carry swrText render codes ("~~", "~c", "~f5", ...)
+// that its own text renderer consumes; strip them so the names read cleanly in
+// plain ImGui widgets. (swrText_Translate already removes the /SCREENTEXT_id/ key.)
+static std::string strip_text_codes(const char *s) {
+    std::string out;
+    if (s == nullptr)
+        return out;
+    for (const char *p = s; *p;) {
+        if (*p == '~') {
+            p++;
+            if (*p == '~') {
+                p++;
+                continue;
+            }
+            if (*p)
+                p++;// the code letter (c / s / r / f ...)
+            while (*p >= '0' && *p <= '9')
+                p++;// optional digits, e.g. ~f5
+            continue;
+        }
+        out.push_back(*p++);
+    }
+    return out;
+}
+
 // Player: quick race-setup knobs. AI count is a global consumed at the next race
 // start; the rest live on the hangar state and only apply in the front-end menu.
 static void panel_race() {
@@ -853,31 +879,46 @@ static void panel_race() {
     if (hang != nullptr) {
         hang->num_players = (char) nb_AI_racers;
 
-        const char *track_name = (hang->track_index >= 0 && hang->track_index < (int) trackCount)
-                                     ? swrUI_GetTrackNameFromId_delta(hang->track_index)
-                                     : "(none)";
-        if (ImGui::BeginCombo("Track", track_name)) {
-            for (int i = 0; i < (int) trackCount; i++) {
-                ImGui::PushID(i);
-                bool sel = hang->track_index == i;
-                if (ImGui::Selectable(swrUI_GetTrackNameFromId_delta(i), sel))
-                    hang->track_index = (char) i;
-                if (sel)
-                    ImGui::SetItemDefaultFocus();
-                ImGui::PopID();
-            }
+        // Track combo: enumerate the real tracks only -- the 4 vanilla circuits'
+        // populated slots (via g_aTrackIDs / g_aTracksInCircuits) plus any custom
+        // tracks -- so the empty planet slots don't show as phantom entries.
+        auto track_item = [&](int tid) {
+            std::string label = strip_text_codes(swrUI_GetTrackNameFromId_delta(tid));
+            ImGui::PushID(tid);
+            bool sel = hang->track_index == tid;
+            if (ImGui::Selectable(label.c_str(), sel))
+                hang->track_index = (char) tid;
+            if (sel)
+                ImGui::SetItemDefaultFocus();
+            ImGui::PopID();
+        };
+        std::string track_preview =
+            (hang->track_index >= 0 && hang->track_index < (int) trackCount)
+                ? strip_text_codes(swrUI_GetTrackNameFromId_delta(hang->track_index))
+                : "(none)";
+        if (ImGui::BeginCombo("Track", track_preview.c_str())) {
+            for (int c = 0; c < 4; c++)
+                for (int s = 0; s < g_aTracksInCircuits[c]; s++)
+                    track_item(g_aTrackIDs[c * DEFAULT_NB_CIRCUIT + s]);
+            for (int tid = DEFAULT_NB_TRACKS; tid < (int) trackCount; tid++)
+                track_item(tid);
             ImGui::EndCombo();
         }
 
-        int vp = hang->vehiclePlayer;
-        const char *pod_name =
-            (vp >= 0 && vp < 23 && swrRacer_PodData[vp].name) ? swrRacer_PodData[vp].name : "?";
-        if (ImGui::BeginCombo("Pod", pod_name)) {
+        // Pod combo: full pilot names via the game's formatter (translated +
+        // name/lastname combined), ~ codes stripped for display.
+        char pod_buf[128] = {0};
+        if (hang->vehiclePlayer >= 0 && hang->vehiclePlayer < 23)
+            swrText_FormatPodName(hang->vehiclePlayer, pod_buf, sizeof(pod_buf));
+        std::string pod_preview = strip_text_codes(pod_buf);
+        if (ImGui::BeginCombo("Pod", pod_preview.c_str())) {
             for (int i = 0; i < 23; i++) {
+                char buf[128] = {0};
+                swrText_FormatPodName(i, buf, sizeof(buf));
+                std::string label = strip_text_codes(buf);
                 ImGui::PushID(i);
-                const char *n = swrRacer_PodData[i].name ? swrRacer_PodData[i].name : "?";
                 bool sel = hang->vehiclePlayer == i;
-                if (ImGui::Selectable(n, sel))
+                if (ImGui::Selectable(label.c_str(), sel))
                     hang->vehiclePlayer = (char) i;
                 if (sel)
                     ImGui::SetItemDefaultFocus();

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -311,6 +311,7 @@ void imgui_Update() {
 
         read_settings_ini();
         register_builtin_debug_panels();
+        debug_ui_register_builtin_shell_panels();
         debug_ui_load_settings();
     }
 
@@ -780,6 +781,39 @@ static void panel_pod_transforms() {
     }
 }
 
+// Dev: read-only live telemetry for the local player's pod (swrRace fields).
+static void panel_pod_readout() {
+    swrRace *pod = currentPlayer_Test;
+    if (pod == nullptr) {
+        ImGui::TextUnformatted("No local pod (currentPlayer_Test is null).");
+        return;
+    }
+
+    ImGui::Text("Speed:         %.2f  (x%.2f applied)", pod->speedValue, pod->multiplayerStats);
+    ImGui::Text("Thrust:        %.2f", pod->thrust);
+
+    const char *boost_state = pod->boostIndicatorStatus == 0   ? "not ready"
+                              : pod->boostIndicatorStatus == 1 ? "charging"
+                              : pod->boostIndicatorStatus == 2 ? "ready"
+                                                               : "?";
+    ImGui::Text("Boost:         %.2f  (%s, charge %.2f)", pod->boostValue, boost_state,
+                pod->boostChargeTimer);
+
+    ImGui::Text("Engine temp:   %.2f", pod->engineTemp);
+    ImGui::Text("Total damage:  %.2f", pod->totalDamage);
+    ImGui::Text("Engine health: %.0f %.0f %.0f / %.0f %.0f %.0f", pod->engineHealth[0],
+                pod->engineHealth[1], pod->engineHealth[2], pod->engineHealth[3],
+                pod->engineHealth[4], pod->engineHealth[5]);
+
+    ImGui::Separator();
+    ImGui::Text("Tilt %.2f   Pitch %.2f   Turn %.2f", pod->tiltAngle, pod->pitch, pod->turnRate);
+    ImGui::Text("Position: %.1f %.1f %.1f", pod->position.x, pod->position.y, pod->position.z);
+    ImGui::Text("Velocity: %.2f %.2f %.2f", pod->velocityDir.x, pod->velocityDir.y,
+                pod->velocityDir.z);
+    ImGui::Text("Lap progress:  %.2f / %.2f", pod->lapComp, pod->lapCompMax);
+    ImGui::Text("Respawn invuln: %.2f", pod->respawnInvincibilityTimer);
+}
+
 // Dev: live tail of the mod's hook.log (pumped only while this section is open).
 static void panel_hook_log() {
     pump_hook_log();
@@ -800,6 +834,8 @@ static DebugPanel g_panel_textures = {
 static DebugPanel g_panel_pod_transforms = {
     .category = "Inspect", .name = "Pod Transforms", .draw = panel_pod_transforms,
     .dev_only = true};
+static DebugPanel g_panel_pod_readout = {
+    .category = "Inspect", .name = "Pod Readout", .draw = panel_pod_readout, .dev_only = true};
 static DebugPanel g_panel_hook_log = {
     .category = "Tools", .name = "Hook Log", .draw = panel_hook_log, .dev_only = true};
 
@@ -810,5 +846,6 @@ static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_scene_inspector);
     debug_ui_register(&g_panel_textures);
     debug_ui_register(&g_panel_pod_transforms);
+    debug_ui_register(&g_panel_pod_readout);
     debug_ui_register(&g_panel_hook_log);
 }

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -19,6 +19,7 @@
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
 #include "game_deltas/window_mode.h"
+#include "game_deltas/tracks_delta.h"
 
 extern "C" {
 #include <globals.h>
@@ -851,6 +852,39 @@ static void panel_race() {
     swrObjHang *hang = (swrObjHang *) swrEvent_GetItem('Hang', 0);
     if (hang != nullptr) {
         hang->num_players = (char) nb_AI_racers;
+
+        const char *track_name = (hang->track_index >= 0 && hang->track_index < (int) trackCount)
+                                     ? swrUI_GetTrackNameFromId_delta(hang->track_index)
+                                     : "(none)";
+        if (ImGui::BeginCombo("Track", track_name)) {
+            for (int i = 0; i < (int) trackCount; i++) {
+                ImGui::PushID(i);
+                bool sel = hang->track_index == i;
+                if (ImGui::Selectable(swrUI_GetTrackNameFromId_delta(i), sel))
+                    hang->track_index = (char) i;
+                if (sel)
+                    ImGui::SetItemDefaultFocus();
+                ImGui::PopID();
+            }
+            ImGui::EndCombo();
+        }
+
+        int vp = hang->vehiclePlayer;
+        const char *pod_name =
+            (vp >= 0 && vp < 23 && swrRacer_PodData[vp].name) ? swrRacer_PodData[vp].name : "?";
+        if (ImGui::BeginCombo("Pod", pod_name)) {
+            for (int i = 0; i < 23; i++) {
+                ImGui::PushID(i);
+                const char *n = swrRacer_PodData[i].name ? swrRacer_PodData[i].name : "?";
+                bool sel = hang->vehiclePlayer == i;
+                if (ImGui::Selectable(n, sel))
+                    hang->vehiclePlayer = (char) i;
+                if (sel)
+                    ImGui::SetItemDefaultFocus();
+                ImGui::PopID();
+            }
+            ImGui::EndCombo();
+        }
 
         int laps = hang->numLaps;
         if (ImGui::SliderInt("Laps", &laps, 1, 125))

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -1,4 +1,5 @@
 #include "imgui_utils.h"
+#include "debug_ui.h"
 #include "n64_shader.h"
 
 #include <string>
@@ -35,6 +36,10 @@ extern float cameraSpeed;
 // Defined in main.cpp: writes/reverts the AI full-LOD .text patches (gated by ai_full_lod).
 extern "C" void set_ai_full_lod(bool on);
 
+// Registers the built-in overlay panels with the debug-ui shell. Defined at the
+// bottom of this file alongside the panel bodies it splits opengl_render_imgui into.
+static void register_builtin_debug_panels();
+
 extern uint8_t replacedTries[323];// 323 MODELIDs
 extern std::map<int, ReplacementModel> replacement_map;
 extern const char *modelid_cstr[];
@@ -47,7 +52,6 @@ char show_imgui = 0;
 #endif
 bool imgui_initialized = false;
 ImGuiState imgui_state = {
-    .show_debug = false,
     .draw_test_scene = false,
     .draw_meshes = true,
     .draw_renderList = true,
@@ -113,6 +117,10 @@ void save_settings_ini() {
 // Called from the (C) window key callbacks so Alt+Enter persists the chosen mode too.
 extern "C" void save_window_mode_setting(void) {
     save_settings_ini();
+}
+
+const wchar_t *settings_ini_path() {
+    return ini_path.c_str();
 }
 
 const char *swrModel_NodeTypeStr(uint32_t nodeType) {
@@ -302,6 +310,8 @@ void imgui_Update() {
         fprintf(hook_log, "[OGL_imgui_Update] imgui initialized.\n");
 
         read_settings_ini();
+        register_builtin_debug_panels();
+        debug_ui_load_settings();
     }
 
     if (imgui_initialized) {
@@ -309,7 +319,7 @@ void imgui_Update() {
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
 
-        opengl_render_imgui();
+        debug_ui_render();
 
         ImGui::EndFrame();
         ImGui::Render();
@@ -400,13 +410,9 @@ struct DebugLog {
         }
     }
 
-    void Draw(const char *title, bool *p_open) {
-        ImGui::SetNextWindowSize(ImVec2(700, 400), ImGuiCond_FirstUseEver);
-        if (!ImGui::Begin(title, p_open)) {
-            ImGui::End();
-            return;
-        }
-
+    // Render the toolbar + scrolling region into the current window. The debug-ui
+    // shell owns the Begin/End and the window's default size (see panel_hook_log).
+    void DrawBody() {
         if (ImGui::BeginPopup("Options")) {
             ImGui::Checkbox("Auto-scroll", &AutoScroll);
             ImGui::EndPopup();
@@ -465,7 +471,6 @@ struct DebugLog {
                 ImGui::SetScrollHereY(1.0f);
         }
         ImGui::EndChild();
-        ImGui::End();
     }
 };
 
@@ -492,200 +497,61 @@ static void pump_hook_log() {
     g_debug_log.Trim();
 }
 
-void opengl_render_imgui() {
-    // Toggled with F5
-    if (!show_imgui)
-        return;
+// --- Panels (the old opengl_render_imgui monolith, split by audience) ---------
+//
+// Each function below draws one registered panel's body; the debug-ui shell wraps
+// it in a window and a menu entry (see register_builtin_debug_panels). The widget
+// logic is unchanged from the monolith -- only the per-section TreeNode wrappers
+// became panels, and the "show X" gating checkboxes became the panel open-state.
 
-    ImGui::Text("FPS rolling 120 frames: %f (%.3f ms)", ImGui::GetIO().Framerate,
-                (1.0f / ImGui::GetIO().Framerate) * 1000);
-    if (ImGui::TreeNodeEx("graphics settings")) {
-        int max_msaa_samples = 1;
-        glGetIntegerv(GL_MAX_SAMPLES, &max_msaa_samples);
-        if (imgui_state.msaa_samples > max_msaa_samples) {
-            imgui_state.msaa_samples = max_msaa_samples;
-            save_settings_ini();
-        }
-        if (ImGui::SliderInt("MSAA samples", &imgui_state.msaa_samples, 1, max_msaa_samples)) {
-            save_settings_ini();
-        }
-
-        int max_anisotropy = 1;
-        glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY, &max_anisotropy);
-        if (imgui_state.anisotropy > max_anisotropy) {
-            imgui_state.anisotropy = max_anisotropy;
-            save_settings_ini();
-        }
-        if (ImGui::SliderInt("Anisotropy", &imgui_state.anisotropy, 1, 16)) {
-            for (int i = 0; i < texture_count; i++) {
-                GLuint handle = gl_texture_from_texture_id((TEXID) i);
-                if (handle != 0) {
-                    glBindTexture(GL_TEXTURE_2D, handle);
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY,
-                                    imgui_state.anisotropy);
-                    glBindTexture(GL_TEXTURE_2D, 0);
-                }
-            }
-            save_settings_ini();
-        }
-        if (ImGui::Checkbox("Enable fog", &imgui_state.enable_fog)) {
-            save_settings_ini();
-        }
-
-        if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
-            set_ai_full_lod(imgui_state.ai_full_lod);
-        }
-
-        static const char *window_mode_items[] = {"Windowed", "Borderless", "Fullscreen"};
-        int window_mode = g_window_mode;
-        if (ImGui::Combo("Window mode", &window_mode, window_mode_items,
-                         IM_ARRAYSIZE(window_mode_items))) {
-            set_window_mode(window_mode);
-
-            save_settings_ini();
-        }
-        ImGui::TreePop();
+// Player: persisted graphics settings (back the same SW_RACER_RE.ini keys).
+static void panel_graphics_settings() {
+    int max_msaa_samples = 1;
+    glGetIntegerv(GL_MAX_SAMPLES, &max_msaa_samples);
+    if (imgui_state.msaa_samples > max_msaa_samples) {
+        imgui_state.msaa_samples = max_msaa_samples;
+        save_settings_ini();
+    }
+    if (ImGui::SliderInt("MSAA samples", &imgui_state.msaa_samples, 1, max_msaa_samples)) {
+        save_settings_ini();
     }
 
-    ImGui::Checkbox("Show Debug informations", &imgui_state.show_debug);
-    if (imgui_state.show_debug) {
-#ifndef NDEBUG
-        auto dump_member = [](auto &member) {
-            ImGui::PushID(member.name);
-            ImGui::Text("%s", member.name);
-            std::set<uint32_t> new_banned;
-            for (const auto &[value, count]: member.count) {
-                ImGui::PushID(value);
-                bool banned = member.banned.contains(value);
-                ImGui::Checkbox("##banned", &banned);
-                ImGui::SameLine();
-                ImGui::Text("0x%08x : %d", value, count);
-                ImGui::PopID();
-
-                if (banned)
-                    new_banned.insert(value);
+    int max_anisotropy = 1;
+    glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY, &max_anisotropy);
+    if (imgui_state.anisotropy > max_anisotropy) {
+        imgui_state.anisotropy = max_anisotropy;
+        save_settings_ini();
+    }
+    if (ImGui::SliderInt("Anisotropy", &imgui_state.anisotropy, 1, 16)) {
+        for (int i = 0; i < texture_count; i++) {
+            GLuint handle = gl_texture_from_texture_id((TEXID) i);
+            if (handle != 0) {
+                glBindTexture(GL_TEXTURE_2D, handle);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY, imgui_state.anisotropy);
+                glBindTexture(GL_TEXTURE_2D, 0);
             }
-            ImGui::PopID();
-            member.count.clear();
-            member.banned = std::move(new_banned);
-        };
-
-        if (ImGui::TreeNodeEx("node props:")) {
-            for (NodeMember &member: node_members) {
-                dump_member(member);
-            }
-            ImGui::TreePop();
         }
-
-        if (ImGui::TreeNodeEx("mesh material props:")) {
-            for (MaterialMember &member: node_material_members) {
-                dump_member(member);
-            }
-            ImGui::TreePop();
-        }
-
-        if (ImGui::TreeNodeEx("render modes:")) {
-            auto dump_mode = [](std::string_view name, auto printer) {
-                for (const MaterialMember &material_member: node_material_members) {
-                    if (material_member.name == name) {
-                        ImGui::Text("%s", material_member.name);
-                        for (const auto &[m, count]: material_member.count)
-                            ImGui::Text("    %s: %d", printer(m).c_str(), count);
-                    }
-                }
-            };
-
-            dump_mode("render_mode_1", [](const uint32_t x) {
-                return dump_blend_mode((const RenderMode &) x, false);
-            });
-            dump_mode("render_mode_2", [](const uint32_t x) {
-                return dump_blend_mode((const RenderMode &) x, true);
-            });
-            dump_mode("cc_cycle1",
-                      [](const uint32_t x) { return CombineMode(x, false).to_string(); });
-            dump_mode("ac_cycle1",
-                      [](const uint32_t x) { return CombineMode(x, true).to_string(); });
-            dump_mode("cc_cycle2",
-                      [](const uint32_t x) { return CombineMode(x, false).to_string(); });
-            dump_mode("ac_cycle2",
-                      [](const uint32_t x) { return CombineMode(x, true).to_string(); });
-            ImGui::TreePop();
-        }
-
-        if (ImGui::TreeNodeEx("banned sprite flags")) {
-            for (int i = 0; i < 17; i++) {
-                bool banned = banned_sprite_flags & (1 << i);
-                if (ImGui::Checkbox(
-                        std::format("0x{:X} ({} times)", 1 << i, num_sprites_with_flag[i]).c_str(),
-                        &banned))
-                    banned_sprite_flags ^= (1 << i);
-            }
-            ImGui::TreePop();
-        }
-        std::fill(std::begin(num_sprites_with_flag), std::end(num_sprites_with_flag), 0);
-#endif
-
-        if (ImGui::TreeNodeEx("scene root node")) {
-            ImGui::Text("Root node address: %p", root_node);
-            imgui_render_node(root_node);
-            ImGui::TreePop();
-        }
-    }// !show debug information
-
-    static bool toto = false;
-    ImGui::Checkbox("matrices pos", &toto);
-    if (toto) {// matrices from test object
-        if (currentPlayer_Test == nullptr) {
-            if (root_node == nullptr) {
-                ImGui::Text("root_node is NULL");
-            } else {
-                ImGui::Text("player test is null. Trying hardcoded path for pod");
-                swrModel_Node *pod_node = root_node->children.nodes[15];
-                if (pod_node == nullptr) {
-                    ImGui::Text("Pod slot is null");
-                } else {
-                    swrModel_Node *node =
-                        pod_node->children.nodes[0]->children.nodes[2]->children.nodes[0];
-                    ImGui::Text("%s", std::format("{} 0x{:08x}",
-                                                  swrModel_NodeTypeStr((uint32_t) node->type),
-                                                  (uintptr_t) node)
-                                          .c_str());
-                    rdMatrix44 mat{};
-                    swrModel_NodeGetTransform((const swrModel_NodeTransformed *) node, &mat);
-
-                    ImGui::Text("engine XfR Position %.2f %.2f %.2f", mat.vD.x, mat.vD.y, mat.vD.z);
-                }
-            }
-        } else {
-            ImGui::Text("350 mat Position: %.2f %.2f %.2f", currentPlayer_Test->unk350_mat.vD.x,
-                        currentPlayer_Test->unk350_mat.vD.y, currentPlayer_Test->unk350_mat.vD.z);
-            ImGui::Text("engine XfR Position: %.2f %.2f %.2f", currentPlayer_Test->engineXfR.vD.x,
-                        currentPlayer_Test->engineXfR.vD.y, currentPlayer_Test->engineXfR.vD.z);
-            ImGui::Text("engine XfL Position: %.2f %.2f %.2f", currentPlayer_Test->engineXfL.vD.x,
-                        currentPlayer_Test->engineXfL.vD.y, currentPlayer_Test->engineXfL.vD.z);
-            ImGui::Text("cockpitXf Position: %.2f %.2f %.2f", currentPlayer_Test->cockpitXf.vD.x,
-                        currentPlayer_Test->cockpitXf.vD.y, currentPlayer_Test->cockpitXf.vD.z);
-        }
+        save_settings_ini();
+    }
+    if (ImGui::Checkbox("Enable fog", &imgui_state.enable_fog)) {
+        save_settings_ini();
     }
 
-#if !defined(NDEBUG)
-    ImGui::Checkbox("Draw test scene instead", &imgui_state.draw_test_scene);
-    if (imgui_state.draw_test_scene) {
-        ImGui::Text("Position: %.2f %.2f %.2f, Front: %.2f %.2f %.2f, Up: %.2f %.2f %.2f",
-                    debugCameraPos.x, debugCameraPos.y, debugCameraPos.z, cameraFront.x,
-                    cameraFront.y, cameraFront.z, cameraUp.x, cameraUp.y, cameraUp.z);
-        ImGui::Text("Pitch: %.2f, Yaw: %.2f", cameraPitch, cameraYaw);
-        ImGui::Text("Camera Speed: %.3f", cameraSpeed);
+    if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
+        set_ai_full_lod(imgui_state.ai_full_lod);
     }
-#endif
 
-    ImGui::Checkbox("Draw meshes", &imgui_state.draw_meshes);
-    ImGui::Checkbox("Draw RenderList", &imgui_state.draw_renderList);
-    ImGui::Checkbox("debug lambertian", &imgui_state.debug_lambertian_cubemap);
-    ImGui::Checkbox("debug ggx cubemap", &imgui_state.debug_ggx_cubemap);
-    ImGui::Checkbox("debug env cubemap", &imgui_state.debug_env_cubemap);
-    ImGui::Checkbox("debug ggx lut", &imgui_state.debug_ggxLut);
+    static const char *window_mode_items[] = {"Windowed", "Borderless", "Fullscreen"};
+    int window_mode = g_window_mode;
+    if (ImGui::Combo("Window mode", &window_mode, window_mode_items,
+                     IM_ARRAYSIZE(window_mode_items))) {
+        set_window_mode(window_mode);
+        save_settings_ini();
+    }
+}
 
+// Player: HD model + texture replacement toggles.
+static void panel_hd_models() {
     if (ImGui::Button("Reload Models from assets/gltf")) {
         for (auto &[key, replacement]: replacement_map) {
             if (replacement.fileExist) {
@@ -704,88 +570,245 @@ void opengl_render_imgui() {
         imgui_state.replacementTries.clear();
     }
 
-    if (ImGui::Button("Show Log"))
-        imgui_state.show_logs = true;
+    ImGui::SeparatorText("Replacement textures");
+    ImGui::Checkbox("enable", &enable_texture_replacement);
+    if (ImGui::Button("refresh replacement textures"))
+        refresh_replacement_textures();
+    ImGui::Text("Found %d replacement textures.", int(replacement_textures.size()));
+}
 
-    if (ImGui::TreeNodeEx("highlight textures from map")) {
-        ImGui::Checkbox("Show texture hovered by mouse cursor",
-                        &imgui_state.enable_picking_texture_when_hovering);
-        if (imgui_state.enable_picking_texture_when_hovering) {
-            ImGui::Checkbox("Ignore transparent objects",
-                            &imgui_state.pick_through_transparent_objects);
-            if (imgui_state.picked_texture_id) {
-                ImGui::Text("Hovered texture:");
-                ImGui::SameLine();
-                ImGui::Image(
-                    (ImTextureID) gl_texture_from_texture_id(*imgui_state.picked_texture_id),
-                    ImVec2(50, 50));
-                ImGui::SameLine();
-                ImGui::Text("#%d", *imgui_state.picked_texture_id);
-            }
+// Dev: render-pipeline debug toggles (read by renderer_hook / renderer_utils).
+static void panel_render_debug() {
+#if !defined(NDEBUG)
+    ImGui::Checkbox("Draw test scene instead", &imgui_state.draw_test_scene);
+    if (imgui_state.draw_test_scene) {
+        ImGui::Text("Position: %.2f %.2f %.2f, Front: %.2f %.2f %.2f, Up: %.2f %.2f %.2f",
+                    debugCameraPos.x, debugCameraPos.y, debugCameraPos.z, cameraFront.x,
+                    cameraFront.y, cameraFront.z, cameraUp.x, cameraUp.y, cameraUp.z);
+        ImGui::Text("Pitch: %.2f, Yaw: %.2f", cameraPitch, cameraYaw);
+        ImGui::Text("Camera Speed: %.3f", cameraSpeed);
+    }
+    ImGui::Separator();
+#endif
+
+    ImGui::Checkbox("Draw meshes", &imgui_state.draw_meshes);
+    ImGui::Checkbox("Draw RenderList", &imgui_state.draw_renderList);
+    ImGui::Checkbox("debug lambertian", &imgui_state.debug_lambertian_cubemap);
+    ImGui::Checkbox("debug ggx cubemap", &imgui_state.debug_ggx_cubemap);
+    ImGui::Checkbox("debug env cubemap", &imgui_state.debug_env_cubemap);
+    ImGui::Checkbox("debug ggx lut", &imgui_state.debug_ggxLut);
+}
+
+// Dev: scene graph + (debug-build only) per-frame node/material property tallies.
+static void panel_scene_inspector() {
+#ifndef NDEBUG
+    auto dump_member = [](auto &member) {
+        ImGui::PushID(member.name);
+        ImGui::Text("%s", member.name);
+        std::set<uint32_t> new_banned;
+        for (const auto &[value, count]: member.count) {
+            ImGui::PushID(value);
+            bool banned = member.banned.contains(value);
+            ImGui::Checkbox("##banned", &banned);
+            ImGui::SameLine();
+            ImGui::Text("0x%08x : %d", value, count);
+            ImGui::PopID();
+
+            if (banned)
+                new_banned.insert(value);
         }
+        ImGui::PopID();
+        member.count.clear();
+        member.banned = std::move(new_banned);
+    };
 
-        ImGui::Separator();
-        ImGui::Checkbox("skip pod textures", &imgui_state.collect_textures_skip_pod_textures);
-        if (ImGui::Button(imgui_state.collected_textures.empty()
-                              ? "collect visible textures"
-                              : "collect visible textures (press again to refresh)")) {
-            std::set<RdMaterial *> visible_textures;
-            for (const auto &vp: swrViewport_array) {
-                if ((vp.flag & 1) == 0)
-                    continue;
+    if (ImGui::TreeNodeEx("node props:")) {
+        for (NodeMember &member: node_members) {
+            dump_member(member);
+        }
+        ImGui::TreePop();
+    }
 
-                collect_all_visual_textures(vp, imgui_state.collect_textures_skip_pod_textures,
-                                            vp.model_root_node, visible_textures);
+    if (ImGui::TreeNodeEx("mesh material props:")) {
+        for (MaterialMember &member: node_material_members) {
+            dump_member(member);
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNodeEx("render modes:")) {
+        auto dump_mode = [](std::string_view name, auto printer) {
+            for (const MaterialMember &material_member: node_material_members) {
+                if (material_member.name == name) {
+                    ImGui::Text("%s", material_member.name);
+                    for (const auto &[m, count]: material_member.count)
+                        ImGui::Text("    %s: %d", printer(m).c_str(), count);
+                }
             }
-            // convert RdMaterial* to TEXIDs
-            imgui_state.collected_textures.clear();
-            for (const auto &tex: visible_textures) {
-                for (int i = 0; i < texture_count; i++) {
-                    if (material_from_texture_id((TEXID) i) == tex) {
-                        imgui_state.collected_textures.insert((TEXID) i);
-                        break;
-                    }
+        };
+
+        dump_mode("render_mode_1", [](const uint32_t x) {
+            return dump_blend_mode((const RenderMode &) x, false);
+        });
+        dump_mode("render_mode_2", [](const uint32_t x) {
+            return dump_blend_mode((const RenderMode &) x, true);
+        });
+        dump_mode("cc_cycle1", [](const uint32_t x) { return CombineMode(x, false).to_string(); });
+        dump_mode("ac_cycle1", [](const uint32_t x) { return CombineMode(x, true).to_string(); });
+        dump_mode("cc_cycle2", [](const uint32_t x) { return CombineMode(x, false).to_string(); });
+        dump_mode("ac_cycle2", [](const uint32_t x) { return CombineMode(x, true).to_string(); });
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNodeEx("banned sprite flags")) {
+        for (int i = 0; i < 17; i++) {
+            bool banned = banned_sprite_flags & (1 << i);
+            if (ImGui::Checkbox(
+                    std::format("0x{:X} ({} times)", 1 << i, num_sprites_with_flag[i]).c_str(),
+                    &banned))
+                banned_sprite_flags ^= (1 << i);
+        }
+        ImGui::TreePop();
+    }
+    std::fill(std::begin(num_sprites_with_flag), std::end(num_sprites_with_flag), 0);
+#endif
+
+    if (ImGui::TreeNodeEx("scene root node")) {
+        ImGui::Text("Root node address: %p", root_node);
+        imgui_render_node(root_node);
+        ImGui::TreePop();
+    }
+}
+
+// Dev: hover-pick a texture and collect the textures visible this frame.
+static void panel_textures() {
+    ImGui::Checkbox("Show texture hovered by mouse cursor",
+                    &imgui_state.enable_picking_texture_when_hovering);
+    if (imgui_state.enable_picking_texture_when_hovering) {
+        ImGui::Checkbox("Ignore transparent objects",
+                        &imgui_state.pick_through_transparent_objects);
+        if (imgui_state.picked_texture_id) {
+            ImGui::Text("Hovered texture:");
+            ImGui::SameLine();
+            ImGui::Image((ImTextureID) gl_texture_from_texture_id(*imgui_state.picked_texture_id),
+                         ImVec2(50, 50));
+            ImGui::SameLine();
+            ImGui::Text("#%d", *imgui_state.picked_texture_id);
+        }
+    }
+
+    ImGui::Separator();
+    ImGui::Checkbox("skip pod textures", &imgui_state.collect_textures_skip_pod_textures);
+    if (ImGui::Button(imgui_state.collected_textures.empty()
+                          ? "collect visible textures"
+                          : "collect visible textures (press again to refresh)")) {
+        std::set<RdMaterial *> visible_textures;
+        for (const auto &vp: swrViewport_array) {
+            if ((vp.flag & 1) == 0)
+                continue;
+
+            collect_all_visual_textures(vp, imgui_state.collect_textures_skip_pod_textures,
+                                        vp.model_root_node, visible_textures);
+        }
+        // convert RdMaterial* to TEXIDs
+        imgui_state.collected_textures.clear();
+        for (const auto &tex: visible_textures) {
+            for (int i = 0; i < texture_count; i++) {
+                if (material_from_texture_id((TEXID) i) == tex) {
+                    imgui_state.collected_textures.insert((TEXID) i);
+                    break;
                 }
             }
         }
+    }
 
-        int i = 0;
-        for (const auto &tex: imgui_state.collected_textures) {
-            ImGui::PushID(tex);
-            ImGui::Image((ImTextureID) gl_texture_from_texture_id(tex), ImVec2(50, 50));
-            if (ImGui::IsItemHovered()) {
-                set_texture_highlighting(tex, true);
-            } else {
-                set_texture_highlighting(tex, false);
-            }
-
-            ImGui::SameLine();
-            ImGui::Text("#%d", tex);
-
-            if (i % 3 != 2) {
-                ImGui::SameLine();
-            }
-            i++;
-
-            ImGui::PopID();
+    int i = 0;
+    for (const auto &tex: imgui_state.collected_textures) {
+        ImGui::PushID(tex);
+        ImGui::Image((ImTextureID) gl_texture_from_texture_id(tex), ImVec2(50, 50));
+        if (ImGui::IsItemHovered()) {
+            set_texture_highlighting(tex, true);
+        } else {
+            set_texture_highlighting(tex, false);
         }
 
-        ImGui::TreePop();
-    }
+        ImGui::SameLine();
+        ImGui::Text("#%d", tex);
 
-    if (ImGui::TreeNodeEx("replacement textures")) {
-        ImGui::Checkbox("enable", &enable_texture_replacement);
-        if (ImGui::Button("refresh replacement textures"))
-            refresh_replacement_textures();
+        if (i % 3 != 2) {
+            ImGui::SameLine();
+        }
+        i++;
 
-        ImGui::Text("Found %d replacement textures.", int(replacement_textures.size()));
-        ImGui::TreePop();
+        ImGui::PopID();
     }
+}
 
-    // Floating log window, opened by the "Show Log" button above. Only tail the
-    // file while it is open so the buffer doesn't grow while it isn't being used.
-    if (imgui_state.show_logs) {
-        pump_hook_log();
-        g_debug_log.Draw("Hook Log", &imgui_state.show_logs);
+// Dev: live pod engine/cockpit transforms (falls back to a hardcoded node path).
+static void panel_pod_transforms() {
+    if (currentPlayer_Test == nullptr) {
+        if (root_node == nullptr) {
+            ImGui::Text("root_node is NULL");
+        } else {
+            ImGui::Text("player test is null. Trying hardcoded path for pod");
+            swrModel_Node *pod_node = root_node->children.nodes[15];
+            if (pod_node == nullptr) {
+                ImGui::Text("Pod slot is null");
+            } else {
+                swrModel_Node *node =
+                    pod_node->children.nodes[0]->children.nodes[2]->children.nodes[0];
+                ImGui::Text("%s", std::format("{} 0x{:08x}",
+                                              swrModel_NodeTypeStr((uint32_t) node->type),
+                                              (uintptr_t) node)
+                                      .c_str());
+                rdMatrix44 mat{};
+                swrModel_NodeGetTransform((const swrModel_NodeTransformed *) node, &mat);
+
+                ImGui::Text("engine XfR Position %.2f %.2f %.2f", mat.vD.x, mat.vD.y, mat.vD.z);
+            }
+        }
+    } else {
+        ImGui::Text("350 mat Position: %.2f %.2f %.2f", currentPlayer_Test->unk350_mat.vD.x,
+                    currentPlayer_Test->unk350_mat.vD.y, currentPlayer_Test->unk350_mat.vD.z);
+        ImGui::Text("engine XfR Position: %.2f %.2f %.2f", currentPlayer_Test->engineXfR.vD.x,
+                    currentPlayer_Test->engineXfR.vD.y, currentPlayer_Test->engineXfR.vD.z);
+        ImGui::Text("engine XfL Position: %.2f %.2f %.2f", currentPlayer_Test->engineXfL.vD.x,
+                    currentPlayer_Test->engineXfL.vD.y, currentPlayer_Test->engineXfL.vD.z);
+        ImGui::Text("cockpitXf Position: %.2f %.2f %.2f", currentPlayer_Test->cockpitXf.vD.x,
+                    currentPlayer_Test->cockpitXf.vD.y, currentPlayer_Test->cockpitXf.vD.z);
     }
+}
+
+// Dev: live tail of the mod's hook.log (pumped only while this panel is open).
+static void panel_hook_log() {
+    pump_hook_log();
+    g_debug_log.DrawBody();
+}
+
+static DebugPanel g_panel_graphics_settings = {
+    .category = "Render", .name = "Graphics Settings", .draw = panel_graphics_settings,
+    .dev_only = false, .open = true};
+static DebugPanel g_panel_hd_models = {
+    .category = "Render", .name = "HD Models", .draw = panel_hd_models, .dev_only = false};
+static DebugPanel g_panel_render_debug = {
+    .category = "Debug", .name = "Render Debug", .draw = panel_render_debug, .dev_only = true};
+static DebugPanel g_panel_scene_inspector = {
+    .category = "Inspect", .name = "Scene", .draw = panel_scene_inspector, .dev_only = true};
+static DebugPanel g_panel_textures = {
+    .category = "Inspect", .name = "Textures", .draw = panel_textures, .dev_only = true};
+static DebugPanel g_panel_pod_transforms = {
+    .category = "Inspect", .name = "Pod Transforms", .draw = panel_pod_transforms,
+    .dev_only = true};
+static DebugPanel g_panel_hook_log = {
+    .category = "Tools", .name = "Hook Log", .draw = panel_hook_log, .dev_only = true,
+    .default_w = 700, .default_h = 400};
+
+static void register_builtin_debug_panels() {
+    debug_ui_register(&g_panel_graphics_settings);
+    debug_ui_register(&g_panel_hd_models);
+    debug_ui_register(&g_panel_render_debug);
+    debug_ui_register(&g_panel_scene_inspector);
+    debug_ui_register(&g_panel_textures);
+    debug_ui_register(&g_panel_pod_transforms);
+    debug_ui_register(&g_panel_hook_log);
 }

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -98,6 +98,12 @@ void read_settings_ini() {
         GetPrivateProfileIntW(L"settings", L"ai_full_lod", 1, ini_path.c_str());
     set_ai_full_lod(imgui_state.ai_full_lod);
 
+    imgui_state.HD_replacement =
+        GetPrivateProfileIntW(L"settings", L"hd_replacement", 1, ini_path.c_str());
+
+    // Default to the build's compiled-in visibility (debug shows, release hides).
+    show_imgui = (char) GetPrivateProfileIntW(L"settings", L"show_imgui", show_imgui, ini_path.c_str());
+
     g_window_mode =
         GetPrivateProfileIntW(L"settings", L"window_mode", WINDOW_MODE_WINDOWED, ini_path.c_str());
     if (g_window_mode < WINDOW_MODE_WINDOWED || g_window_mode > WINDOW_MODE_FULLSCREEN)
@@ -118,12 +124,19 @@ void save_settings_ini() {
     WritePrivateProfileStringW(L"settings", L"ai_full_lod", imgui_state.ai_full_lod ? L"1" : L"0",
                                ini_path.c_str());
 
+    WritePrivateProfileStringW(L"settings", L"hd_replacement",
+                               imgui_state.HD_replacement ? L"1" : L"0", ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"show_imgui", show_imgui ? L"1" : L"0",
+                               ini_path.c_str());
+
     WritePrivateProfileStringW(L"settings", L"window_mode", std::to_wstring(g_window_mode).c_str(),
                                ini_path.c_str());
 }
 
-// Called from the (C) window key callbacks so Alt+Enter persists the chosen mode too.
-extern "C" void save_window_mode_setting(void) {
+// C-callable persistence for the window key callbacks (window-mode changes and
+// the F5 overlay toggle); writes the whole settings block.
+extern "C" void persist_settings_ini(void) {
     save_settings_ini();
 }
 
@@ -573,7 +586,8 @@ static void panel_hd_models() {
         replacement_map.clear();
     }
 
-    ImGui::Checkbox("Enable HD model replacement.", &imgui_state.HD_replacement);
+    if (ImGui::Checkbox("Enable HD model replacement.", &imgui_state.HD_replacement))
+        save_settings_ini();
     ImGui::Checkbox("Show original on top of replacements.",
                     &imgui_state.show_original_and_replacements);
     ImGui::Checkbox("Show replacement tries", &imgui_state.show_replacementTries);
@@ -918,8 +932,9 @@ static void panel_video() {
     flag_checkbox("Reflections", swrConfig_VIDEO_REFLECTIONS);
     flag_checkbox("Z-buffer effects", swrConfig_VIDEO_ZEFFECTS);
     flag_checkbox("Dynamic lighting", swrConfig_VIDEO_DYNAMIC_LIGHTING);
-    flag_checkbox("Lens flare", swrConfig_VIDEO_LENSFLARE);
     flag_checkbox("Engine exhaust (smoke)", swrConfig_VIDEO_ENGINEEXHAUST);
+    // (Lens flare omitted: its native flag gated the original D3D path that the
+    //  GL renderer bypasses, so toggling it has no effect.)
 
     const char *detail_items[] = {"Low", "Medium", "High"};
     int model_detail = (swrConfig_VIDEO_MODEL_DETAIL >= 0 && swrConfig_VIDEO_MODEL_DETAIL <= 2)

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -809,9 +809,12 @@ static void panel_pod_readout() {
 
     ImGui::Text("Engine temp:   %.2f", pod->engineTemp);
     ImGui::Text("Total damage:  %.2f", pod->totalDamage);
-    ImGui::Text("Engine health: %.0f %.0f %.0f / %.0f %.0f %.0f", pod->engineHealth[0],
-                pod->engineHealth[1], pod->engineHealth[2], pod->engineHealth[3],
-                pod->engineHealth[4], pod->engineHealth[5]);
+    // engineHealth[] is a 0..1 damage accumulator (0 = pristine, 1 = blown), so
+    // show it as a health percentage.
+    ImGui::Text("Engine health %%: %.0f %.0f %.0f / %.0f %.0f %.0f",
+                (1.0f - pod->engineHealth[0]) * 100.0f, (1.0f - pod->engineHealth[1]) * 100.0f,
+                (1.0f - pod->engineHealth[2]) * 100.0f, (1.0f - pod->engineHealth[3]) * 100.0f,
+                (1.0f - pod->engineHealth[4]) * 100.0f, (1.0f - pod->engineHealth[5]) * 100.0f);
 
     ImGui::Separator();
     ImGui::Text("Tilt %.2f   Pitch %.2f   Turn %.2f", pod->tiltAngle, pod->pitch, pod->turnRate);
@@ -932,10 +935,16 @@ static void panel_cheats() {
         swrRace_truguts += 1000;
 }
 
-// Dev: live tail of the mod's hook.log (pumped only while this section is open).
-static void panel_hook_log() {
+// Live tail of the mod's hook.log in its own floating window (toggled from the
+// overlay footer). Only pump while open so the buffer doesn't grow unused.
+void imgui_draw_log_window(bool *p_open) {
+    if (!*p_open)
+        return;
     pump_hook_log();
-    g_debug_log.DrawBody(320.0f);
+    ImGui::SetNextWindowSize(ImVec2(700, 400), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("Hook Log", p_open))
+        g_debug_log.DrawBody(0.0f);// 0 = fill the window
+    ImGui::End();
 }
 
 static DebugPanel g_panel_graphics_settings = {
@@ -960,8 +969,6 @@ static DebugPanel g_panel_pod_transforms = {
     .dev_only = true};
 static DebugPanel g_panel_pod_readout = {
     .category = "Inspect", .name = "Pod Readout", .draw = panel_pod_readout, .dev_only = true};
-static DebugPanel g_panel_hook_log = {
-    .category = "Tools", .name = "Hook Log", .draw = panel_hook_log, .dev_only = true};
 
 static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_graphics_settings);
@@ -974,5 +981,4 @@ static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_textures);
     debug_ui_register(&g_panel_pod_transforms);
     debug_ui_register(&g_panel_pod_readout);
-    debug_ui_register(&g_panel_hook_log);
 }

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -26,6 +26,8 @@ extern "C" {
 #include <Swr/swrModel.h>
 #include <Swr/swrRace.h>
 #include <Swr/swrSound.h>
+#include <Swr/swrObj.h>
+#include <Swr/swrEvent.h>
 }
 
 extern rdVector3 debugCameraPos;
@@ -829,31 +831,43 @@ static void panel_pod_readout() {
 // start; the rest live on the hangar state and only apply in the front-end menu.
 static void panel_race() {
     ImGui::SliderInt("AI racers", &nb_AI_racers, 1, 20);
-    ImGui::TextDisabled("(applies to a race started from the menu, not an in-race Restart)");
 
-    swrObjHang *hang = g_objHang2;
-    if (hang == nullptr) {
-        ImGui::TextDisabled("Laps / mirror / etc. are editable in the hangar menu.");
-        return;
+    // The hangar entity (reachable mid-race via the event registry, like annodue)
+    // holds the rest of the race setup; keep its racer count synced to the slider.
+    swrObjHang *hang = (swrObjHang *) swrEvent_GetItem('Hang', 0);
+    if (hang != nullptr) {
+        hang->num_players = (char) nb_AI_racers;
+
+        int laps = hang->numLaps;
+        if (ImGui::SliderInt("Laps", &laps, 1, 125))
+            hang->numLaps = (char) laps;
+
+        bool mirror = hang->bMirror != 0;
+        if (ImGui::Checkbox("Mirror mode", &mirror))
+            hang->bMirror = mirror ? 1 : 0;
+
+        const char *ai_speed_items[] = {"Slow", "Average", "Fast"};
+        int ai_speed = (hang->AISpeed >= 1 && hang->AISpeed <= 3) ? hang->AISpeed - 1 : 1;
+        if (ImGui::Combo("AI speed", &ai_speed, ai_speed_items, IM_ARRAYSIZE(ai_speed_items)))
+            hang->AISpeed = (char) (ai_speed + 1);
+
+        const char *winnings_items[] = {"Fair", "Skilled", "Winner takes all"};
+        int winnings = (hang->WinningsID >= 1 && hang->WinningsID <= 3) ? hang->WinningsID - 1 : 0;
+        if (ImGui::Combo("Winnings", &winnings, winnings_items, IM_ARRAYSIZE(winnings_items)))
+            hang->WinningsID = (char) (winnings + 1);
     }
 
-    int laps = hang->numLaps;
-    if (ImGui::SliderInt("Laps", &laps, 1, 125))
-        hang->numLaps = (char) laps;
-
-    bool mirror = hang->bMirror != 0;
-    if (ImGui::Checkbox("Mirror mode", &mirror))
-        hang->bMirror = mirror ? 1 : 0;
-
-    const char *ai_speed_items[] = {"Slow", "Average", "Fast"};
-    int ai_speed = (hang->AISpeed >= 1 && hang->AISpeed <= 3) ? hang->AISpeed - 1 : 1;
-    if (ImGui::Combo("AI speed", &ai_speed, ai_speed_items, IM_ARRAYSIZE(ai_speed_items)))
-        hang->AISpeed = (char) (ai_speed + 1);
-
-    const char *winnings_items[] = {"Fair", "Skilled", "Winner takes all"};
-    int winnings = (hang->WinningsID >= 1 && hang->WinningsID <= 3) ? hang->WinningsID - 1 : 0;
-    if (ImGui::Combo("Winnings", &winnings, winnings_items, IM_ARRAYSIZE(winnings_items)))
-        hang->WinningsID = (char) (winnings + 1);
+    // Apply by re-running the game's own in-race load (annodue's technique): the
+    // setup above is written, then an 'RStr' on the judge respawns the field --
+    // the same path the pause-menu Restart uses, so no live entity surgery.
+    ImGui::Separator();
+    swrObjJdge *jdge = (swrObjJdge *) swrEvent_GetItem('Jdge', 0);
+    ImGui::BeginDisabled(jdge == nullptr);
+    if (ImGui::Button("Restart race (apply settings)"))
+        swrObjJdge_Clear(jdge, 'RStr');
+    ImGui::EndDisabled();
+    if (jdge == nullptr)
+        ImGui::TextDisabled("Restart is available during a race.");
 }
 
 // Player: audio controls. Master volume drives the A3D device output gain (the

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #include <globals.h>
 #include <macros.h>
 #include <Swr/swrModel.h>
+#include <Swr/swrRace.h>
 }
 
 extern rdVector3 debugCameraPos;
@@ -39,6 +40,10 @@ extern "C" void set_ai_full_lod(bool on);
 // Registers the built-in overlay panels with the debug-ui shell. Defined at the
 // bottom of this file alongside the panel bodies it splits opengl_render_imgui into.
 static void register_builtin_debug_panels();
+
+// Applies the enabled cheats. Called every frame from imgui_Update so the cheats
+// hold whether or not the overlay window is open.
+static void apply_cheats();
 
 extern uint8_t replacedTries[323];// 323 MODELIDs
 extern std::map<int, ReplacementModel> replacement_map;
@@ -316,6 +321,8 @@ void imgui_Update() {
     }
 
     if (imgui_initialized) {
+        apply_cheats();
+
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
@@ -814,6 +821,98 @@ static void panel_pod_readout() {
     ImGui::Text("Respawn invuln: %.2f", pod->respawnInvincibilityTimer);
 }
 
+// Player: quick race-setup knobs. AI count is a global consumed at the next race
+// start; the rest live on the hangar state and only apply in the front-end menu.
+static void panel_race() {
+    ImGui::SliderInt("AI racers (next race)", &nb_AI_racers, 1, 20);
+
+    swrObjHang *hang = g_objHang2;
+    if (hang == nullptr) {
+        ImGui::TextDisabled("Laps / mirror / etc. are editable in the hangar menu.");
+        return;
+    }
+
+    int laps = hang->numLaps;
+    if (ImGui::SliderInt("Laps", &laps, 1, 125))
+        hang->numLaps = (char) laps;
+
+    bool mirror = hang->bMirror != 0;
+    if (ImGui::Checkbox("Mirror mode", &mirror))
+        hang->bMirror = mirror ? 1 : 0;
+
+    const char *ai_speed_items[] = {"Slow", "Average", "Fast"};
+    int ai_speed = (hang->AISpeed >= 1 && hang->AISpeed <= 3) ? hang->AISpeed - 1 : 1;
+    if (ImGui::Combo("AI speed", &ai_speed, ai_speed_items, IM_ARRAYSIZE(ai_speed_items)))
+        hang->AISpeed = (char) (ai_speed + 1);
+
+    const char *winnings_items[] = {"Fair", "Skilled", "Winner takes all"};
+    int winnings = (hang->WinningsID >= 1 && hang->WinningsID <= 3) ? hang->WinningsID - 1 : 0;
+    if (ImGui::Combo("Winnings", &winnings, winnings_items, IM_ARRAYSIZE(winnings_items)))
+        hang->WinningsID = (char) (winnings + 1);
+}
+
+// Player: audio toggles backed by the game's sound globals. Most apply to sounds
+// started after the change.
+static void panel_audio() {
+    ImGui::SliderFloat("Master volume", &Main_sound_gain, 0.0f, 2.0f, "%.2f");
+
+    bool sound_3d = Sound_enabled_3d != 0;
+    if (ImGui::Checkbox("3D sound", &sound_3d))
+        Sound_enabled_3d = sound_3d;
+    bool doppler = Main_doppler_sound != 0;
+    if (ImGui::Checkbox("Doppler", &doppler))
+        Main_doppler_sound = doppler;
+    bool music = swrRace_music_enabled != 0;
+    if (ImGui::Checkbox("Music", &music))
+        swrRace_music_enabled = music;
+    bool voices = swrRace_voices_enabled != 0;
+    if (ImGui::Checkbox("In-race voices", &voices))
+        swrRace_voices_enabled = voices;
+}
+
+// Cheats. The toggles are held in these flags; apply_cheats() enforces them every
+// frame (see imgui_Update) so they persist with the overlay closed.
+static bool g_cheat_god = false;
+static bool g_cheat_fast = false;
+static bool g_cheat_no_overheat = false;
+static bool g_cheat_no_fall = false;
+static bool g_cheat_fly = false;
+
+static void apply_cheats() {
+    swrRace_IsInvincible = g_cheat_god ? 1 : 0;
+    swr_FastMode = g_cheat_fast ? 1 : 0;
+
+    swrRace *pod = currentPlayer_Test;
+    if (pod != nullptr) {
+        if (g_cheat_no_overheat)
+            pod->engineTemp = 0.0f;
+        if (g_cheat_no_fall)
+            pod->fallTimer = 0.0f;
+        if (g_cheat_fly)
+            pod->flags0 = (swrObjTest_FLAG0) (pod->flags0 | swrObjTest_FLAG0_ZON);
+    }
+}
+
+static void panel_cheats() {
+    ImGui::Checkbox("God mode (no damage)", &g_cheat_god);
+    ImGui::Checkbox("Infinite boost / no overheat", &g_cheat_no_overheat);
+    ImGui::Checkbox("Disable out-of-bounds timer", &g_cheat_no_fall);
+    ImGui::Checkbox("Anti-grav / fly", &g_cheat_fly);
+    ImGui::Checkbox("Fast mode (speed up time)", &g_cheat_fast);
+
+    if (currentPlayer_Test == nullptr)
+        ImGui::TextDisabled("Pod cheats take effect once you're in a race.");
+
+    ImGui::Separator();
+    // swrRace_CheatUnlockAll is not reimplemented yet (no linkable body), so call
+    // the original through its named _ADDR rather than by symbol.
+    if (ImGui::Button("Unlock all pods & tracks"))
+        ((void (*)(void)) swrRace_CheatUnlockAll_ADDR)();
+    ImGui::SameLine();
+    if (ImGui::Button("+1000 truguts"))
+        swrRace_truguts += 1000;
+}
+
 // Dev: live tail of the mod's hook.log (pumped only while this section is open).
 static void panel_hook_log() {
     pump_hook_log();
@@ -825,6 +924,12 @@ static DebugPanel g_panel_graphics_settings = {
     .dev_only = false, .open = true};
 static DebugPanel g_panel_hd_models = {
     .category = "Render", .name = "HD Models", .draw = panel_hd_models, .dev_only = false};
+static DebugPanel g_panel_race = {
+    .category = "Race", .name = "Quick Race", .draw = panel_race, .dev_only = false};
+static DebugPanel g_panel_audio = {
+    .category = "Settings", .name = "Audio", .draw = panel_audio, .dev_only = false};
+static DebugPanel g_panel_cheats = {
+    .category = "Cheats", .name = "Cheats", .draw = panel_cheats, .dev_only = false};
 static DebugPanel g_panel_render_debug = {
     .category = "Debug", .name = "Render Debug", .draw = panel_render_debug, .dev_only = true};
 static DebugPanel g_panel_scene_inspector = {
@@ -842,6 +947,9 @@ static DebugPanel g_panel_hook_log = {
 static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_graphics_settings);
     debug_ui_register(&g_panel_hd_models);
+    debug_ui_register(&g_panel_race);
+    debug_ui_register(&g_panel_audio);
+    debug_ui_register(&g_panel_cheats);
     debug_ui_register(&g_panel_render_debug);
     debug_ui_register(&g_panel_scene_inspector);
     debug_ui_register(&g_panel_textures);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -880,6 +880,12 @@ static void panel_audio() {
     if (ImGui::SliderFloat("Master volume", &master, 0.0f, 1.0f, "%.2f"))
         swrSound_SetOutputGain(master);
 
+    ImGui::SliderFloat("Sound effects volume", &Main_sound_gain, 0.0f, 2.0f, "%.2f");
+
+    int music_vol = sound_music_volume;
+    if (ImGui::SliderInt("Music volume", &music_vol, 0, 100))
+        sound_music_volume = (short) music_vol;
+
     bool sound_3d = Sound_enabled_3d != 0;
     if (ImGui::Checkbox("3D sound", &sound_3d))
         Sound_enabled_3d = sound_3d;
@@ -894,6 +900,44 @@ static void panel_audio() {
     bool voices = swrRace_voices_enabled != 0;
     if (ImGui::Checkbox("In-race voices", &voices))
         swrRace_voices_enabled = voices;
+
+    bool hires = Main_hiRes_sound != 0;
+    if (ImGui::Checkbox("Use hi-res sounds (22kHz)", &hires))
+        Main_hiRes_sound = hires;
+    ImGui::TextDisabled("(hi-res applies to sounds loaded afterwards)");
+}
+
+// Player: the game's native video/detail flags (loaded from video.cfg). These
+// gate game-side effect/LOD generation, so they still affect the GL renderer.
+static void panel_video() {
+    auto flag_checkbox = [](const char *label, int &flag) {
+        bool b = flag != 0;
+        if (ImGui::Checkbox(label, &b))
+            flag = b;
+    };
+    flag_checkbox("Reflections", swrConfig_VIDEO_REFLECTIONS);
+    flag_checkbox("Z-buffer effects", swrConfig_VIDEO_ZEFFECTS);
+    flag_checkbox("Dynamic lighting", swrConfig_VIDEO_DYNAMIC_LIGHTING);
+    flag_checkbox("Lens flare", swrConfig_VIDEO_LENSFLARE);
+    flag_checkbox("Engine exhaust (smoke)", swrConfig_VIDEO_ENGINEEXHAUST);
+
+    const char *detail_items[] = {"Low", "Medium", "High"};
+    int model_detail = (swrConfig_VIDEO_MODEL_DETAIL >= 0 && swrConfig_VIDEO_MODEL_DETAIL <= 2)
+                           ? swrConfig_VIDEO_MODEL_DETAIL
+                           : 2;
+    if (ImGui::Combo("Model detail", &model_detail, detail_items, IM_ARRAYSIZE(detail_items)))
+        swrConfig_VIDEO_MODEL_DETAIL = model_detail;
+}
+
+// Player: joystick basics. Per-axis sensitivity / invert live in the swrControl
+// axis registrations, not single globals, so they're not exposed here.
+static void panel_controls() {
+    bool joy = swrConfig_joystick_enabled != 0;
+    if (ImGui::Checkbox("Joystick enabled", &joy))
+        swrConfig_joystick_enabled = joy;
+
+    ImGui::SliderFloat("Joystick deadzone", &Deadzone, 0.0f, 1.0f, "%.2f");
+    ImGui::TextDisabled("(per-axis sensitivity / invert not exposed here)");
 }
 
 // Cheats. The toggles are held in these flags; apply_cheats() enforces them every
@@ -970,6 +1014,10 @@ static DebugPanel g_panel_race = {
     .category = "Race", .name = "Quick Race", .draw = panel_race, .dev_only = false};
 static DebugPanel g_panel_audio = {
     .category = "Settings", .name = "Audio", .draw = panel_audio, .dev_only = false};
+static DebugPanel g_panel_video = {
+    .category = "Settings", .name = "Video", .draw = panel_video, .dev_only = false};
+static DebugPanel g_panel_controls = {
+    .category = "Settings", .name = "Controls", .draw = panel_controls, .dev_only = false};
 static DebugPanel g_panel_cheats = {
     .category = "Cheats", .name = "Cheats", .draw = panel_cheats, .dev_only = false};
 static DebugPanel g_panel_render_debug = {
@@ -989,6 +1037,8 @@ static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_hd_models);
     debug_ui_register(&g_panel_race);
     debug_ui_register(&g_panel_audio);
+    debug_ui_register(&g_panel_video);
+    debug_ui_register(&g_panel_controls);
     debug_ui_register(&g_panel_cheats);
     debug_ui_register(&g_panel_render_debug);
     debug_ui_register(&g_panel_scene_inspector);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -114,7 +114,7 @@ void read_settings_ini() {
         GetPrivateProfileIntW(L"settings", L"show_fps_overlay", 0, ini_path.c_str());
 
     imgui_state.show_fps_graph =
-        GetPrivateProfileIntW(L"settings", L"show_fps_graph", 1, ini_path.c_str());
+        GetPrivateProfileIntW(L"settings", L"show_fps_graph", 0, ini_path.c_str());
 
     imgui_state.enable_fog = GetPrivateProfileIntW(L"settings", L"enable_fog", 1, ini_path.c_str());
 

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -410,9 +410,10 @@ struct DebugLog {
         }
     }
 
-    // Render the toolbar + scrolling region into the current window. The debug-ui
-    // shell owns the Begin/End and the window's default size (see panel_hook_log).
-    void DrawBody() {
+    // Render the toolbar + scrolling region into the current window. child_height
+    // bounds the scroll region (0 = fill remaining space); the debug-ui shell
+    // renders this inside the Hook Log accordion section (see panel_hook_log).
+    void DrawBody(float child_height) {
         if (ImGui::BeginPopup("Options")) {
             ImGui::Checkbox("Auto-scroll", &AutoScroll);
             ImGui::EndPopup();
@@ -429,7 +430,7 @@ struct DebugLog {
 
         ImGui::Separator();
 
-        if (ImGui::BeginChild("scrolling", ImVec2(0, 0), ImGuiChildFlags_None,
+        if (ImGui::BeginChild("scrolling", ImVec2(0, child_height), ImGuiChildFlags_None,
                               ImGuiWindowFlags_HorizontalScrollbar)) {
             if (clear)
                 Clear();
@@ -779,10 +780,10 @@ static void panel_pod_transforms() {
     }
 }
 
-// Dev: live tail of the mod's hook.log (pumped only while this panel is open).
+// Dev: live tail of the mod's hook.log (pumped only while this section is open).
 static void panel_hook_log() {
     pump_hook_log();
-    g_debug_log.DrawBody();
+    g_debug_log.DrawBody(320.0f);
 }
 
 static DebugPanel g_panel_graphics_settings = {
@@ -800,8 +801,7 @@ static DebugPanel g_panel_pod_transforms = {
     .category = "Inspect", .name = "Pod Transforms", .draw = panel_pod_transforms,
     .dev_only = true};
 static DebugPanel g_panel_hook_log = {
-    .category = "Tools", .name = "Hook Log", .draw = panel_hook_log, .dev_only = true,
-    .default_w = 700, .default_h = 400};
+    .category = "Tools", .name = "Hook Log", .draw = panel_hook_log, .dev_only = true};
 
 static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_graphics_settings);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <macros.h>
 #include <Swr/swrModel.h>
 #include <Swr/swrRace.h>
+#include <Swr/swrSound.h>
 }
 
 extern rdVector3 debugCameraPos;
@@ -824,7 +825,8 @@ static void panel_pod_readout() {
 // Player: quick race-setup knobs. AI count is a global consumed at the next race
 // start; the rest live on the hangar state and only apply in the front-end menu.
 static void panel_race() {
-    ImGui::SliderInt("AI racers (next race)", &nb_AI_racers, 1, 20);
+    ImGui::SliderInt("AI racers", &nb_AI_racers, 1, 20);
+    ImGui::TextDisabled("(applies to a race started from the menu, not an in-race Restart)");
 
     swrObjHang *hang = g_objHang2;
     if (hang == nullptr) {
@@ -851,10 +853,15 @@ static void panel_race() {
         hang->WinningsID = (char) (winnings + 1);
 }
 
-// Player: audio toggles backed by the game's sound globals. Most apply to sounds
-// started after the change.
+// Player: audio controls. Master volume drives the A3D device output gain (the
+// one knob that scales every channel); music uses the fade state machine so the
+// toggle stops/starts playback live, not just on the next track change.
 static void panel_audio() {
-    ImGui::SliderFloat("Master volume", &Main_sound_gain, 0.0f, 2.0f, "%.2f");
+    static float master = -1.0f;
+    if (master < 0.0f)
+        master = a3dOutputGain > 0.0f ? a3dOutputGain : Main_sound_gain_const;
+    if (ImGui::SliderFloat("Master volume", &master, 0.0f, 1.0f, "%.2f"))
+        swrSound_SetOutputGain(master);
 
     bool sound_3d = Sound_enabled_3d != 0;
     if (ImGui::Checkbox("3D sound", &sound_3d))
@@ -863,8 +870,10 @@ static void panel_audio() {
     if (ImGui::Checkbox("Doppler", &doppler))
         Main_doppler_sound = doppler;
     bool music = swrRace_music_enabled != 0;
-    if (ImGui::Checkbox("Music", &music))
+    if (ImGui::Checkbox("Music", &music)) {
         swrRace_music_enabled = music;
+        swrSound_SetMusicFade(music ? 1 : 0);// 1 = arm/resume, 0 = stop now
+    }
     bool voices = swrRace_voices_enabled != 0;
     if (ImGui::Checkbox("In-race voices", &voices))
         swrRace_voices_enabled = voices;
@@ -879,18 +888,28 @@ static bool g_cheat_no_fall = false;
 static bool g_cheat_fly = false;
 
 static void apply_cheats() {
+    // engineTemp is a 0..100 "coolness" gauge: it drains while boosting and the
+    // engine blows when it hits 0, so "no overheat" means pinning it full, not 0.
+    static bool prev_fly = false;
+
     swrRace_IsInvincible = g_cheat_god ? 1 : 0;
     swr_FastMode = g_cheat_fast ? 1 : 0;
 
     swrRace *pod = currentPlayer_Test;
     if (pod != nullptr) {
         if (g_cheat_no_overheat)
-            pod->engineTemp = 0.0f;
+            pod->engineTemp = 100.0f;
         if (g_cheat_no_fall)
             pod->fallTimer = 0.0f;
         if (g_cheat_fly)
             pod->flags0 = (swrObjTest_FLAG0) (pod->flags0 | swrObjTest_FLAG0_ZON);
+        else if (prev_fly)
+            // Clear the bit once on untoggle; afterwards the game owns it again so
+            // we don't fight legitimate anti-grav track sections every frame.
+            pod->flags0 = (swrObjTest_FLAG0) (pod->flags0 & ~swrObjTest_FLAG0_ZON);
     }
+
+    prev_fly = g_cheat_fly;
 }
 
 static void panel_cheats() {

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -52,3 +52,6 @@ const wchar_t *settings_ini_path();
 
 void imgui_Update();
 void imgui_render_node(swrModel_Node *node);
+
+// Floating hook.log viewer; *p_open gates visibility (cleared by the window's [x]).
+void imgui_draw_log_window(bool *p_open);

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -34,7 +34,7 @@ typedef struct ImGuiState {
     bool cache_meshes = true;// cache per-mesh GL geometry; static meshes upload once, not every frame
     bool ai_full_lod = true;// force every racer (incl. AI) onto the full pod model (no LOD pop-in)
     bool show_fps_overlay = false;// pinned top-right FPS readout + frame-time graph
-    bool show_fps_graph = true;// graph beneath the FPS overlay number
+    bool show_fps_graph = false;// graph beneath the FPS overlay number (opt-in)
     bool show_pod_names = true;// draw the overhead racer labels (MP player names / SP place numbers)
 
     bool enable_picking_texture_when_hovering = false;

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -11,7 +11,6 @@ extern "C" {
 }
 
 typedef struct ImGuiState {
-    bool show_debug;
     bool draw_test_scene;
     bool draw_meshes;
     bool draw_renderList;
@@ -21,7 +20,6 @@ typedef struct ImGuiState {
     // Show dynamic replacements
     bool show_replacementTries;
     std::string replacementTries;
-    bool show_logs;
     bool debug_env_cubemap;
     bool HD_replacement;
     bool show_original_and_replacements;
@@ -48,6 +46,9 @@ extern ImGuiState imgui_state;
 const RdMaterial *material_from_texture_id(TEXID id);
 GLuint gl_texture_from_texture_id(TEXID id);
 
+// Absolute path to SW_RACER_RE.ini (next to the exe). Shared so the debug-ui
+// shell persists its panel state into the same file as the graphics settings.
+const wchar_t *settings_ini_path();
+
 void imgui_Update();
 void imgui_render_node(swrModel_Node *node);
-void opengl_render_imgui();

--- a/dinput_hook/renderer_hook.h
+++ b/dinput_hook/renderer_hook.h
@@ -11,5 +11,3 @@ extern GLuint default_framebuffer;
 extern "C" int stdDisplay_Update_Hook();
 
 extern "C" void init_renderer_hooks();
-
-void opengl_render_imgui();

--- a/dinput_hook/renderer_utils.cpp
+++ b/dinput_hook/renderer_utils.cpp
@@ -1548,7 +1548,7 @@ static void debug_scene_key_callback(GLFWwindow *window, int key, int scancode, 
         // the debug menu dropdown.
         set_window_mode(g_window_mode == WINDOW_MODE_FULLSCREEN ? WINDOW_MODE_WINDOWED
                                                                 : WINDOW_MODE_FULLSCREEN);
-        save_window_mode_setting();
+        persist_settings_ini();
         return;
     }
 


### PR DESCRIPTION

<img width="528" height="382" alt="image" src="https://github.com/user-attachments/assets/58b6133a-17cb-41e4-86e7-89d01533b39a" />

Reworks the F5 debug overlay from the single flat `opengl_render_imgui()` into a small
panel registry, then builds a bunch of player-facing tools on top. All in the `dinput_hook`
overlay layer -- no `src/` reimpl changes.

**Shell** (`debug_ui.{h,cpp}`): each subsystem registers a `DebugPanel`; the shell draws one
"SWE1R Debug" window of collapsing-header sections grouped by category, with a section filter,
expand/collapse-all, an FPS sparkline, and a Developer-mode toggle (dev sections hidden in
release). This kills the old "every feature splices the same two spots" merge-conflict problem.

**Sections**
- Render: graphics settings, HD models
- Quick Race: pod + track dropdowns, AI racers, laps, mirror, AI speed, winnings, and a
  "Restart race" button that applies them via the game's own reload (`swrObjJdge_Clear(jdge,'RStr')`,
  reached through `swrEvent_GetItem`) -- same approach annodue uses, no live entity surgery
- Settings: Audio (master via `swrSound_SetOutputGain`, SFX/music, 3D/doppler/voices, hi-res),
  Video (the native `swrConfig_VIDEO_*` flags), Controls (joystick enable + deadzone)
- Cheats: god / no-overheat / no-OOB / fly / fast, unlock-all, +truguts (applied every frame
  from `imgui_Update`)
- Inspect (dev): Scene, Textures, Pod Transforms, Pod Readout telemetry
- Tools: theme/opacity/demo/metrics; the hook log is back as its own toggleable window

HD-replacement and the F5 visibility flag now persist to `SW_RACER_RE.ini`.

Built + linked clean; playtested. Happy to split it up if you'd rather review the shell and the
features separately.