### PR TITLE
swrMultiplayer/sithMulti/stdComm: name 14 multiplayer functions

### DIFF
--- a/src/Dss/sithMulti.h
+++ b/src/Dss/sithMulti.h
@@ -16,6 +16,11 @@
 #define sithMulti_CreatePlayerFromConfig_ADDR (0x00404a20)
 
 #define sithMulti_RunCallback_ADDR (0x0041b8f0)
+#define sithMulti_ResetCallbackState_ADDR (0x0041b920)
+#define sithMulti_DefaultCallback_ADDR (0x0041b940)
+#define sithMulti_ClearMessageField_Maybe_ADDR (0x0041b950)
+#define swrMultiplayer_SendPlayerLeave_Maybe_ADDR (0x0041b960)
+#define sithMulti_TrackMessagePair_Maybe_ADDR (0x0041b9a0)
 
 #define sithMulti_CloseGame_ADDR (0x0041c570)
 
@@ -27,6 +32,21 @@ HRESULT sithMulti_JoinSessionAndCreatePlayer(int sessionId, wchar_t* playerName,
 HRESULT sithMulti_CreatePlayerFromConfig(int param_1);
 
 int sithMulti_RunCallback(tSithMessage* message);
+
+// Resets the multiplayer message and callback bookkeeping buffers (best guess).
+void sithMulti_ResetCallbackState(void);
+
+// A default message handler that simply returns one (best guess).
+unsigned int sithMulti_DefaultCallback(tSithMessage* message);
+
+// Clears a single field of a message struct (best guess).
+void sithMulti_ClearMessageField_Maybe(int message);
+
+// Sends a player-leave message to one DirectPlay peer (best guess).
+void swrMultiplayer_SendPlayerLeave_Maybe(DPID to, unsigned short value);
+
+// Tracks a message pair in a 128-entry table, appending if unseen and reporting whether it was already present (best guess).
+unsigned int sithMulti_TrackMessagePair_Maybe(int a, int b);
 
 void sithMulti_CloseGame(void);
 

--- a/src/Swr/swrMultiplayer.h
+++ b/src/Swr/swrMultiplayer.h
@@ -117,6 +117,8 @@
 
 // Session lifecycle + event/player-list senders (subtype / 4-char magic noted).
 #define swrMultiplayer_InitMessaging_ADDR (0x0041b700)
+#define swrMultiplayer_FormatTimeString_Maybe_ADDR (0x0041bc20)
+#define swrMultiplayer_ResetRacerListState_Maybe_ADDR (0x0041bd60)
 #define swrMultiplayer_SendMenuEvent_ADDR (0x0041c3f0)
 #define swrMultiplayer_BroadcastMenuReset_ADDR (0x0041c450)
 #define swrMultiplayer_GetRacerId_ADDR (0x0041c4d0)
@@ -124,11 +126,16 @@
 #define swrMultiplayer_ClearHostState_ADDR (0x0041c760)
 #define swrMultiplayer_SendRejoin_ADDR (0x0041c870)
 #define swrMultiplayer_SendProxy_ADDR (0x0041c8e0)
+#define swrMultiplayer_MarkAllPodsRemote_Maybe_ADDR (0x0041c940)
+#define swrMultiplayer_MarkPodLocal_Maybe_ADDR (0x0041c990)
 #define swrMultiplayer_OnPlayerJoined_ADDR (0x0041c9e0)
 #define swrMultiplayer_BecomeHost_ADDR (0x0041ca50)
 #define swrMultiplayer_SendPlayerName_ADDR (0x0041cb20)
 #define swrMultiplayer_SendPlayerList_ADDR (0x0041cbd0)
 #define swrMultiplayer_SendPlayerJoin_ADDR (0x0041cde0)
+#define swrMultiplayer_TickRacerListOverlay_ADDR (0x0041e880)
+#define swrMultiplayer_RenderRacerListOverlay_ADDR (0x0041e920)
+#define swrMultiplayer_BuildAllMenuScreens_ADDR (0x0041e9b0)
 
 void swrMultiplayer_SetInMultiplayer(int bInMultiplayer);
 
@@ -164,6 +171,15 @@ void swrMultiplayer_BroadcastPlayerState(void);
 void swrMultiplayer_UpdateReadyState(int slot);
 // Adds a chat/session string to the on-screen message log (with a display TTL).
 void swrMultiplayer_AddChatMessage(char* text);
+
+// Ages the racer-list overlay each frame, freeing expired slots and compacting the slot array.
+void swrMultiplayer_TickRacerListOverlay(void);
+
+// Draws the racer-list overlay, rendering each non-empty slot down a column.
+void swrMultiplayer_RenderRacerListOverlay(void);
+
+// Builds all five multiplayer menu pages in one call.
+void swrMultiplayer_BuildAllMenuScreens(void);
 // Builds the "Create A Game" multiplayer dialog (name/game/password fields).
 int swrMultiplayer_BuildCreateGameUI(void);
 
@@ -224,6 +240,9 @@ int swrMultiplayer_ApplyPlayerJoin(void* message);
 int swrMultiplayer_VerifyPlayerList(void* message);
 // 0x28: removes a player from a session group bitfield, freeing the slot when it empties.
 int swrMultiplayer_ApplyPlayerLeave(void* message);
+
+// Formats a minutes/seconds/hundredths time into a shared text buffer and returns it (best guess).
+char* swrMultiplayer_FormatTimeString_Maybe(float minutes, float seconds, float hundredths);
 // 0x2a: handles a player quit - closes the game on host quit, else removes that player.
 int swrMultiplayer_ApplyPlayerQuit(void* message);
 // 0x24/0x2f: no-op handler (acknowledges without acting).
@@ -275,6 +294,9 @@ int swrMultiplayer_IsAvailable(void);                               // can a ses
 unsigned int swrMultiplayer_CreateSession(wchar_t* a1, wchar_t* a2, wchar_t* a3, char* a4, int a5);
 char* swrMultiplayer_GetSessionName(void);
 void swrMultiplayer_SetNetworkTick(int value); // sets swrMultiplayer_networkTick (read by UpdateNetworkTick/ApplyEvent)
+
+// Resets the racer-list overlay slot, TTL, and id tables (best guess).
+void swrMultiplayer_ResetRacerListState_Maybe(void);
 void swrMultiplayer_SetRacerListDisplay(int enabled, int x, int y); // toggle racer-list overlay + free slot cache
 void swrMultiplayer_FreeRacerSlot(int slot);
 void swrMultiplayer_ResetRaceSettings(void);                        // reset racer ids + track (Boonta) / laps (3)
@@ -354,5 +376,11 @@ void swrMultiplayer_SendMenuEvent(int value);
 // 'rejn' / 'prxy': forward a SendEvent payload (a4..a10) for the rejoin / proxy events.
 void swrMultiplayer_SendRejoin(int a4, float a5, float a6, double a7, void* a8, void* a9, int a10);
 void swrMultiplayer_SendProxy(int a4, float a5, float a6, double a7, void* a8, void* a9, int a10);
+
+// Marks every pod as remote across the entity table, stamping a remote tag (best guess).
+void swrMultiplayer_MarkAllPodsRemote_Maybe(void);
+
+// Marks one indexed pod as host or local, stamping its proxy state (best guess).
+void swrMultiplayer_MarkPodLocal_Maybe(int playerIndex);
 
 #endif // SWRMULTIPLAYER_H

--- a/src/Win95/stdComm.h
+++ b/src/Win95/stdComm.h
@@ -13,10 +13,13 @@
 #define stdComm_GetConnection_ADDR (0x00486c10)
 
 #define stdComm_GetNumSessionSettings_ADDR (0x00486c50)
+#define stdComm_GetSessionSettingsByIndex_ADDR (0x00486c60)
 #define stdComm_Send_ADDR (0x00486ca0)
 #define stdComm_Receive_ADDR (0x00486cd0)
+#define stdComm_HostSession_ADDR (0x00486d40)
 
 #define stdComm_GetSessionSettings_ADDR (0x00486f50)
+#define stdComm_SetSessionOpenState_ADDR (0x00486fc0)
 #define stdComm_JoinSession_ADDR (0x004870d0)
 
 #define stdComm_Close_ADDR (0x00487180)
@@ -42,10 +45,19 @@ int stdComm_GetNumConnections(void);
 int stdComm_GetConnection(unsigned int connectionIndex, StdCommConnection* connection_out);
 
 int stdComm_GetNumSessionSettings(void);
+
+// Copies the indexed session-settings record into the output, returning failure on out-of-range.
+int stdComm_GetSessionSettingsByIndex(unsigned int index, StdCommSessionSettings* pSettings);
 int stdComm_Send(DPID idFrom, DPID idTo, LPVOID lpData, DWORD dwDataSize, DWORD dwFlags);
 int stdComm_Receive(DPID* pSender, void* pData, unsigned int* pLength);
 
+// Builds a DirectPlay session description and opens it to create and host a session.
+HRESULT stdComm_HostSession(int pSessionDesc);
+
 int stdComm_GetSessionSettings(void* unused, StdCommSessionSettings* pSettings);
+
+// Toggles a session's open or locked state and capacity host-side, updating its name suffix.
+int stdComm_SetSessionOpenState(int unused, int sessionName, DWORD maxPlayers, int bClosed);
 HRESULT stdComm_JoinSession(int sessionIndex, wchar_t* password);
 
 void stdComm_Close(void);


### PR DESCRIPTION
Multiplayer cluster of the naming sweep. Header-only across sithMulti.h / swrMultiplayer.h / stdComm.h, builds clean.

14 newly-named: sithMulti callback helpers; swrMultiplayer racer-list overlay (tick/render/reset) + pod local/remote tagging + the menu-screen builder; and three stdComm session helpers — `stdComm_HostSession` (DirectPlay Open mode 2), `stdComm_SetSessionOpenState`, `stdComm_GetSessionSettingsByIndex` (the indexed getter, distinct from the existing non-indexed one). Uncertain ones carry `_Maybe`.

One register-arg time-formatter at 0x41bc20 whose float args the decompiler couldn't recover is left unnamed for a GUI pass rather than guessed.