### PR TITLE
swrRace/swrObjJdge/swrCam: name 35 race + flight functions

### DIFF
--- a/src/Swr/swrCam.h
+++ b/src/Swr/swrCam.h
@@ -15,6 +15,9 @@
 #define swrCam_CamState_SetOffsetSource_ADDR (0x00428b10)
 #define swrCam_CamState_GetOffsetTransform_ADDR (0x00428c40)
 #define swrCam_CamState_ApplyToViewport_ADDR (0x00428cd0)
+#define swrCam_GetActiveViewportCameraTransform_ADDR (0x004292b0)
+#define swrCam_PickNearestSplitCameraTransform_Maybe_ADDR (0x00429330)
+#define swrCam_IsBehaviorActiveViewportCamera_Maybe_ADDR (0x004294e0)
 
 // Reset/init the per-camera transform matrices across the camera-state array.
 void swrCam_CamState_InitMatrices(void);
@@ -37,5 +40,14 @@ void swrCam_CamState_GetOffsetTransform(int mode, swrModel_NodeTransformed* node
 
 // Compose the camera-state transform and apply it to the viewport.
 void swrCam_CamState_ApplyToViewport(swrViewport* viewport);
+
+// Copies the transform of the first visible viewport camera into the output, or identity if none.
+void swrCam_GetActiveViewportCameraTransform(rdMatrix44* out);
+
+// Compares the two split-screen viewport cameras and copies the one nearest the given position (best guess).
+void swrCam_PickNearestSplitCameraTransform_Maybe(swrModel_Behavior* out, float* pos);
+
+// Returns whether the given mesh behavior is the active camera of any viewport (best guess).
+int swrCam_IsBehaviorActiveViewportCamera_Maybe(swrModel_Behavior* behavior);
 
 #endif // SWRCAM_H

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -226,6 +226,13 @@
 #define swrScene_InitWorld_ADDR (0x00449040)
 #define swrScene_InitCameras_ADDR (0x004490a0)
 #define swrScene_Init_ADDR (0x004491f0)
+#define swrObjcMan_UpdateSplineGuideMarker_Maybe_ADDR (0x004535c0)
+#define swrObjJdge_DrawSpeedDialHud_Maybe_ADDR (0x0045fe70)
+#define swrObjJdge_LayoutHudFrameSprites_Maybe_ADDR (0x004603f0)
+#define swrObjJdge_OnCycleHudButton_ADDR (0x00462cf0)
+#define swrObjJdge_SetupLensFlareSprites_ADDR (0x00463ec0)
+#define swrObjJdge_ToggleSkyboxVisibility_Maybe_ADDR (0x00466e40)
+#define swrRace_ClosestApproach2D_Maybe_ADDR (0x0047aee0)
 #define swrScene_SetObjectsLoaded_ADDR (0x004804a0)
 #define swrScene_ResetRenderState_ADDR (0x004834b0)
 
@@ -336,6 +343,9 @@ void swrObjcMan_UpdateTerrainVisuals(swrObjcMan* cman);
 // Spectator/track-following camera (mode_type 6): positions a cinematic view
 // along the track spline relative to the pod.
 void swrObjcMan_UpdateSplineCamera(swrObjcMan* cman);
+
+// Per frame advances and positions a trailing spline guide-marker node, setting its color (best guess).
+void swrObjcMan_UpdateSplineGuideMarker_Maybe(int cman);
 // Applies FOV/near/far to the viewport and updates fog color/distance and the
 // clear color each frame (swrViewport_SetCameraParameters + SetFogParameters).
 void swrObjcMan_UpdateFogAndViewport(swrObjcMan* cman);
@@ -455,6 +465,9 @@ int swrObjJdge_CheckIfPauseRequested();
 void swrObjJdge_F3(swrObjJdge* jdge);
 int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3);
 
+// Sets up the eight lens-flare sprites with descending sizes and colors.
+void swrObjJdge_SetupLensFlareSprites(int param_1, int baseSprite, float scale);
+
 int SetPlanetIdAndTrackNumber(int, int);
 
 void swrObjJdge_AddTriggersToScene(swrObjJdge* a1);
@@ -473,6 +486,9 @@ void InitPrimaryLight();
 void InitAISettingsForTrack(swrObjJdge*);
 
 unsigned int swrObjJdge_InitTrack(swrObjJdge* judge, swrScore* scores);
+
+// Toggles the skybox root node's visibility and sets the debug clear color (best guess).
+void swrObjJdge_ToggleSkyboxVisibility_Maybe(int param_1, unsigned char mode);
 
 // track/level load pipeline (called from swrObjJdge_InitTrack):
 // Selects the track spline by planet/track, loads it, and sets fog/clear color + start camera.
@@ -503,11 +519,20 @@ void swrObjJdge_UpdateViewportLayout(swrObjJdge* jdge, int mode);
 void swrObjJdge_ScrollCredits(swrObjJdge* jdge);
 // Standings/position HUD + full-screen minimap state machine (keyed on hud_mode).
 void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge);
+
+// Draws a player's speed-dial gauge, boost text, and net-play prompt on the HUD (best guess).
+void swrObjJdge_DrawSpeedDialHud_Maybe(int racer, int score, short x, short y, int playerIdx);
 // Draws a centered HUD meter sprite (id 0x1a) sized/colored by a race metric (_DAT_00e9824c),
 // hidden below threshold. Exact metric uncertain (boost/charge-like bar).
 void swrObjJdge_DrawHudBar(void);
+
+// Positions the single-player HUD frame, border, and minimap-scroll sprites by mode bits (best guess).
+void swrObjJdge_LayoutHudFrameSprites_Maybe(unsigned int mode);
 // Per-racer HUD: in-race timer, engine UI, finish statistics and the lap marker.
 void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score);
+
+// Handles the cycle-HUD button: plays a sound and cycles the HUD display mode.
+void swrObjJdge_OnCycleHudButton(void);
 // Whether a racer is still actively racing (not finished / at the finish line).
 int swrObjJdge_IsRacerRacing(swrObjJdge* jdge, swrRace* racer);
 // Draws the 2-player split-screen divider bar.
@@ -616,6 +641,9 @@ void swrRace_PlaceOnTrack(swrRace* racer);
 int swrObjTest_F4(swrRace* player, int* subEvent, int ghost);
 
 void swrObjTest_TurnResponse(swrRace* player);
+
+// Computes the closest-approach parameter and points between two 2D segments (best guess).
+float swrRace_ClosestApproach2D_Maybe(rdVector2* a0, float* a1, rdVector2* b0, float* b1, rdVector2* outA, rdVector2* outB, rdVector2* outDirA, rdVector2* outDirB);
 
 void swrObjTest_SuperUnk(swrRace* player);
 void swrObjToss_F2(swrObjToss* toss);

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -8,6 +8,8 @@
 #define swrRace_ReservedSettingsMenu_ADDR (0x0040fb50)
 
 #define swrRace_LoadSaveConfigMenu_ADDR (0x0040ffe0)
+#define swrRace_BuildProfileSelectMenu_ADDR (0x00410230)
+#define swrRace_PollScreenshotKey_ADDR (0x00410430)
 
 #define swrRace_SettingsMenu_ADDR (0x00411950)
 
@@ -206,13 +208,20 @@
 // (records, unlock bitfields, and the embedded saved-profile table), prefixed on disk by
 // a 4-byte version magic (0x10003). Original engine module name: "elfSaveLoad".
 #define swrRace_InitGameData_ADDR (0x00421810)
+#define swrRace_LoadProfileFromFile_Maybe_ADDR (0x00421850)
 #define swrRace_SaveProfile_ADDR (0x004219d0)
 #define swrRace_ResetGameData_ADDR (0x00421b20)
 #define swrRace_LoadGameData_ADDR (0x00421b90)
 #define swrRace_SaveGameData_ADDR (0x00421c90)
 #define swrRace_IsGameDataUninitialized_ADDR (0x00421d80)
+#define swrRace_GetLensFlareEnabled_ADDR (0x004376b0)
+#define swrRace_DrawRecordText_Maybe_ADDR (0x00439c70)
 #define swrRace_ResetAllProfiles_ADDR (0x0043d970)
 #define swrRace_CheatUnlockAll_ADDR (0x0043d9a0)
+#define swrRace_ComputeUpgradePrices_ADDR (0x0043eb50)
+#define swrRace_GetEngineNodeOffsetPos_Maybe_ADDR (0x0044afb0)
+#define swrRace_SetEngineNodeRotScale_Maybe_ADDR (0x0044b180)
+#define swrRace_SetEngineNodeTranslation_Maybe_ADDR (0x0044b270)
 #define swrRace_InitDefaultGameData_ADDR (0x0044e320)
 #define swrRace_ComputeSaveChecksum_ADDR (0x0044e440)
 #define swrRace_Crc32_ADDR (0x0044e460)
@@ -221,12 +230,33 @@
 #define swrRace_CopyProfileFromSave_ADDR (0x0044e500)
 #define swrRace_CopyProfileToSave_ADDR (0x0044e530)
 #define swrRace_SaveCurrentProfile_ADDR (0x0044e560)
+#define swrRace_GetProfileRecordVec3_Maybe_ADDR (0x0044e5a0)
+#define swrRace_UpdatePitDroidModels_Maybe_ADDR (0x00456200)
+#define swrRace_UpdateDeathPitch_Maybe_ADDR (0x0046aec0)
+#define swrRace_SendFlameEvent_Maybe_ADDR (0x0046bb30)
+#define swrRace_SpawnExplosionByIndex_Maybe_ADDR (0x0046bb50)
+#define swrRace_GetEngineUiBarColor_Maybe_ADDR (0x0046bc50)
+#define swrRace_UpdateEngineFireballNode_Maybe_ADDR (0x0046ebf0)
+#define swrRace_ApplyEngineProximityPush_Maybe_ADDR (0x0046ecd0)
+#define swrRace_SpawnGroundDustKick_Maybe_ADDR (0x0046fd60)
+#define swrRace_SmoothEngineExhaustSize_Maybe_ADDR (0x00470510)
+#define swrRace_ResetGravityDown_Maybe_ADDR (0x004764a0)
+#define swrRace_HandleWallScrapeHit_Maybe_ADDR (0x00479d40)
+#define swrRace_UpdateScrapeContact_Maybe_ADDR (0x0047a3a0)
+#define swrRace_UpdateSplineOrientation_Maybe_ADDR (0x0047a610)
+#define swrRace_GetSplineProgressValue_Maybe_ADDR (0x0047f890)
 
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4);
 
 void swrRace_ReservedSettingsMenu(swrUI_unk* param_1);
 
 void swrRace_LoadSaveConfigMenu(swrUI_unk* param_1);
+
+// Builds the profile-select menu list with Create/Remove-Racer and Current-Player entries.
+void swrRace_BuildProfileSelectMenu(swrUI_unk* param_1);
+
+// Polls the screenshot key and, when pressed, plays a UI sound and captures a screenshot.
+void swrRace_PollScreenshotKey(void);
 
 int swrRace_SettingsMenu(void);
 
@@ -263,7 +293,13 @@ void swrRace_MainMenu(swrObjHang* hang);
 
 void swrRace_AudioVideoSettings(swrObjHang* hang);
 
+// Returns whether the lens-flare video option is enabled.
+int swrRace_GetLensFlareEnabled(void);
+
 void swrRace_HangarMenu(swrObjHang* hang);
+
+// Formats a record entry and creates the text entry that displays it (best guess).
+void swrRace_DrawRecordText_Maybe(int x, int y, void* recordFields);
 
 void swrRace_ResultsMenu(swrObjHang* hang);
 
@@ -274,6 +310,9 @@ void swrRace_CourseInfoMenu(swrObjHang* hang);
 void swrRace_UpdatePartsHealth(void);
 
 void swrRace_GenerateDefaultDataSAV(int user_tgfd, int slot);
+
+// Computes which pod upgrades are affordable against the player's current truguts.
+void swrRace_ComputeUpgradePrices(void);
 
 void swrRace_BuyPitdroidsMenu(swrObjHang* hang);
 
@@ -286,6 +325,9 @@ void swrRace_UpdatePartNodeSelection(void);
 void swrRace_SetupStatsMenuLighting(void);
 void swrRace_DrawStatBar(swrObjHang* hang, short x, short y, float value, float lo, float mid, float hi);
 void swrRace_UpdateStatPartModels(void);
+
+// Randomizes and positions the pit-droid models and sets the stats-menu light (best guess).
+void swrRace_UpdatePitDroidModels_Maybe(void);
 
 // ray = {origin.xyz, dir.xyz, maxDist}; returns hit distance (<0 = miss), fills outHit/outNormal.
 float swrRace_InitUnk(swrModel_Node* model, float* ray, rdVector3* outHit, rdVector3* outNormal);
@@ -302,6 +344,15 @@ void swrRace_UpdateTurn(float* param_1, float* param_2, float param_3, float par
 
 void swrRace_SetAngleFromTurnRate(float* out_tilt, float cur_turnrate, void* unused, float max_turnrate, float max_angle);
 
+// Reads an engine node's world translation and offsets it by the paired node's Y position (best guess).
+void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos);
+
+// Builds a rotation and scale transform for an engine node, offset by the paired node's Y (best guess).
+void swrRace_SetEngineNodeRotScale_Maybe(void** nodePair, float scale, float angle);
+
+// Copies an engine node's transform and sets its translation minus the paired node's Y offset (best guess).
+void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos);
+
 void swrRace_ReplaceMarsGuoWithJinnReeso(void);
 void swrRace_ReplaceBullseyeWithCyYunga(void);
 
@@ -314,6 +365,9 @@ void swrRace_InRaceEngineUI(void* param_1, int param_2);
 void swrRace_InRaceEndStatistics(void* param_1, void* param_2);
 
 void swrRace_Repair(swrRace* player);
+
+// Sets the pod death-pitch field based on a speed or flag threshold (best guess).
+void swrRace_UpdateDeathPitch_Maybe(int player, float param_2, int param_3, int param_4);
 
 void swrRace_Tilt(swrRace* player, float b);
 
@@ -331,6 +385,9 @@ int swrRace_BoostCharge(int player);
 void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotion, rdVector3* pRDot);
 // Extracts pitch + signed-roll angles of a forward/right basis relative to a reference (down) vector.
 void swrRace_ComputeTiltAngles(rdVector3* fwd, rdVector3* right, rdVector3* ref, rdVector3* out);
+
+// Resets the pod's gravity field and down-reference vector to negative Z (best guess).
+void swrRace_ResetGravityDown_Maybe(int player);
 // Builds a surface-aligned basis from the pod forward + surface normal and accumulates the heading/tilt
 // correction into pRDot (turn input). The +-85 deg pitch clamp + the magnet (flags1 0x400) gating live here.
 void swrRace_AlignToSurface(swrRace* player, rdVector3* up, rdVector3* fwd_vB, rdVector3* vA_fallback,
@@ -384,6 +441,12 @@ void swrRace_UpdateEngineSound(swrRace* player);
 // that flags nearby pods.
 void swrRace_UpdateEngineDamageFX(swrRace* player);
 
+// Spawns a per-planet ground dust kick with a scrape sound during a vehicle reaction (best guess).
+void swrRace_SpawnGroundDustKick_Maybe(swrRace* player, float* transform, float sx, float sy, float sz, float param_6, int param_7);
+
+// Smooths a per-side engine exhaust size toward a target over time (best guess).
+void swrRace_SmoothEngineExhaustSize_Maybe(int player, float side, float a, float b, float c, float rate, int param_7, int param_8);
+
 // pod state + engine secondary-motion helpers:
 // Counts down the death timer; on expiry dispatches the 'Snap' event and resets engine health/flags.
 void swrRace_HandleDeathSnap(swrRace* player);
@@ -405,6 +468,12 @@ void swrRace_AssignRandomMeshNodes(swrModel_Node* node);
 void swrRace_RandomizeMeshNodes(swrModel_Node* dst, swrModel_Node* src);
 void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos, float scale);
 
+// Animates the engine fireball node's transform and hides it when its animation finishes (best guess).
+void swrRace_UpdateEngineFireballNode_Maybe(int player);
+
+// Projects a relative position onto the two engine bases to push pods apart in proximity (best guess).
+void swrRace_ApplyEngineProximityPush_Maybe(swrRace* player, float* otherPos, rdVector3* out);
+
 // player/AI/autopilot control + engine-damage helpers:
 // Sets the respawn flag (flags0 0x1000) when the player's reset input bit is held.
 void swrRace_CheckResetInput(swrRace* player, int playerIndex);
@@ -421,6 +490,9 @@ void swrRace_AutopilotSteer(swrRace* player);
 void swrRace_ApplyPodProximityForce(swrRace* player);
 // Autopilot/pre-race control: snap events and tilt while not under player input.
 void swrRace_UpdateAutopilotControl(swrRace* player);
+
+// Fills the HUD engine-bar color and fill amount from the pod's engine state.
+void swrRace_GetEngineUiBarColor_Maybe(int player, uint8_t* outRgb, uint8_t* outRgba, float* outFill);
 // Human player control: maps input to turn/pitch/brake/boost, drives force
 // feedback and tilt, and sets projTurnRate/pitch/gravityMultiplier.
 void swrRace_UpdatePlayerControl(swrRace* player);
@@ -430,6 +502,12 @@ void swrRace_UpdateCatchup(swrRace* player);
 // collision / ground-contact physics + explosion spawn:
 // Spawns the explosion effect (type-8 Smok) and destruction sounds for the pod.
 void swrRace_SpawnExplosionEffect(swrRace* player);
+
+// Sends a 'flam' flame multiplayer event for the given player (best guess).
+void swrRace_SendFlameEvent_Maybe(int player, double param_2, void* param_3, void* param_4, int param_5);
+
+// Spawn the explosion effect for the racer at the given index (best guess).
+void swrRace_SpawnExplosionByIndex_Maybe(int racerIndex);
 // Raycasts the terrain collision mesh; sets terrainModel (0x140) and ground height, returns distance.
 float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNormal);
 // Samples the 4 hover-pad ground heights and builds the shadow transforms (0x1290); returns hover height.
@@ -440,6 +518,9 @@ void swrRace_ApplySlopeSteering(swrRace* player, int velocity, int scrapeData, f
 void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeData, float groundDist, rdVector3* normal, rdVector3* out1, rdVector3* out2);
 // Wall collision response: reflects velocity off the wall normal into velocityCollision and dispatches hit/scrape events.
 void swrRace_ApplyWallCollision(swrRace* player, rdVector3* normal, rdVector3* dir);
+
+// Handles a wall-scrape hit: spawns spray and sends the scrape multiplayer event (best guess).
+void swrRace_HandleWallScrapeHit_Maybe(swrRace* player);
 
 // pod init + death/scrape/collision-toggle helpers:
 // Initializes a pod for a race: loads stats from the racer data, sets the spawn
@@ -462,12 +543,21 @@ void swrRace_UpdateEnergyBinder(swrRace* player, float side, rdVector3* pointA, 
 void swrRace_BuildStretchedQuad(rdMatrix44* a, rdMatrix44* b, float param_3, float param_4, int keyframeIdx, rdMatrix44* out);
 // Wall-contact dispatch: wall-scrape + collision response when fast/airborne, else terrain follow.
 float swrRace_UpdateWallContact(swrRace* player, float* param_2, float* param_3, rdVector3* param_4);
+
+// Decays the scrape timer, finds nearby smoke, and computes the scrape reflection force (best guess).
+void swrRace_UpdateScrapeContact_Maybe(int player, int param_2);
+
+// Integrates spline-bound pod orientation, rebuilding the basis and applying turn, pitch, and roll (best guess).
+void swrRace_UpdateSplineOrientation_Maybe(int player, rdVector3* up);
 // Pod-to-pod collision: finds a nearby pod and resolves the 2D collision (push apart + DeathSpeed).
 void swrRace_ResolvePodCollision(swrRace* player);
 
 void swrRace_TriggerHandler(int player, int a, char b);
 
 float swrRace_LapProgress(int a);
+
+// Returns a component of the spline progress values for a spline cursor (best guess).
+float swrRace_GetSplineProgressValue_Maybe(void* splineCursor);
 
 bool swrRace_LapCompletion(void* engineData, int param_2);
 
@@ -492,6 +582,9 @@ void swrRace_ComputeTrackOffset(swrRace* player);
 // Save / profile persistence.
 // Boot entry: load tgfd.dat; on failure rebuild defaults and write a fresh file.
 void swrRace_InitGameData(void);
+
+// Loads a player profile file, validates its magic, reads the profile blob, and copies it into the save image (best guess).
+bool swrRace_LoadProfileFromFile_Maybe(int playerId);
 // Read .\data\player\tgfd.dat, verify the 0x10003 version magic, load the 0xfd4-byte image.
 bool swrRace_LoadGameData(void);
 // Create .\data\player\ and write the version magic + 0xfd4-byte image to tgfd.dat.
@@ -506,6 +599,9 @@ bool swrRace_IsGameDataUninitialized(void);
 // Sync the live working profile into the save image and persist it. Called after any change
 // that must survive (shop purchase, race result, settings, name entry) and at shutdown.
 void swrRace_SaveCurrentProfile(void);
+
+// Reads a vec3 field from an indexed save/profile record (best guess).
+void swrRace_GetProfileRecordVec3_Maybe(int base, int index, float* out3);
 // Build the default save image in place (records, "AAA" record-holder names, default unlock
 // bitfield, default profiles) and store its checksum.
 void swrRace_InitDefaultGameData(void* saveImage);

--- a/src/Swr/swrViewport.h
+++ b/src/Swr/swrViewport.h
@@ -29,6 +29,8 @@
 
 #define swrViewport_Render_ADDR (0x00483A90)
 #define swrViewport_Activate_ADDR (0x00483BB0)
+#define swrRace_DrawDebugPosition_ADDR (0x00483be0)
+#define swrRace_DrawDebugMetaCamera_Maybe_ADDR (0x00483ca0)
 
 #define swrViewport_SetRootNodeForAllViewports_ADDR (0x00483fc0)
 #define swrViewport_SetNodeFlagsForAllViewports_ADDR (0x00483ff0)
@@ -63,6 +65,12 @@ void swrViewport_Setup(int);
 void swrViewport_Render(int x);
 
 void swrViewport_Activate(int);
+
+// Prints the pod position and lap progress as a debug text overlay.
+void swrRace_DrawDebugPosition(int param_1);
+
+// Debug overlay near DrawDebugPosition; forwards to the metacamera draw (best guess).
+void swrRace_DrawDebugMetaCamera_Maybe(void);
 
 void swrViewport_SetRootNodeForAllViewports(swrModel_Node* unk);
 void swrViewport_SetNodeFlagsForAllViewports(int flag, int value);


### PR DESCRIPTION
Race/flight cluster of the naming sweep toward 100% named. Header-only, builds clean, address-sorted into the existing define blocks.

**33 newly-named** functions across swrRace.h / swrObj.h / swrCam.h / swrViewport.h — engine/exhaust FX, wall-scrape + spline-orientation handlers, HUD draw helpers, camera-transform getters, profile/save helpers, etc. Uncertain ones carry a `_Maybe` suffix (easy to grep/refine).

**2 divergence fixes** folded into the DB (no diff here — already declared upstream under these names): `0x445150` was `swrRace_ResetMatrixStack` -> it's the generic `rdMatrixStack44_Init`; `0x4651a0` was `swrObjJdge_LoadCommonModels` -> it's `swrModel_LoadBeamAndSparkModels` (loads beamanim_vlec + sparky_part).

A few subsystem reassignments where the nearest-named neighbor was misleading (e.g. three camera helpers -> `swrCam_`, the speed-dial/HUD-frame draws -> `swrObjJdge_`). Happy to take your DB names for any of the `_Maybe` ones.