### PR TITLE
Windowed mode: re-render on resize + aspect-correct FOV + FOV slider

### DIFF
--- a/dinput_hook/game_deltas/Window_delta.c
+++ b/dinput_hook/game_deltas/Window_delta.c
@@ -388,6 +388,19 @@ void GLAPIENTRY Window_glDebugMessageCallback(GLenum source, GLenum type, GLuint
 }
 
 // 0x0049cd40
+// On a live window resize, keep swrDisplay_screenWidth/Height (== screen_width/height) tracking the
+// framebuffer. The GL viewport + MSAA FBO already follow the framebuffer each frame; these globals
+// were the only thing frozen at startup, so without this the 3D projection aspect, the 2D UI ortho,
+// and the resolution-independent UI scale all render for the startup size and get stretched into the
+// resized window. Guard against the 0x0 framebuffer reported while minimized.
+static void Window_FramebufferSizeCallback(GLFWwindow *window, int width, int height) {
+    (void) window;
+    if (width > 0 && height > 0) {
+        swrDisplay_screenWidth = width;
+        swrDisplay_screenHeight = height;
+    }
+}
+
 int Window_Main_delta(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine, int nCmdShow,
                       const char *window_name) {
     InitCommonControls();
@@ -417,6 +430,7 @@ int Window_Main_delta(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLin
     glfwMakeContextCurrent(window);
     glfwSetKeyCallback(window, key_callback);
     glfwSetMouseButtonCallback(window, mouse_button_callback);
+    glfwSetFramebufferSizeCallback(window, Window_FramebufferSizeCallback);
 
     Main_Startup((char *) pCmdLine);
 

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <cstdio>
 #include <cstring>
+#include <cwchar>
 
 #include <imgui.h>
 #include <imgui_stdlib.h>
@@ -86,6 +87,11 @@ void read_settings_ini() {
         GetPrivateProfileIntW(L"settings", L"ai_full_lod", 1, ini_path.c_str());
     set_ai_full_lod(imgui_state.ai_full_lod);
 
+    wchar_t fov_scale_buf[32] = {0};
+    GetPrivateProfileStringW(L"settings", L"fov_scale", L"1.0", fov_scale_buf, 32, ini_path.c_str());
+    float fov_scale = (float) wcstod(fov_scale_buf, nullptr);
+    imgui_state.fov_scale = (fov_scale >= 0.5f && fov_scale <= 2.0f) ? fov_scale : 1.0f;
+
     g_window_mode =
         GetPrivateProfileIntW(L"settings", L"window_mode", WINDOW_MODE_WINDOWED, ini_path.c_str());
     if (g_window_mode < WINDOW_MODE_WINDOWED || g_window_mode > WINDOW_MODE_FULLSCREEN)
@@ -105,6 +111,8 @@ void save_settings_ini() {
 
     WritePrivateProfileStringW(L"settings", L"ai_full_lod", imgui_state.ai_full_lod ? L"1" : L"0",
                                ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"fov_scale",
+                               std::to_wstring(imgui_state.fov_scale).c_str(), ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"window_mode", std::to_wstring(g_window_mode).c_str(),
                                ini_path.c_str());
@@ -534,6 +542,11 @@ void opengl_render_imgui() {
 
         if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
             set_ai_full_lod(imgui_state.ai_full_lod);
+        }
+
+        // Camera FOV multiplier (1.0 = game default; aspect handled automatically via Hor+).
+        if (ImGui::SliderFloat("FOV scale", &imgui_state.fov_scale, 0.5f, 2.0f, "%.2f")) {
+            save_settings_ini();
         }
 
         static const char *window_mode_items[] = {"Windowed", "Borderless", "Fullscreen"};

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -37,6 +37,9 @@ typedef struct ImGuiState {
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;
     std::optional<TEXID> picked_texture_id;
+    // Camera FOV multiplier (1.0 == game default; >1 widens the view / zooms out). Aspect ratio is
+    // handled in the projection (Hor+: the 4:3 vertical fov is held constant across ratios). Persisted.
+    float fov_scale = 1.0f;
 } ImGuiState;
 
 extern "C" {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -920,10 +920,17 @@ void swrViewport_Render_Hook(int x) {
     float f = frustum->zFar;
     float n = frustum->zNear;
     const float t = 1.0f / tan(0.5 * rdCamera_pCurCamera->fov / 180.0 * 3.14159);
-    float a = float(h) / w;
+    // The game's fov is the HORIZONTAL fov, calibrated for 4:3. Hold the 4:3 VERTICAL fov constant
+    // across aspect ratios (Hor+) so widescreen reveals more horizontally instead of cropping the
+    // top and bottom, then apply the user FOV multiplier (>1 = wider / zoom out). At 4:3 this is
+    // identical to the original (xscale=t). w/h>0 guards the 0x0 framebuffer reported while minimized.
+    const float design_aspect = 4.0f / 3.0f;
+    const float fov_scale = imgui_state.fov_scale > 0.0f ? imgui_state.fov_scale : 1.0f;
+    const float yscale = (h > 0) ? (float) (t * design_aspect / fov_scale) : t;
+    const float xscale = (w > 0) ? (float) (yscale * (float) h / (float) w) : t;
     const rdMatrix44 proj_mat{
-        {mirrored ? -t : t, 0, 0, 0},
-        {0, t / a, 0, 0},
+        {mirrored ? -xscale : xscale, 0, 0, 0},
+        {0, yscale, 0, 0},
         {0, 0, -(f + n) / (f - n), -1},
         {0, 0, -2 * f * n / (f - n), 1},
     };


### PR DESCRIPTION
Fixes windowed mode. Resizing the window now re-renders the game at the new resolution instead of stretching a fixed-size frame, and the camera FOV is aspect-correct for non-4:3 with a user slider.

- A GLFW framebuffer-size callback keeps `swrDisplay_screenWidth/Height` tracking the live window size. The GL viewport + MSAA FBO already follow the framebuffer each frame; these globals were the only thing frozen at startup, so the 3D projection, the 2D ortho, and the cursor all rendered for the startup size and got stretched into the resized window.
- The projection now holds the 4:3 **vertical** FOV constant across aspect ratios (Hor+) instead of the horizontal one, so widescreen reveals more horizontally rather than cropping top/bottom. 4:3 is byte-identical to before.
- New persisted **FOV scale** slider (0.5-2.0, default 1.0).

Independent of #185 (this is a 3D-camera / window concern). Builds + links clean; playtested in windowed mode at various sizes and with the FOV slider.