### PR TITLE
Resolution-independent + centered 2D UI

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1315,6 +1315,11 @@ rdMatrix44_unk9 0x00e2b440 rdMatrix44
 
 swrTextEntries1Colors 0x00e2b480 char[128][4]
 
+# per-entry text clip box (L/T/R/B, design space) + its enable flag, paralleling the other
+# swrTextEntries1* arrays; written by swrText_SetEntryClipRect, consumed by swrText_RenderEntries1.
+swrTextEntries1ClipRect 0x00e2b670 int[128][4]
+swrTextEntries1ClipEnabled 0x00e2be7c int[128]
+
 miniMapPositions 0x00E2C080 short[190][2]
 
 sithMulti_g_serverId 0x00ec7620 DPID

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -10,6 +10,8 @@ swrText_minTimedMessageDuration 0x004acd08 float
 
 swrObjJdge_maxRaceTime 0x004ad230 float # rank baseline for finished racers (sort key = maxRaceTime - total_time); ceiling above any real race time
 
+swrObjJdge_minimapAnchorX 0x004ad304 float # in-race minimap radar horizontal anchor (design space); swrObjJdge_DrawRaceHUD computes screen X = racerRelX - this, so the radar centers at -this
+
 swrObjJdge_notRacingZoneMinX 0x004ad464 float
 
 swrObjJdge_notRacingZoneMaxX 0x004ad468 float

--- a/dinput_hook/game_deltas/stdConsole_delta.cpp
+++ b/dinput_hook/game_deltas/stdConsole_delta.cpp
@@ -1,6 +1,7 @@
 #include "stdConsole_delta.h"
 
 #include "../imgui_utils.h"
+#include "../ui_transform.h"
 
 #include <imgui.h>
 #include <imgui_stdlib.h>
@@ -33,8 +34,20 @@ int stdConsole_GetCursorPos_delta(int *out_x, int *out_y) {
         double x, y;
         glfwGetCursorPos(window, &x, &y);
 
-        *out_x = x * 640 / w;
-        *out_y = y * 480 / h;
+        if (ui_enabled()) {
+            // Map window px -> framebuffer px (identity when they match), subtract the UI-centering
+            // offset (so hit-tests align with the shifted visuals), then invert the uniform draw
+            // scale so clicks land on the centered menu frames.
+            float fb_x = (float) x * (float) swrDisplay_screenWidth / (float) w;
+            float fb_y = (float) y * (float) swrDisplay_screenHeight / (float) h;
+            fb_x -= ui_center_offset_px();
+            UiVec2 d = ui_screen_to_design(UI_H_LEFT, UI_V_TOP, UiVec2{fb_x, fb_y});
+            *out_x = (int) d.x;
+            *out_y = (int) d.y;
+        } else {
+            *out_x = x * 640 / w;
+            *out_y = y * 480 / h;
+        }
         return 1;
     }
 
@@ -46,8 +59,20 @@ int stdConsole_GetCursorPos_delta(int *out_x, int *out_y) {
     } else {
         if (io.MouseDelta.x != 0 || io.MouseDelta.y != 0) {
             // mouse moved, update virtual mouse position
-            virtual_cursor_pos.x = (io.MousePos.x * 640) / io.DisplaySize.x;
-            virtual_cursor_pos.y = (io.MousePos.y * 480) / io.DisplaySize.y;
+            if (ui_enabled()) {
+                // Map window px -> framebuffer px (identity when they match), subtract the
+                // UI-centering offset (so hit-tests align with the shifted visuals), then invert the
+                // uniform draw scale so clicks land on the centered menu frames.
+                float fb_x = io.MousePos.x * (float) swrDisplay_screenWidth / io.DisplaySize.x;
+                float fb_y = io.MousePos.y * (float) swrDisplay_screenHeight / io.DisplaySize.y;
+                fb_x -= ui_center_offset_px();
+                UiVec2 d = ui_screen_to_design(UI_H_LEFT, UI_V_TOP, UiVec2{fb_x, fb_y});
+                virtual_cursor_pos.x = (LONG) d.x;
+                virtual_cursor_pos.y = (LONG) d.y;
+            } else {
+                virtual_cursor_pos.x = (io.MousePos.x * 640) / io.DisplaySize.x;
+                virtual_cursor_pos.y = (io.MousePos.y * 480) / io.DisplaySize.y;
+            }
         }
     }
 
@@ -68,7 +93,16 @@ void stdConsole_SetCursorPos_delta(int X, int Y) {
         if (w == 0 || h == 0)
             return;
 
-        glfwSetCursorPos(window, X * w / 640, Y * h / 480);
+        if (ui_enabled()) {
+            // design -> framebuffer px, add the UI-centering offset (inverse of GetCursorPos), then
+            // framebuffer -> window px (identity when they match).
+            UiVec2 fb = ui_design_to_screen(UI_H_LEFT, UI_V_TOP, UiVec2{(float) X, (float) Y});
+            fb.x += ui_center_offset_px();
+            glfwSetCursorPos(window, fb.x * w / swrDisplay_screenWidth,
+                             fb.y * h / swrDisplay_screenHeight);
+        } else {
+            glfwSetCursorPos(window, X * w / 640, Y * h / 480);
+        }
     }
 
     virtual_cursor_pos = POINT{X, Y};

--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -346,17 +346,17 @@ void swrText_CreateEntry2_delta(short x, short y, char r, char g, char b, char a
 }
 
 // 0x00450310
-// Parallel per-entry clip arrays, verified from the disassembly at 0x450310 (not yet named in
-// data_symbols.syms): clip L/T/R/B = int[4] at 0x00e2b670 + count*0x10; per-entry enable flag =
-// int at 0x00e2be7c + count*4; count = swrTextEntries1Count. The input rect[0..3] is a 640x480
+// Parallel per-entry clip arrays (verified from the disassembly at 0x450310, now named in
+// data_symbols.syms): swrTextEntries1ClipRect[count] = L/T/R/B, swrTextEntries1ClipEnabled[count]
+// = the per-entry enable flag; count = swrTextEntries1Count. The input rect[0..3] is a 640x480
 // design-space L/T/R/B.
 void swrText_SetEntryClipRect_delta(int *rect) {
     const int count = swrTextEntries1Count;
     if (count <= 0 || count >= 0x80 || rect == NULL)
         return;
 
-    int *clip = (int *) ((char *) 0x00e2b670 + (size_t) count * 0x10);
-    int *clip_enabled = (int *) 0x00e2be7c;
+    int *clip = swrTextEntries1ClipRect[count];
+    int *clip_enabled = swrTextEntries1ClipEnabled;
 
     int left, top, right, bottom;
     if (ui_enabled() && swrDisplay_screenWidth > 0 && swrDisplay_screenHeight > 0) {

--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <format>
 
@@ -13,12 +14,15 @@
 #include "../custom_tracks.h"
 #include "../nv_dds/nv_dds.h"
 #include "../imgui_utils.h"
+#include "../ui_transform.h"
 
 #include <regex>
 
 extern "C" {
 #include <Swr/swrModel.h>
 #include <Swr/swrSprite.h>
+#include <Swr/swrText.h>
+#include <Swr/swrUI.h>
 #include <Swr/swrLoader.h>
 #include <Swr/swrAssetBuffer.h>
 }
@@ -260,4 +264,134 @@ void swrModel_InitializeTextureBuffer_delta() {
     VirtualProtect(range_begin, range_end - range_begin, old_protect, &old_protect);
 
     swrLoader_CloseBlock(swrLoader_TYPE_TEXTURE_BLOCK);
+}
+
+// 0x0042c7a0
+void swrText_CreateTextEntry2_delta(int16_t screen_x, int16_t screen_y, char r, char g, char b,
+                                    char a, char *screenText) {
+    UiVec2 px = {(float) screen_x, (float) screen_y};
+    UiVec2 design = ui_project_px_to_design(px);
+    // Call the ORIGINAL (trampoline), NOT swrText_CreateTextEntry1 by name -- that resolves to the
+    // hooked EXE address and would recurse + apply the centering offset to this projected text.
+    hook_call_original(swrText_CreateTextEntry1, (int) lroundf(design.x), (int) lroundf(design.y), r,
+                       g, b, a, screenText);
+}
+
+// Menu-text scope: ui_menu_text_depth (shared, in ui_transform) is held > 0 while a swrUI / front-end
+// text path runs, so swrText_CreateTextEntry1_delta uses the widget (640) scale for menu text and the
+// HUD (320) scale for direct/in-race callers. Caller-based, not game-state-based: the pause menu
+// draws menu text mid-race and still needs the menu scale. (swrObjHang_F0 is flagged in its existing
+// delta in swrObjHang_delta.cpp, since that function is already hooked for the MP input fix.)
+typedef void (*swrUI_DrawText_t)(int, int, int, int, int, int, int, char *, int, int, int);
+typedef void (*swrUI_DrawTextAligned_t)(int, char *, short *, unsigned int, int, int, int, int, int,
+                                        int, int);
+
+// 0x004173c0
+void swrUI_DrawText_delta(int font, int x, int y, int color0, int color1, int color2, int color3,
+                          char *text, int unk9, int unk10, int disabled) {
+    ui_menu_text_depth++;
+    // swrUI_DrawText is prototype-only (no linkable body), so pass a function-pointer cast of its
+    // address to hook_call_original -- the hooks map is keyed by address, so this resolves the
+    // trampoline (the original) without needing the symbol.
+    hook_call_original((swrUI_DrawText_t) swrUI_DrawText_ADDR, font, x, y, color0, color1, color2,
+                       color3, text, unk9, unk10, disabled);
+    ui_menu_text_depth--;
+}
+
+// 0x00417540 -- swrUI_DrawTextAligned (screen titles like "SELECT VEHICLE", aligned/centered text).
+// Flags menu text the same way; it does not route through the hooked swrUI_DrawText, so it needs
+// its own wrapper. (ui_menu_text_depth is a counter, so nesting is safe.)
+void swrUI_DrawTextAligned_delta(int font, char *text, short *bbox, unsigned int alignFlags,
+                                 int color0, int color1, int color2, int color3, int unk9, int unk10,
+                                 int unk11) {
+    ui_menu_text_depth++;
+    hook_call_original((swrUI_DrawTextAligned_t) swrUI_DrawTextAligned_ADDR, font, text, bbox,
+                       alignFlags, color0, color1, color2, color3, unk9, unk10, unk11);
+    ui_menu_text_depth--;
+}
+
+// Shared X-centering shift for every entries1 (menu/HUD) text string, whichever wrapper emitted it:
+// swrText_CreateTextEntry1, swrText_CreateColorlessEntry1, and swrText_CreateColorlessFormattedEntry1
+// all sink into swrText_CreateEntry. Menu text (inside a swrUI_DrawText scope) lives in the 640
+// widget space (ui_layout_scale); all other text in the ~320 draw space (ui_sprite_scale). Match the
+// divisor to the text's space so it shifts the same px as its sibling sprites. Returns x unchanged
+// when centering is off (ui_center_offset_px() is 0).
+static int ui_center_text_x(int x) {
+    float s = ui_menu_text_depth ? ui_layout_scale() : ui_sprite_scale();
+    if (s > 0.0f)
+        x += (int) lroundf(ui_center_offset_px() / s);
+    return x;
+}
+
+// 0x00450530
+void swrText_CreateTextEntry1_delta(int x, int y, int r, int g, int b, int a, char *screenText) {
+    // Center the 2D UI by shifting the text origin right (see ui_center_text_x). Call the ORIGINAL
+    // via the trampoline; calling swrText_CreateTextEntry1 by name would re-enter this same hook (the
+    // symbol resolves to the hooked EXE address) -> infinite recursion. swrText_CreateTextEntry2_delta
+    // calls the DLL copy (not this hook), keeping projected text world-locked.
+    hook_call_original(swrText_CreateTextEntry1, ui_center_text_x(x), y, r, g, b, a, screenText);
+}
+
+// 0x00450560 -- swrText_CreateColorlessEntry1 and 0x00450590 -- swrText_CreateColorlessFormattedEntry1.
+// Sibling wrappers that call swrText_CreateEntry DIRECTLY (NOT via swrText_CreateTextEntry1), so the
+// CreateTextEntry1 hook never sees them. The hangar screen TITLES ("SELECT VEHICLE" in
+// swrRace_SelectVehicle, "MAIN MENU" in swrRace_MainMenu) are drawn through CreateColorlessEntry1 at
+// x=0xa0; without these hooks the titles miss the centering offset and sit left of the pillarboxed
+// UI. Apply the same shift as CreateTextEntry1.
+void swrText_CreateColorlessEntry1_delta(short x, short y, char *screenText) {
+    hook_call_original(swrText_CreateColorlessEntry1, (short) ui_center_text_x(x), y, screenText);
+}
+
+void swrText_CreateColorlessFormattedEntry1_delta(int formatInt, short x, short y, char *screenText) {
+    hook_call_original(swrText_CreateColorlessFormattedEntry1, formatInt, (short) ui_center_text_x(x),
+                       y, screenText);
+}
+
+// 0x004505c0 -- swrText_CreateEntry2. Writes the entries2 buffer (drawn by swrText_RenderEntries2 at
+// the same recip scale as entries1). Its ONLY caller is the in-race pause menu, which draws the
+// option text through this at x=0xa0; the projected distance/name labels use the unrelated
+// swrText_CreateTextEntry2 (0x42c7a0), which routes through entries1, so offsetting entries2 here
+// shifts only the pause options. Same centering as CreateTextEntry1.
+void swrText_CreateEntry2_delta(short x, short y, char r, char g, char b, char a, char *screenText) {
+    hook_call_original(swrText_CreateEntry2, (short) ui_center_text_x(x), y, r, g, b, a, screenText);
+}
+
+// 0x00450310
+// Parallel per-entry clip arrays, verified from the disassembly at 0x450310 (not yet named in
+// data_symbols.syms): clip L/T/R/B = int[4] at 0x00e2b670 + count*0x10; per-entry enable flag =
+// int at 0x00e2be7c + count*4; count = swrTextEntries1Count. The input rect[0..3] is a 640x480
+// design-space L/T/R/B.
+void swrText_SetEntryClipRect_delta(int *rect) {
+    const int count = swrTextEntries1Count;
+    if (count <= 0 || count >= 0x80 || rect == NULL)
+        return;
+
+    int *clip = (int *) ((char *) 0x00e2b670 + (size_t) count * 0x10);
+    int *clip_enabled = (int *) 0x00e2be7c;
+
+    int left, top, right, bottom;
+    if (ui_enabled() && swrDisplay_screenWidth > 0 && swrDisplay_screenHeight > 0) {
+        // Uniform 640-space scale on all four edges so the clip box matches the now-uniform text
+        // (and scales with the ui_scale slider). clipY already used screen_height/480 in vanilla;
+        // only clipX changes (was the stretched screen_width/640). The centering offset shifts the
+        // box's X edges right by the same amount the text moved, so clipped text stays inside it.
+        float s = ui_layout_scale();
+        float off = ui_center_offset_px();
+        left = (int) ((float) rect[0] * s + off);
+        top = (int) ((float) rect[1] * s);
+        right = (int) ((float) rect[2] * s + off);
+        bottom = (int) ((float) rect[3] * s);
+    } else {
+        // Vanilla: L/R * screen_width/640, T/B * screen_height/480 (integer, truncated toward zero).
+        left = (int) ((int64_t) rect[0] * swrDisplay_screenWidth / 640);
+        top = (int) ((int64_t) rect[1] * swrDisplay_screenHeight / 480);
+        right = (int) ((int64_t) rect[2] * swrDisplay_screenWidth / 640);
+        bottom = (int) ((int64_t) rect[3] * swrDisplay_screenHeight / 480);
+    }
+
+    clip_enabled[count] = 1;
+    clip[0] = left;
+    clip[1] = top;
+    clip[2] = right;
+    clip[3] = bottom;
 }

--- a/dinput_hook/game_deltas/swrModel_delta.h
+++ b/dinput_hook/game_deltas/swrModel_delta.h
@@ -7,3 +7,50 @@ void swrModel_LoadFonts_delta(void);
 swrModel_Header *swrModel_LoadFromId_delta(MODELID id);
 
 void swrModel_InitializeTextureBuffer_delta();
+
+// 0x0042c7a0 -- swrText_CreateTextEntry2. The projected-TEXT seam (the only caller is
+// swrPlayerHUD_RenderDistanceText: opponent distance / name labels). Mirrors swrSprite_SetPosF:
+// normalizes a framebuffer-pixel coordinate into design space (pixel/screen * design) before
+// swrText_CreateTextEntry1, which the text draw later scales back up. Routes through
+// ui_project_px_to_design so projected text tracks its true pixel when the toggle is on.
+void swrText_CreateTextEntry2_delta(int16_t screen_x, int16_t screen_y, char r, char g, char b,
+                                    char a, char *screenText);
+
+// 0x00450310 -- swrText_SetEntryClipRect. Per-text-entry scissor rect (used by swrUI_DrawText for
+// e.g. the scrolling profile list). The vanilla X mapping uses the stretched screen_width/640 while
+// res-independent text now draws uniform, so clipped text fell left of the clip box and vanished.
+// When the toggle is on, scales all four edges by the uniform ui_layout_scale so the box tracks the
+// text; otherwise reproduces vanilla exactly.
+void swrText_SetEntryClipRect_delta(int *rect);
+
+// 0x00450530 -- swrText_CreateTextEntry1. The chokepoint every menu/HUD text string flows through
+// (swrUI_DrawText, swrObj HUD). When centering is active, shifts the text origin right by the
+// UI-centering offset (design units). Projected text reaches CreateTextEntry1 via the DLL-internal
+// copy (called from swrText_CreateTextEntry2_delta), not this EXE hook, so it is not centered.
+void swrText_CreateTextEntry1_delta(int x, int y, int r, int g, int b, int a, char *screenText);
+
+// 0x004173c0 -- swrUI_DrawText. Wraps the original to flag "menu text in progress" so the
+// CreateTextEntry1 hook can scale the centering offset by the widget space (vs the HUD space for
+// direct callers). swrUI_DrawTextAligned routes through this too.
+void swrUI_DrawText_delta(int font, int x, int y, int color0, int color1, int color2, int color3,
+                          char *text, int unk9, int unk10, int disabled);
+
+// 0x00417540 -- swrUI_DrawTextAligned. Same menu-text flagging as swrUI_DrawText, for aligned/
+// centered swrUI widget text that does not route through swrUI_DrawText. (The hangar titles "SELECT
+// VEHICLE" / "MAIN MENU" are NOT drawn here -- they go through swrText_CreateColorlessEntry1 below.)
+void swrUI_DrawTextAligned_delta(int font, char *text, short *bbox, unsigned int alignFlags,
+                                 int color0, int color1, int color2, int color3, int unk9, int unk10,
+                                 int unk11);
+
+// 0x00450560 -- swrText_CreateColorlessEntry1 / 0x00450590 -- swrText_CreateColorlessFormattedEntry1.
+// Sibling text-entry wrappers that sink into swrText_CreateEntry without passing through
+// swrText_CreateTextEntry1, so they need their own centering hooks. Used for the hangar screen titles
+// ("SELECT VEHICLE", "MAIN MENU"); apply the same UI-centering X shift as CreateTextEntry1.
+void swrText_CreateColorlessEntry1_delta(short x, short y, char *screenText);
+void swrText_CreateColorlessFormattedEntry1_delta(int formatInt, short x, short y, char *screenText);
+
+// 0x004505c0 -- swrText_CreateEntry2. The entries2-buffer sink; its only caller is the in-race pause
+// menu (swrRace_UpdateInRaceMenu's option text). Apply the same UI-centering X shift as the entries1
+// wrappers. (Projected text uses swrText_CreateTextEntry2 (0x42c7a0), a different function.)
+void swrText_CreateEntry2_delta(short x, short y, char r, char g, char b, char a, char *screenText);
+

--- a/dinput_hook/game_deltas/swrSprite_delta.cpp
+++ b/dinput_hook/game_deltas/swrSprite_delta.cpp
@@ -1,0 +1,166 @@
+#include "swrSprite_delta.h"
+
+#include "../ui_transform.h"
+#include "../hook_helper.h"
+
+extern "C" {
+#include <Swr/swrSprite.h>
+#include <Swr/swrUI.h>
+}
+
+#include <globals.h>
+#include <windows.h>
+
+#include <cmath>
+
+// The text glyph scale lives in rdProcEntry_Add2DQuad2 as screen_dim * swrText_design{Width,Height}
+// Recip (read-only .rdata doubles, one per axis). Menu TEXT therefore stretches independently of the
+// sprite/frame scale. To make text un-stretch AND track the UI-scale slider, patch BOTH recips so
+// each product equals ui_sprite_scale() (which already folds in ui_scale); restore the originals
+// when disabled. Patching only X (the earlier approach) left the vertical scale stuck on vanilla, so
+// the slider visibly changed text width but not height. Writing .rdata needs VirtualProtect (a raw
+// write crashes).
+static double g_orig_text_recipX = 0.0;
+static double g_orig_text_recipY = 0.0;
+static int g_text_recip_saved = 0;
+
+static void ui_patch_recip(double *recip, double target) {
+    if (*recip == target)
+        return;
+    DWORD old_protect;
+    if (VirtualProtect((void *) recip, sizeof(double), PAGE_READWRITE, &old_protect)) {
+        *recip = target;
+        VirtualProtect((void *) recip, sizeof(double), old_protect, &old_protect);
+    }
+}
+
+static void ui_apply_text_recip(int enabled) {
+    if (!g_text_recip_saved) {
+        g_orig_text_recipX = swrText_designWidthRecip;
+        g_orig_text_recipY = swrText_designHeightRecip;
+        g_text_recip_saved = 1;
+    }
+    double targetX = g_orig_text_recipX;
+    double targetY = g_orig_text_recipY;
+    if (enabled && swrDisplay_screenWidth > 0 && swrDisplay_screenHeight > 0) {
+        // Both axes draw at the uniform ui_sprite_scale, so text reaches full size, stays square,
+        // and scales with the ui_scale slider on both axes.
+        targetX = (double) ui_sprite_scale() / (double) swrDisplay_screenWidth;
+        targetY = (double) ui_sprite_scale() / (double) swrDisplay_screenHeight;
+    }
+    ui_patch_recip(&swrText_designWidthRecip, targetX);
+    ui_patch_recip(&swrText_designHeightRecip, targetY);
+}
+
+// The in-race minimap radar is positioned around a design-space anchor constant (swrObjJdge_minimapAnchorX),
+// read ONLY by swrObjJdge_DrawRaceHUD (screen X = racerRelX - anchor, so the radar centers at -anchor).
+// Detouring the minimap draw to shift the dots corrupts the radar (RenderMiniMapDotsAndCrosses has a
+// non-standard calling convention), so instead shift the anchor itself: the game then computes AND
+// draws the dots at the centered position through its own un-hooked path. Same .rdata VirtualProtect
+// pattern as the text recip; the radar draws at ui_sprite_scale (the patched text recip), so the
+// design shift is the px offset / that scale. Decreasing the anchor moves the radar right (center =
+// -anchor). Restore the original when disabled.
+static float g_orig_minimap_anchor_x = 0.0f;
+static int g_minimap_anchor_saved = 0;
+
+static void ui_apply_radar_center(int enabled) {
+    if (!g_minimap_anchor_saved) {
+        g_orig_minimap_anchor_x = swrObjJdge_minimapAnchorX;
+        g_minimap_anchor_saved = 1;
+    }
+    float target = g_orig_minimap_anchor_x;
+    if (enabled) {
+        float s = ui_sprite_scale();
+        if (s > 0.0f)
+            target = g_orig_minimap_anchor_x - ui_center_offset_px() / s;
+    }
+    if (swrObjJdge_minimapAnchorX != target) {
+        DWORD old_protect;
+        if (VirtualProtect(&swrObjJdge_minimapAnchorX, sizeof(float), PAGE_READWRITE, &old_protect)) {
+            swrObjJdge_minimapAnchorX = target;
+            VirtualProtect(&swrObjJdge_minimapAnchorX, sizeof(float), old_protect, &old_protect);
+        }
+    }
+}
+
+// 0x0044f640
+void swrSprite_GetUIScale_delta(float *out_xscale, float *out_yscale) {
+    ui_apply_text_recip(ui_enabled());
+    ui_apply_radar_center(ui_enabled());
+    if (!ui_enabled()) {
+        // Vanilla: X and Y scale independently to fill the framebuffer (the 4:3 stretch).
+        *out_xscale = (float) ((double) swrDisplay_screenWidth * swrUI_designWidthRecip);
+        *out_yscale = (float) ((double) swrDisplay_screenHeight * swrUI_designHeightRecip);
+        return;
+    }
+    // Uniform sprite draw scale (the engine's own recip-defined space, ~2x the widget/cursor
+    // scale). Pairs with the text recip patch above and the cursor remap in stdConsole_delta.
+    float s = ui_sprite_scale();
+    *out_xscale = s;
+    *out_yscale = s;
+}
+
+// 0x0042bb00
+void swrSprite_SetPosF_delta(short id, short x, short y) {
+    UiVec2 px = {(float) x, (float) y};
+    UiVec2 design = ui_project_px_to_design(px);
+    // Call the ORIGINAL (trampoline), NOT swrSprite_SetPos by name -- that resolves to the hooked
+    // EXE address and would (a) infinitely recurse and (b) apply the centering offset, which would
+    // wrongly shift these projected/world sprites. The original keeps them world-locked.
+    hook_call_original(swrSprite_SetPos, id, (short) lroundf(design.x), (short) lroundf(design.y));
+}
+
+// The 2D UI has TWO design spaces and sprites live in both, split by the DRAW CALLER (not the
+// texture source): sprites emitted by the swrUI front-end element tree (menu chrome, backgrounds,
+// buttons) are 640x480 and draw at ui_layout_scale (~2.869); sprites set by direct callers (in-race
+// HUD, hangar pod/decorations) are 320x240 and draw at ui_sprite_scale (~5.738, 2x). The centering
+// offset must divide by the matching scale or one group shifts 2x the other. We detect "element-
+// tree sprite" by wrapping swrUI_RenderElementSprites and flagging the SetPos calls it makes.
+typedef void (*swrUI_RenderElementSprites_t)(void *);
+static int g_in_element_render = 0;
+
+// 0x004151f0
+void swrUI_RenderElementSprites_delta(void *ui) {
+    g_in_element_render++;
+    hook_call_original((swrUI_RenderElementSprites_t) swrUI_RenderElementSprites_ADDR, ui);
+    g_in_element_render--;
+}
+
+// A sprite is in the 640-design widget space (ui_layout_scale) if EITHER it is emitted by the swrUI
+// element tree (buttons, menu chrome -- caught by g_in_element_render) OR it is a loose-TGA/HD
+// sprite (menu backgrounds + logos, which are set by direct callers but authored at 640). Everything
+// else (out_spriteblock HUD + hangar in-game sprites, set by direct callers at 320) uses the
+// ui_sprite_scale space. Resolve the sprite's texture pointer back to swrSpriteTexIsTGA.
+static int swrSpriteTex_is_tga(const swrSpriteTexture *tex) {
+    if (tex == NULL)
+        return 0;
+    for (int i = 0; i < 149; i++) {
+        if (swrSpriteTexItems[i].texture == tex)
+            return swrSpriteTexIsTGA[i];
+    }
+    return 0;
+}
+
+static int swrSprite_id_is_tga(short id) {
+    if (id < 0 || id >= 251)
+        return 0;
+    return swrSpriteTex_is_tga(swrSprite_array[id].texture);
+}
+
+// 0x00428660
+void swrSprite_SetPos_delta(short id, short x, short y) {
+    // Center the 2D UI: shift sprites right by the centering offset, dividing by the sprite's own
+    // position scale -- 640-design (element-tree OR TGA) -> ui_layout_scale, else (direct/HUD/game,
+    // 320-design) -> ui_sprite_scale. Negative special ids (cursor) are left alone; projected sprites
+    // bypass this via swrSprite_SetPosF_delta's trampoline call. The matching TEXT split lives in
+    // swrText_CreateTextEntry1_delta. ui_center_offset_px() is 0 when the toggle is off.
+    if (id >= 0) {
+        bool widget_space = g_in_element_render || swrSprite_id_is_tga(id);
+        float s = widget_space ? ui_layout_scale() : ui_sprite_scale();
+        if (s > 0.0f)
+            x = (short) (x + lroundf(ui_center_offset_px() / s));
+    }
+    // Call the ORIGINAL via the trampoline; calling swrSprite_SetPos by name would re-enter this
+    // same hook (the symbol resolves to the hooked EXE address) -> infinite recursion.
+    hook_call_original(swrSprite_SetPos, id, x, y);
+}

--- a/dinput_hook/game_deltas/swrSprite_delta.h
+++ b/dinput_hook/game_deltas/swrSprite_delta.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// 0x0044f640 -- swrSprite_GetUIScale. When the resolution-independent toggle is on, returns one
+// uniform scale on both axes (no 4:3 stretch) for the swrSprite_array layer (menu frames via
+// swrUI_RenderElementSprites + the in-race HUD), and patches the text X reciprocal so menu TEXT
+// un-stretches to match the frames. Otherwise reproduces the vanilla stretch and restores the recip.
+void swrSprite_GetUIScale_delta(float *out_xscale, float *out_yscale);
+
+// 0x0042bb00 -- swrSprite_SetPosF. The seam that places every PROJECTED sprite (lens flares, light
+// streaks, world/target sprites, weather particles): it takes a framebuffer-pixel coordinate from
+// swrViewport_ProjectToScreen and normalizes it into design space (pixel/screen * design) for
+// swrSprite_SetPos; swrSprite_DrawSprites later scales it back up by GetUIScale. When the toggle is
+// on, the draw scale is uniform, so this re-derives the design coordinate via ui_project_px_to_design
+// to keep projected sprites on their true pixel across the full framebuffer. (The args are int16 in
+// the binary -- callers __ftol then push -- not the float the swrSprite.h prototype claims.)
+void swrSprite_SetPosF_delta(short id, short x, short y);
+
+// 0x00428660 -- swrSprite_SetPos. The single chokepoint every menu/HUD sprite position flows
+// through (swrUI_RenderElementSprites, the in-race HUD). When centering is active, shifts normal
+// sprites right by the UI-centering offset (in design units). Projected sprites reach SetPos via
+// the DLL-internal copy (called from swrSprite_SetPosF_delta), not this EXE hook, so they are not
+// centered. Negative special ids (e.g. the cursor sprite) keep their vanilla position.
+void swrSprite_SetPos_delta(short id, short x, short y);
+
+// 0x004151f0 -- swrUI_RenderElementSprites. Wraps the original to flag "emitting element-tree
+// sprites" so swrSprite_SetPos_delta scales the centering offset by the widget space (640) for menu
+// sprites, vs the HUD/game space (320) for direct SetPos callers.
+void swrUI_RenderElementSprites_delta(void *ui);
+
+#ifdef __cplusplus
+}
+#endif

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <cstdio>
 #include <cstring>
+#include <cwchar>
 
 #include <imgui.h>
 #include <imgui_stdlib.h>
@@ -15,6 +16,7 @@
 #include "replacements.h"
 #include "renderer_utils.h"
 #include "texture_replacement.h"
+#include "ui_transform.h"
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
 #include "game_deltas/window_mode.h"
@@ -86,6 +88,13 @@ void read_settings_ini() {
         GetPrivateProfileIntW(L"settings", L"ai_full_lod", 1, ini_path.c_str());
     set_ai_full_lod(imgui_state.ai_full_lod);
 
+    imgui_state.ui_resolution_independent =
+        GetPrivateProfileIntW(L"settings", L"ui_resolution_independent", 0, ini_path.c_str()) != 0;
+    wchar_t ui_scale_buf[32] = {0};
+    GetPrivateProfileStringW(L"settings", L"ui_scale", L"1.0", ui_scale_buf, 32, ini_path.c_str());
+    float ui_scale = (float) wcstod(ui_scale_buf, nullptr);
+    imgui_state.ui_scale = (ui_scale >= 0.5f && ui_scale <= 2.0f) ? ui_scale : 1.0f;
+
     g_window_mode =
         GetPrivateProfileIntW(L"settings", L"window_mode", WINDOW_MODE_WINDOWED, ini_path.c_str());
     if (g_window_mode < WINDOW_MODE_WINDOWED || g_window_mode > WINDOW_MODE_FULLSCREEN)
@@ -108,6 +117,12 @@ void save_settings_ini() {
 
     WritePrivateProfileStringW(L"settings", L"window_mode", std::to_wstring(g_window_mode).c_str(),
                                ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"ui_resolution_independent",
+                               imgui_state.ui_resolution_independent ? L"1" : L"0",
+                               ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"ui_scale",
+                               std::to_wstring(imgui_state.ui_scale).c_str(), ini_path.c_str());
 }
 
 // Called from the (C) window key callbacks so Alt+Enter persists the chosen mode too.
@@ -534,6 +549,29 @@ void opengl_render_imgui() {
 
         if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
             set_ai_full_lod(imgui_state.ai_full_lod);
+        }
+
+        if (ImGui::Checkbox("Resolution-independent UI (experimental)",
+                            &imgui_state.ui_resolution_independent)) {
+            save_settings_ini();
+        }
+        if (ImGui::SliderFloat("UI scale", &imgui_state.ui_scale, 0.5f, 2.0f, "%.2f")) {
+            save_settings_ini();
+        }
+        if (imgui_state.ui_resolution_independent) {
+            const ImGuiIO &io = ImGui::GetIO();
+            // Live per-domain scales: sprite scale = what GetUIScale_delta returns;
+            // text X/Y = the Add2DQuad2 scale (screen dim * recip) after the recip patch. All three
+            // should read equal when uniform; any divergence localizes the remaining stretch.
+            const float text_x = (float) ((double) swrDisplay_screenWidth * swrText_designWidthRecip);
+            const float text_y =
+                (float) ((double) swrDisplay_screenHeight * swrText_designHeightRecip);
+            const float spr_x = (float) ((double) swrDisplay_screenWidth * swrUI_designWidthRecip);
+            const float spr_y = (float) ((double) swrDisplay_screenHeight * swrUI_designHeightRecip);
+            ImGui::Text("swrDisplay %dx%d | imgui %.0fx%.0f", swrDisplay_screenWidth,
+                        swrDisplay_screenHeight, io.DisplaySize.x, io.DisplaySize.y);
+            ImGui::Text("widget %.3f | sprite %.3f | spriteRecip %.3f x %.3f | text %.3f x %.3f",
+                        ui_layout_scale(), ui_sprite_scale(), spr_x, spr_y, text_x, text_y);
         }
 
         static const char *window_mode_items[] = {"Windowed", "Borderless", "Fullscreen"};

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -37,6 +37,12 @@ typedef struct ImGuiState {
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;
     std::optional<TEXID> picked_texture_id;
+
+    // Resolution-independent 2D UI. When false, every 2D
+    // consumer reproduces vanilla behavior; the shared transform is inert.
+    bool ui_resolution_independent = false;
+    // User UI-scale slider; multiplies ui_layout_scale(). 1.0 == no change.
+    float ui_scale = 1.0f;
 } ImGuiState;
 
 extern "C" {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -25,6 +25,7 @@ extern "C" {
 }
 
 #include "./game_deltas/stdConsole_delta.h"
+#include "./game_deltas/swrSprite_delta.h"
 #include "./game_deltas/swrModel_delta.h"
 #include "./game_deltas/swrSpline_delta.h"
 #include "./game_deltas/swrObjJdge_delta.h"
@@ -1173,6 +1174,52 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) stdConsole_GetCursorPos_delta);
     hook_function("stdConsole_SetCursorPos", (uint32_t) 0x00408360,
                   (uint8_t *) stdConsole_SetCursorPos_delta);
+
+    // 2D UI resolution-independent transform (gated by imgui_state.ui_resolution_independent).
+    // Pairs the swrSprite_array/menu-frame scale + the text recip with the cursor remap below.
+    hook_function("swrSprite_GetUIScale", (uint32_t) swrSprite_GetUIScale_ADDR,
+                  (uint8_t *) swrSprite_GetUIScale_delta);
+    // Projected-element seams: re-derive the design coordinate for sprites/text that
+    // swrViewport_ProjectToScreen places by framebuffer pixel (lens flares, light streaks, world
+    // sprites, weather, distance/name HUD text) so they track their true pixel under the uniform
+    // sprite scale instead of squishing to the letterboxed UI width.
+    hook_function("swrSprite_SetPosF", (uint32_t) swrSprite_SetPosF_ADDR,
+                  (uint8_t *) swrSprite_SetPosF_delta);
+    hook_function("swrText_CreateTextEntry2", (uint32_t) swrText_CreateTextEntry2_ADDR,
+                  (uint8_t *) swrText_CreateTextEntry2_delta);
+    // Per-entry text clip rect: un-stretch the X edges so clipped menu text (e.g. the profile list)
+    // stays inside its now-uniform clip box instead of falling left of it.
+    hook_function("swrText_SetEntryClipRect", (uint32_t) swrText_SetEntryClipRect_ADDR,
+                  (uint8_t *) swrText_SetEntryClipRect_delta);
+    // UI centering: shift every menu/HUD sprite + text string right by the centering offset so the
+    // uniform-width UI box is pillarboxed in the window. The game's own SetPos/CreateTextEntry1
+    // callers hit these EXE hooks; the projected seams call the DLL copies, so world elements stay
+    // put. The cursor remap subtracts the same offset to keep hit-tests aligned.
+    hook_function("swrSprite_SetPos", (uint32_t) swrSprite_SetPos_ADDR,
+                  (uint8_t *) swrSprite_SetPos_delta);
+    hook_function("swrText_CreateTextEntry1", (uint32_t) swrText_CreateTextEntry1_ADDR,
+                  (uint8_t *) swrText_CreateTextEntry1_delta);
+    // Sibling text-entry wrappers that bypass CreateTextEntry1 (they call swrText_CreateEntry
+    // directly): the hangar titles "SELECT VEHICLE" / "MAIN MENU" draw through CreateColorlessEntry1,
+    // so they need their own centering hooks or they sit left of the pillarboxed UI.
+    hook_function("swrText_CreateColorlessEntry1", (uint32_t) swrText_CreateColorlessEntry1_ADDR,
+                  (uint8_t *) swrText_CreateColorlessEntry1_delta);
+    hook_function("swrText_CreateColorlessFormattedEntry1",
+                  (uint32_t) swrText_CreateColorlessFormattedEntry1_ADDR,
+                  (uint8_t *) swrText_CreateColorlessFormattedEntry1_delta);
+    // The in-race pause menu draws its option text through swrText_CreateEntry2 (the entries2
+    // buffer), which bypasses the CreateTextEntry1 chokepoint, so it needs its own centering hook.
+    hook_function("swrText_CreateEntry2", (uint32_t) swrText_CreateEntry2_ADDR,
+                  (uint8_t *) swrText_CreateEntry2_delta);
+    // Flags menu-vs-HUD content so the centering offset uses the widget scale (640) for front-end
+    // UI and the HUD/game scale (320) for direct callers. swrUI_RenderElementSprites scopes element-
+    // tree SPRITES; swrUI_DrawText/Aligned scope menu TEXT.
+    hook_function("swrUI_RenderElementSprites", (uint32_t) swrUI_RenderElementSprites_ADDR,
+                  (uint8_t *) swrUI_RenderElementSprites_delta);
+    hook_function("swrUI_DrawText", (uint32_t) swrUI_DrawText_ADDR,
+                  (uint8_t *) swrUI_DrawText_delta);
+    hook_function("swrUI_DrawTextAligned", (uint32_t) swrUI_DrawTextAligned_ADDR,
+                  (uint8_t *) swrUI_DrawTextAligned_delta);
 
     // stdDisplay
     hook_function("stdDisplay_Startup", (uint32_t) 0x00487d20,

--- a/dinput_hook/ui_transform.cpp
+++ b/dinput_hook/ui_transform.cpp
@@ -1,0 +1,186 @@
+#include "ui_transform.h"
+
+#include "imgui_utils.h"
+
+#include <globals.h>
+
+int ui_menu_text_depth = 0;
+
+/* Layer/group transform stack. The composed top is what the emit applies; an
+ * empty stack reads as identity so menus (which push nothing) are unaffected.
+ * Each slot already stores its composition with the slot below, so
+ * ui_layer_current() is O(1). */
+enum {
+    UI_LAYER_STACK_MAX = 8,
+};
+static UiXform g_layer_stack[UI_LAYER_STACK_MAX];
+static int g_layer_depth = 0;
+
+UiXform ui_xform_identity(void) {
+    UiXform x = {1.0f, 0.0f, 0.0f};
+    return x;
+}
+
+UiXform ui_xform_compose(UiXform outer, UiXform inner) {
+    /* outer(inner(p)) = outer.scale*(inner.scale*p + inner.t) + outer.t */
+    UiXform r;
+    r.scale = outer.scale * inner.scale;
+    r.tx = outer.scale * inner.tx + outer.tx;
+    r.ty = outer.scale * inner.ty + outer.ty;
+    return r;
+}
+
+UiXform ui_xform_invert(UiXform x) {
+    UiXform r;
+    float s = (x.scale != 0.0f) ? x.scale : 1.0f;
+    r.scale = 1.0f / s;
+    r.tx = -x.tx / s;
+    r.ty = -x.ty / s;
+    return r;
+}
+
+UiVec2 ui_xform_apply(UiXform x, UiVec2 p) {
+    UiVec2 r;
+    r.x = x.scale * p.x + x.tx;
+    r.y = x.scale * p.y + x.ty;
+    return r;
+}
+
+float ui_layout_scale(void) {
+    float s = (float) swrDisplay_screenHeight / UI_DESIGN_H;
+    return s * imgui_state.ui_scale;
+}
+
+float ui_sprite_scale(void) {
+    // The sprite/text draw space is the engine's own recip-defined space (~320x240), NOT the
+    // 640x480 widget space. Its non-stretched axis is Y = screen_height * heightRecip; use that
+    // uniformly so sprites/text reach full size and align with the widget/hit space (which is
+    // ui_layout_scale, ~half of this). Derived from the recip, not a hardcoded design height.
+    return (float) ((double) swrDisplay_screenHeight * swrUI_designHeightRecip) * imgui_state.ui_scale;
+}
+
+static float anchor_screen_x(UiAnchorH h) {
+    switch (h) {
+    case UI_H_CENTER:
+        return (float) swrDisplay_screenWidth * 0.5f;
+    case UI_H_RIGHT:
+        return (float) swrDisplay_screenWidth;
+    default:
+        return 0.0f;
+    }
+}
+
+static float anchor_screen_y(UiAnchorV v) {
+    switch (v) {
+    case UI_V_MIDDLE:
+        return (float) swrDisplay_screenHeight * 0.5f;
+    case UI_V_BOTTOM:
+        return (float) swrDisplay_screenHeight;
+    default:
+        return 0.0f;
+    }
+}
+
+static float anchor_design_x(UiAnchorH h) {
+    switch (h) {
+    case UI_H_CENTER:
+        return UI_DESIGN_W * 0.5f;
+    case UI_H_RIGHT:
+        return UI_DESIGN_W;
+    default:
+        return 0.0f;
+    }
+}
+
+static float anchor_design_y(UiAnchorV v) {
+    switch (v) {
+    case UI_V_MIDDLE:
+        return UI_DESIGN_H * 0.5f;
+    case UI_V_BOTTOM:
+        return UI_DESIGN_H;
+    default:
+        return 0.0f;
+    }
+}
+
+UiVec2 ui_anchor_point(UiAnchorH h, UiAnchorV v) {
+    UiVec2 p = {anchor_screen_x(h), anchor_screen_y(v)};
+    return p;
+}
+
+UiVec2 ui_design_to_screen(UiAnchorH h, UiAnchorV v, UiVec2 design) {
+    float s = ui_layout_scale();
+    UiVec2 r;
+    r.x = anchor_screen_x(h) + s * (design.x - anchor_design_x(h));
+    r.y = anchor_screen_y(v) + s * (design.y - anchor_design_y(v));
+    return r;
+}
+
+UiVec2 ui_screen_to_design(UiAnchorH h, UiAnchorV v, UiVec2 screen) {
+    float s = ui_layout_scale();
+    if (s == 0.0f)
+        s = 1.0f;
+    UiVec2 r;
+    r.x = anchor_design_x(h) + (screen.x - anchor_screen_x(h)) / s;
+    r.y = anchor_design_y(v) + (screen.y - anchor_screen_y(v)) / s;
+    return r;
+}
+
+float ui_center_offset_px(void) {
+    if (!ui_enabled())
+        return 0.0f;
+    // Uniform-width UI box = UI_DESIGN_W * ui_layout_scale() (== sprite-design-width * ui_sprite_scale).
+    // Half the leftover framebuffer width pillarboxes it. Goes negative (overflow both sides) only if
+    // the ui_scale slider pushes the box wider than the window, which is still correctly centered.
+    float ui_w = UI_DESIGN_W * ui_layout_scale();
+    return ((float) swrDisplay_screenWidth - ui_w) * 0.5f;
+}
+
+UiVec2 ui_project_px_to_design(UiVec2 px) {
+    UiVec2 r;
+    if (ui_enabled() && swrDisplay_screenWidth > 0 && swrDisplay_screenHeight > 0) {
+        // The draw applies ui_sprite_scale uniformly; divide by it so the round trip recovers the
+        // original framebuffer pixel. ui_scale (the slider) is included, so projected elements stay
+        // locked to the world/scene regardless of UI-scale rather than drifting with it.
+        float s = ui_sprite_scale();
+        if (s <= 0.0f)
+            s = 1.0f;
+        r.x = px.x / s;
+        r.y = px.y / s;
+        return r;
+    }
+    // Vanilla: design = pixel / (screenDim * recip). screenDim*recip is the draw's per-axis scale,
+    // and 1/recip is the design dimension, so this equals the engine's own (pixel/screen)*design.
+    float gx = (float) ((double) swrDisplay_screenWidth * swrUI_designWidthRecip);
+    float gy = (float) ((double) swrDisplay_screenHeight * swrUI_designHeightRecip);
+    if (gx == 0.0f)
+        gx = 1.0f;
+    if (gy == 0.0f)
+        gy = 1.0f;
+    r.x = px.x / gx;
+    r.y = px.y / gy;
+    return r;
+}
+
+void ui_layer_push(UiXform x) {
+    if (g_layer_depth >= UI_LAYER_STACK_MAX)
+        return;
+    UiXform base = ui_layer_current();
+    g_layer_stack[g_layer_depth] = ui_xform_compose(base, x);
+    g_layer_depth++;
+}
+
+void ui_layer_pop(void) {
+    if (g_layer_depth > 0)
+        g_layer_depth--;
+}
+
+UiXform ui_layer_current(void) {
+    if (g_layer_depth == 0)
+        return ui_xform_identity();
+    return g_layer_stack[g_layer_depth - 1];
+}
+
+int ui_enabled(void) {
+    return imgui_state.ui_resolution_independent ? 1 : 0;
+}

--- a/dinput_hook/ui_transform.h
+++ b/dinput_hook/ui_transform.h
@@ -1,0 +1,103 @@
+#pragma once
+/*
+ * Shared UI coordinate transform -- the single definition of the
+ * design<->framebuffer mapping that every 2D consumer routes through.
+ *
+ * Representation: a uniform scale plus a framebuffer-space translation (a
+ * similarity with NO rotation -- in-race HUD wobble is position-only). It
+ * composes and inverts, so a UI-scale slider, repositionable elements, and HUD
+ * wobble all drop in as additional inputs rather than as rewrites.
+ *
+ * C-linkage so both the .c and .cpp deltas in game_deltas/ can consume it.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Authoring reference dims -- the ONLY place 640/480 live in the layout path. */
+#define UI_DESIGN_W 640.0f
+#define UI_DESIGN_H 480.0f
+
+typedef struct UiVec2 {
+    float x;
+    float y;
+} UiVec2;
+
+/* Uniform scale + framebuffer-space translation. No rotation term. */
+typedef struct UiXform {
+    float scale;
+    float tx;
+    float ty;
+} UiXform;
+
+typedef enum UiAnchorH {
+    UI_H_LEFT,
+    UI_H_CENTER,
+    UI_H_RIGHT,
+} UiAnchorH;
+
+typedef enum UiAnchorV {
+    UI_V_TOP,
+    UI_V_MIDDLE,
+    UI_V_BOTTOM,
+} UiAnchorV;
+
+/* --- transform algebra --- */
+UiXform ui_xform_identity(void);
+/* Apply `inner` first, then `outer` (outer after inner). */
+UiXform ui_xform_compose(UiXform outer, UiXform inner);
+UiXform ui_xform_invert(UiXform x);
+UiVec2 ui_xform_apply(UiXform x, UiVec2 p);
+
+/* --- shared design<->framebuffer mapping --- */
+/* Uniform layout scale for the WIDGET / cursor / hit-test space (640x480 == UI_DESIGN_W/H):
+ * (screenHeight / UI_DESIGN_H) * ui_scale slider. Square pixels => no horizontal stretch. */
+float ui_layout_scale(void);
+/* Uniform scale for the SPRITE / TEXT DRAW space, which the engine defines via its own height
+ * reciprocal (NOT 640x480 -- it is ~320x240, so this is ~2x ui_layout_scale). Use this for the
+ * sprite draw scale (GetUIScale) and the text reciprocal so they un-stretch to full size and stay
+ * aligned with the (separately scaled) widget/hit space (two distinct design spaces). */
+float ui_sprite_scale(void);
+/* The screen-pinned origin for an anchor, evaluated vs the live framebuffer. */
+UiVec2 ui_anchor_point(UiAnchorH h, UiAnchorV v);
+/* design-space coordinate (0..640, 0..480) -> framebuffer px. */
+UiVec2 ui_design_to_screen(UiAnchorH h, UiAnchorV v, UiVec2 design);
+/* framebuffer px -> design-space coordinate (inverse: cursor + drag-reposition). */
+UiVec2 ui_screen_to_design(UiAnchorH h, UiAnchorV v, UiVec2 screen);
+
+/* Projected-element seam: convert a framebuffer-pixel coordinate (as produced by
+ * swrViewport_ProjectToScreen for lens flares / light streaks / world sprites / weather /
+ * the distance+name HUD text) into the sprite/text DESIGN coordinate that the draw then scales
+ * back up. swrSprite_SetPosF and swrText_CreateTextEntry2 are exactly this seam in the engine
+ * (pixel/screen * design). When res-independence is on the draw multiplies by the uniform
+ * ui_sprite_scale on BOTH axes, so dividing the pixel by ui_sprite_scale here makes the round
+ * trip land the element on its true projected pixel (spanning the full framebuffer, not the
+ * letterboxed UI box). When off, reproduces the vanilla per-axis normalization. */
+UiVec2 ui_project_px_to_design(UiVec2 px);
+
+/* Horizontal framebuffer translation that centers the uniform-width 2D UI box in the window:
+ * (screenWidth - UI_DESIGN_W * ui_layout_scale()) / 2, or 0 when res-independence is off. The
+ * whole 2D UI layer (menu + in-race HUD sprites, text, clip rects) shifts right by this; the
+ * cursor subtracts it so hit-tests stay aligned. Projected/world elements (lens flares, weather,
+ * markers) are NOT shifted -- they route through the DLL-internal seam copies, not the EXE hooks. */
+float ui_center_offset_px(void);
+
+/* Menu-text scope depth. Incremented while a swrUI / front-end text path is active (swrUI_DrawText,
+ * swrUI_DrawTextAligned, the swrObjHang_F0 hangar dispatcher, the in-race pause menu) so that
+ * swrText_CreateTextEntry1's centering offset uses the widget (640) scale instead of the HUD (320)
+ * scale. Shared because the wrapping deltas live in several translation units. > 0 means "menu". */
+extern int ui_menu_text_depth;
+
+/* --- layer/group stack (the in-race HUD pushes a translation for wobble) --- */
+void ui_layer_push(UiXform x);
+void ui_layer_pop(void);
+UiXform ui_layer_current(void);
+
+/* Is the resolution-independent path active? (toggle gate). When 0, consumers
+ * must reproduce vanilla behavior. */
+int ui_enabled(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Makes the 2D UI resolution-independent: menus, the in-race HUD, and projected elements draw at a uniform square-pixel scale (no more 640x480 stretch) and are pillarboxed/centered in the window, with an optional UI-scale slider. All behind the off-by-default **Resolution-independent UI** toggle -- byte-vanilla when off.

Everything routes through one shared design<->framebuffer transform (`ui_transform`):
- `swrSprite_GetUIScale` + the text reciprocals go to a single uniform scale; the cursor remap stays in lockstep so hit-tests match the un-stretched, centered draw.
- The centering offset is applied at every 2D draw sink: `swrSprite_SetPos`, all three entries1 text wrappers (`CreateTextEntry1` + the colorless siblings the hangar titles use), the pause menu's `CreateEntry2`, and the clip rects.
- Projected elements (lens flares, weather, opponent/distance labels) stay world-locked via the `SetPosF` / `CreateTextEntry2` seams.
- The minimap radar centers by shifting its anchor constant (`swrObjJdge_minimapAnchorX`) rather than hooking its draw, whose non-standard calling convention breaks under a detour.

Playtested across menus, hangar/cantina, the in-race HUD (all minimap modes), and pause; builds + links clean.

One known nit: two per-entry clip-array addresses in `swrText_SetEntryClipRect_delta` are left as documented raw literals -- naming them needs the mis-typed `swrTextEntries1` data block re-RE'd first, which I'll do as a follow-up.