### PR TITLE
swrModel/rd*/std3D/Window: name 33 renderer + engine functions

### DIFF
--- a/src/Engine/rdClip.h
+++ b/src/Engine/rdClip.h
@@ -15,6 +15,8 @@
 #define rdClip_Face3GTOrtho_ADDR (0x00499840)
 #define rdClip_Face3T_ADDR (0x0049a390)
 #define rdClip_Face3TOrtho_ADDR (0x0049b7d0)
+#define rdClip_Face3TTestFrustum_Maybe_ADDR (0x0049c810)
+#define rdClip_Face3TClipPlane_Maybe_ADDR (0x0049c9f0)
 
 int rdClip_Line2(rdCanvas* canvas, int* pX1, int* pY1, int* pX2, int* pY2);
 int rdClip_CalcOutcode2(rdCanvas* canvas, int x, int y);
@@ -28,5 +30,11 @@ int rdClip_Face3GT(rdClipFrustum* pFrustrum, rdVector3* aVertices, rdVector2* aT
 int rdClip_Face3GTOrtho(rdClipFrustum* pFrustrum, rdVector3* aVertices, rdVector2* aTexVertices, int numVertices);
 int rdClip_Face3T(rdClipFrustum* pFrustrum, rdVector3* aVertices, rdVector2* aTexVertices, rdVector4* aIntensities, int numVertices);
 int rdClip_Face3TOrtho(rdClipFrustum* pFrustum, rdVector3* aVertices, rdVector2* aTexVertices, rdVector4* aIntensities, int numVertices);
+
+// Tests a face against the perspective frustum planes, returning the vertex count to keep or zero to reject (best guess).
+int rdClip_Face3TTestFrustum_Maybe(float* frustum, int* face);
+
+// Clips a textured-gouraud face against one frustum plane, interpolating crossings into the output (best guess).
+void rdClip_Face3TClipPlane_Maybe(int* frustum, int* face, int* out);
 
 #endif // RDCLIP_H

--- a/src/Engine/rdPuppet.h
+++ b/src/Engine/rdPuppet.h
@@ -4,8 +4,12 @@
 #include "types.h"
 
 #define rdPuppet_BuildJointMatrices_ADDR (0x00493310)
+#define rdClip_Face3T_Maybe_ADDR (0x00493b80)
 
 // void __cdecl rdPuppet_BuildJointMatrices(RdThing* prdThing, const RdMatrix* pPlacement)
 void rdPuppet_BuildJointMatrices(void* prdThing, rdMatrix34* pPlacement);
+
+// Clips a perspective textured-gouraud face: copies and offsets verts, then culls and W-clips it (best guess).
+void rdClip_Face3T_Maybe(rdClipFrustum* frustum, unsigned int* srcFace, int* dstFace, float* offset);
 
 #endif // RDPUPPET_H

--- a/src/Platform/std3D.h
+++ b/src/Platform/std3D.h
@@ -10,6 +10,8 @@
 #define std3D_Open_ADDR (0x00489ec0)
 
 #define std3D_Close_ADDR (0x0048a1c0)
+#define std3D_GetTextureFormatInfo_Maybe_ADDR (0x0048a230)
+#define std3D_GetTextureFormatClass_Maybe_ADDR (0x0048a2d0)
 
 #define std3D_GetNumTextureFormats_ADDR (0x0048a2f0)
 #define std3D_StartScene_ADDR (0x0048a300)
@@ -48,6 +50,12 @@ Device3D* std3D_GetAllDevices(void);
 int std3D_Open(unsigned int deviceNum);
 
 void std3D_Close(void);
+
+// Selects a texture format and returns its color-key fields and color-mode descriptor (best guess).
+void std3D_GetTextureFormatInfo_Maybe(int formatType, tColorMode* outColorModes, int* outHasColorKey, void** outColorKey);
+
+// Classifies a texture by a format field into one of three classes (best guess).
+int std3D_GetTextureFormatClass_Maybe(tSystemTexture* tex);
 
 int std3D_GetNumTextureFormats(void);
 int std3D_StartScene(void);

--- a/src/Primitives/rdMatrix.h
+++ b/src/Primitives/rdMatrix.h
@@ -9,6 +9,9 @@
 #define rdMatrix_Multiply44_ADDR (0x0042fb70)
 #define rdMatrix_Multiply44Acc_ADDR (0x0042ff80)
 #define rdMatrix_Unk1_ADDR (0x00430310)
+#define rdMatrix_LUDecompose_Maybe_ADDR (0x004304c0)
+#define rdMatrix_LUSolve_Maybe_ADDR (0x00430730)
+#define rdMatrix_InvertGeneral_Maybe_ADDR (0x00430810)
 #define rdMatrix_Multiply3_ADDR (0x00430980)
 #define rdMatrix_Transform3_ADDR (0x00430a00)
 #define rdMatrix_Multiply4_ADDR (0x00430ab0)
@@ -57,6 +60,15 @@ void rdMatrix_GetColumn(rdMatrix44* mat, int n, rdVector3* out);
 void rdMatrix_Multiply44(rdMatrix44* out, const rdMatrix44* mat1, const rdMatrix44* mat2);
 void rdMatrix_Multiply44Acc(rdMatrix44* out, rdMatrix44* mat2);
 void rdMatrix_Unk1(rdMatrix44* m1, rdMatrix44* m2);
+
+// Performs LU factorization with partial pivoting of a 3x3 matrix for the matrix inverse (best guess).
+int rdMatrix_LUDecompose_Maybe(float* mat, float* in, float* pivots);
+
+// Solves a linear system in place by forward and back substitution using the LU pivots (best guess).
+void rdMatrix_LUSolve_Maybe(float* lu, int* pivots, float* b);
+
+// Computes a general 4x4 matrix inverse via LU decomposition and back-substitution (best guess).
+void rdMatrix_InvertGeneral_Maybe(rdMatrix44* out, rdMatrix44* in);
 void rdMatrix_Multiply3(rdVector3* out, rdVector3* in, const rdMatrix44* mat);
 void rdMatrix_Transform3(rdVector3* out, rdVector3* in, const rdMatrix44* mat);
 void rdMatrix_Multiply4(rdVector4* out, rdVector4* in, rdMatrix44* mat);

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -73,6 +73,7 @@
 #define swrModel_MeshGetCollisionData_ADDR (0x004317E0)
 #define swrModel_MeshGetAABB_ADDR (0x00431820)
 #define swrModel_NodeGetMesh_ADDR (0x00431850)
+#define swrModel_MeshSetCollisionData_Maybe_ADDR (0x00431860)
 #define swrModel_ClassifyMaterialFacing_ADDR (0x00431880)
 
 #define swrModel_MeshGetBehavior_ADDR (0x004318b0)
@@ -80,6 +81,8 @@
 #define swrModel_NodeModifyFlags_ADDR (0x00431A50)
 #define swrModel_NodeGetFlags1Or2_ADDR (0x00431B00)
 #define swrModel_NodeInit_ADDR (0x00431B20)
+#define swrViewport_SetRootNode_Maybe_ADDR (0x00431b90)
+#define swrViewport_ResetCameraState_Maybe_ADDR (0x00431ba0)
 
 // Sphere / ray vs mesh collision (the swept-collision pipeline).
 #define swrModel_PointInTriangle_ADDR (0x00441040)
@@ -134,6 +137,7 @@
 #define swrModel_SetAnimListSpeed_ADDR (0x0044b330)
 
 #define swrModel_AnimationsSetSettings_ADDR (0x0044B360)
+#define swrModel_NodeGetAnimSpeed_Maybe_ADDR (0x0044b470)
 
 // Per-node render-matrix (MVP) compose + cache into swrModel_NodeTransformed +0xf4.
 #define swrModel_GetNodeYaw_ADDR (0x0044b4a0)
@@ -180,6 +184,12 @@
 #define swrModel_LoadPuppet_ADDR (0x0045CE10)
 
 #define swrModel_SwapSceneModels_ADDR (0x0045cf30)
+#define swrModel_FxAnimGetState_Maybe_ADDR (0x0046d690)
+#define swrModel_FxAdvanceAnimTimers_Maybe_ADDR (0x0046d6a0)
+#define swrMath_ClampToRange_Maybe_ADDR (0x0046d730)
+#define swrModel_DeformPoddConnectionMesh_ADDR (0x00481c30)
+#define swrModel_TransformPointAndDir_Maybe_ADDR (0x00482dd0)
+#define swrViewport_AdvanceFrameParity_Maybe_ADDR (0x00482e20)
 
 void* swrModel_AllocMaterial(unsigned int offset, unsigned int byteSize);
 
@@ -251,6 +261,9 @@ uint32_t* swrModel_MeshGetPrimitiveSizes(swrModel_Mesh* mesh);
 void swrModel_MeshGetCollisionData(swrModel_Mesh* mesh, int disable, swrModel_CollisionVertex** vertices, uint16_t** optional_indices);
 void swrModel_MeshGetAABB(swrModel_Mesh* mesh, float* aabb);
 swrModel_Mesh* swrModel_NodeGetMesh(swrModel_NodeMeshGroup* node, int a2);
+
+// Stores collision data on a mesh when the type matches (best guess).
+void swrModel_MeshSetCollisionData_Maybe(int mesh, int type, void* data);
 // Classifies a mesh material's collision facing (front/back/double-sided) for the ray test.
 int swrModel_ClassifyMaterialFacing(swrModel_MeshMaterial* material, int enable);
 
@@ -259,6 +272,12 @@ swrModel_Behavior* swrModel_MeshGetBehavior(swrModel_Mesh* mesh);
 void swrModel_NodeModifyFlags(swrModel_Node* node, int flag_id, int value, char modify_children, int modify_op);
 uint32_t swrModel_NodeGetFlags1Or2(swrModel_Node* node, int flag_id);
 void swrModel_NodeInit(swrModel_Node* node, uint32_t base_flags);
+
+// Stores the root node pointer on a viewport (best guess).
+void swrViewport_SetRootNode_Maybe(swrViewport* viewport, swrModel_Node* node);
+
+// Resets the camera and view globals to their default scale, field of view, and flags (best guess).
+void swrViewport_ResetCameraState_Maybe(void);
 
 // Sphere/ray-vs-mesh collision (distinct from the closest-point query family
 // further down). The MeshCollisionFaceCallback* below are the per-face hooks
@@ -325,6 +344,9 @@ void swrModel_SetAnimListSpeed(swrModel_Animation** anims, float speed);
 
 void swrModel_AnimationsSetSettings(swrModel_Animation** anims, float animation_time, float loop_start_time, float loop_end_time, bool set_loop, float transition_speed, float loop_transition_speed);
 
+// Returns a node's animation speed field, defaulting when the node is null (best guess).
+float swrModel_NodeGetAnimSpeed_Maybe(int** node);
+
 // Per-node render-matrix caching (fills swrModel_NodeTransformed +0xf4 block used for collision/render).
 float swrModel_GetNodeYaw(int a1, int* nodePair);
 void swrModel_CachePrecomputedMatrices(void);
@@ -348,6 +370,15 @@ void swrModel_AnimationsResetToZero(swrModel_Animation** anims);
 // all are still playing or the array is empty. Used to gate engine-fireball spawning.
 int swrModel_AnyFxAnimDone(swrModel_Animation** anims);
 
+// Returns zero as an always-not-done FX animation state (best guess).
+int swrModel_FxAnimGetState_Maybe(void);
+
+// Advances up to five FX or engine animation timers by the per-frame delta, gated by enable flags (best guess).
+void swrModel_FxAdvanceAnimTimers_Maybe(int entity);
+
+// Clamps a value to a centered range and then to a min/max range (best guess).
+float swrMath_ClampToRange_Maybe(float value, float center, float min, float max, float upper, float lower);
+
 swrModel_Material* swrModel_NodeFindFirstMaterial(swrModel_Node* node);
 void swrModel_NodeSetAnimationFlagsAndSpeed(swrModel_Node* node, swrModel_AnimationFlags flags_to_disable, swrModel_AnimationFlags flags_to_enable, float speed);
 
@@ -358,6 +389,9 @@ float swrModel_ClosestPointOnTriangleImpl(float* query, float* a, float* b, floa
 
 void swrModel_NodeSetLodDistances(swrModel_NodeLODSelector* node, float* a2);
 void swrModel_SetupFaceNormal(int vertexArray, int faceOut, int i0, int i1, int i2); // rdMath_CalcSurfaceNormal + store the 3 vertex indices
+
+// Deforms the pod engine-cable connection mesh, rewriting its tube vertices and face normals by energy.
+void swrModel_DeformPoddConnectionMesh(swrModel_Node* node, int unk2, int unk3, int unk4, int unk5, float energy, float maxEnergy, int unk8);
 
 int swrModel_NodeComputeFirstMeshAABB(swrModel_Node* node, float* aabb, int a3);
 
@@ -377,6 +411,12 @@ int swrModel_NodeSelectLOD(swrModel_Node* node);
 void swrModel_NodeTreeClosestPoint(swrModel_Node* targetNode, swrModel_Node* node, rdMatrix44* transform, int active, int mode, float* minDistSq, rdVector3* queryPoint, rdVector3* outPoint, rdVector3* outNormal);
 // Entry point: find the surface point on a model nearest queryPoint, writing outPoint + outNormal.
 void swrModel_FindClosestPointOnModel(swrModel_Node* node, swrModel_Node* targetNode, rdVector3* queryPoint, int maxNodeDepth, void* nodeChainOut, rdVector3* outPoint, rdVector3* outNormal);
+
+// Transforms a point and direction into a frame-described coordinate space (best guess).
+void swrModel_TransformPointAndDir_Maybe(rdVector3* outPoint, rdVector3* outDir, int frameDesc, rdVector3* point, rdVector3* dir);
+
+// Advances per-frame buffer parity, stepping a ring counter and flipping a toggle (best guess).
+void swrViewport_AdvanceFrameParity_Maybe(void);
 
 void swrModel_LoadPuppet(MODELID model, INGAME_MODELID index, int a3, float a4);
 

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -224,8 +224,11 @@
 #define swrScene_LoadObjects_ADDR (0x00448f40)
 #define swrScene_InitFog_ADDR (0x00449000)
 #define swrScene_InitWorld_ADDR (0x00449040)
+#define swrScene_Stub_Maybe_ADDR (0x00449090)
 #define swrScene_InitCameras_ADDR (0x004490a0)
 #define swrScene_Init_ADDR (0x004491f0)
+#define swrScene_ClearTextureAnim_Maybe_ADDR (0x00449260)
+#define swrScene_UpdateTextureScroll_Maybe_ADDR (0x00449270)
 #define swrScene_SetObjectsLoaded_ADDR (0x004804a0)
 #define swrScene_ResetRenderState_ADDR (0x004834b0)
 
@@ -659,8 +662,17 @@ void swrScene_LoadPreviewModel(void);
 void swrScene_LoadObjects(void);
 void swrScene_InitFog(void);
 void swrScene_InitWorld(int param_1, int param_2);
+
+// An empty placeholder scene routine (best guess).
+void swrScene_Stub_Maybe(void);
 void swrScene_InitCameras(void);
 void swrScene_Init(int param_1, int param_2);
+
+// Clears the texture-animation block driven by the texture-scroll tick (best guess).
+void swrScene_ClearTextureAnim_Maybe(void);
+
+// Advances scrolling palette animation each step, rotating and copying palette entries (best guess).
+void swrScene_UpdateTextureScroll_Maybe(void);
 // Sets the scene-objects-loaded flag; called by swrObjJdge_F4 at 'Begn'.
 void swrScene_SetObjectsLoaded(void);
 void swrScene_ResetRenderState(void);

--- a/src/Swr/swrRender.h
+++ b/src/Swr/swrRender.h
@@ -11,9 +11,11 @@
 #define SetLightColorsAndDirection_ADDR (0x00409600)
 #define SetLightColorsAndDirectionFromPrimaryLight_ADDR (0x00409700)
 #define SetAlternativeLightColorsAndDirection_ADDR (0x00409750)
+#define swrRender_InitScene_ADDR (0x00409800)
 
 #define rdModel3Mesh_ApplySwrModelColors_ADDR (0x00432B80)
 #define rdModel_ConvertSwrModelMesh_ADDR (0x00432D30)
+#define rdModel_SetForceFlatNormals_Maybe_ADDR (0x00433680)
 
 #define rdModel_ApplyNodeSettings_ADDR (0x0044C440)
 #define rdModel_RevertNodeSettings_ADDR (0x0044C4C0)
@@ -26,6 +28,10 @@
 #define NodeLODSelector_FindLODIndex_ADDR (0x0044d740)
 #define rdModel_AddNodeToScene_ADDR (0x0044d7c0)
 #define rdModel_AddNodeToScene2_ADDR (0x0044dae0)
+#define rdModel_BuildAndDrawScene_ADDR (0x0044db70)
+#define rdModel_BuildSceneNoDraw_Maybe_ADDR (0x0044de10)
+#define rdModel_SetupSceneFogAndLights_Maybe_ADDR (0x0044e000)
+#define rdModel_SetFogEnabled_Maybe_ADDR (0x0044e0c0)
 
 #define SetFogParameters_ADDR (0x0044E0E0)
 #define SetPrimaryLightColorsAndDirection_ADDR (0x0044E140)
@@ -48,8 +54,14 @@ float* SetLightColorsAndDirection(int light_index, short ambient_r, short ambien
 int SetLightColorsAndDirectionFromPrimaryLight(short light_index);
 float* SetAlternativeLightColorsAndDirection(int index, short light_r, short light_g, short light_b, short pos_x, short pos_y, short pos_z);
 
+// Builds the canvas, camera, and lights from the display settings and drives the progress bar.
+rdVector4* swrRender_InitScene(swrMainDisplaySettings* settings);
+
 void rdModel3Mesh_ApplySwrModelColors(rdModel3Mesh* rdmesh, swrModel_Mesh* mesh);
 void rdModel_ConvertSwrModelMesh(Gfx* display_list, rdModel3Mesh* result, swrModel_Mesh* mesh, RdFaceFlag material_flags);
+
+// Toggles a render flag for forcing flat normals (best guess).
+void rdModel_SetForceFlatNormals_Maybe(int enable);
 
 char rdModel_ApplyNodeSettings(char flags_5, short light_index);
 void rdModel_RevertNodeSettings(char state);
@@ -62,6 +74,18 @@ void rdModel_NodeTransformedComputedToScene(swrModel_NodeTransformedComputed* no
 int NodeLODSelector_FindLODIndex(swrModel_NodeLODSelector* node);
 void rdModel_AddNodeToScene(swrModel_Node* a1);
 void rdModel_AddNodeToScene2(swrModel_Node* a1);
+
+// Builds and draws the full scene: allocates the shared root model and pools, walks the viewport root, and renders it.
+void rdModel_BuildAndDrawScene(int* outAccum, swrViewport* viewport);
+
+// Builds the scene without drawing it, walking the viewport root in an accumulation pass (best guess).
+void rdModel_BuildSceneNoDraw_Maybe(swrViewport* viewport);
+
+// Initializes scene fog and light globals and enables or disables fog and the primary light (best guess).
+void rdModel_SetupSceneFogAndLights_Maybe(int* state);
+
+// Toggles the fog-disable game-setting flag (best guess).
+void rdModel_SetFogEnabled_Maybe(int enable);
 
 void SetFogParameters(int fogStart_, int fogEnd_, int fogColorR, int fogColorG, int fogColorB, int fogColorA);
 void SetPrimaryLightColorsAndDirection(short* ambient_color, short* light_color, short* light_position);

--- a/src/Swr/swrViewport.h
+++ b/src/Swr/swrViewport.h
@@ -4,6 +4,7 @@
 #include "types.h"
 
 #define swrViewport_SetCameraIndex_ADDR (0x00428B40)
+#define swrViewport_SetActiveCamera_ADDR (0x00428bd0)
 
 #define swrViewport_UpdateCameras_ADDR (0x00429540)
 
@@ -34,6 +35,9 @@
 #define swrViewport_SetNodeFlagsForAllViewports_ADDR (0x00483ff0)
 
 void swrViewport_SetCameraIndex(short a1, swrViewport* mesh);
+
+// Selects the active viewport camera, clearing the previous selection's flag and setting the new one's.
+void swrViewport_SetActiveCamera(short cameraIndex);
 void swrViewport_UpdateCameras();
 
 // Projects a world (or camera-relative) point to screen pixels for the given viewport.

--- a/src/Unknown/rdMatrixStack.h
+++ b/src/Unknown/rdMatrixStack.h
@@ -17,6 +17,8 @@ int rdMatrixStack34_modified; // 0x004c3c0c
 #define rdMatrixStack44_Push_ADDR (0x00445200)
 #define rdMatrixStack44_Peek_ADDR (0x00445500)
 #define rdMatrixStack44_Pop_ADDR (0x00445630)
+#define rdMatrixStack_SetField_Maybe_ADDR (0x00445640)
+#define rdMatrixStack_GetField_Maybe_ADDR (0x00445660)
 #define rdMatrix44_ringBuffer_Get_ADDR (0x0044b660)
 #define SetModelMVPAndTranslation_ADDR (0x0044b690)
 #define rdMatrixStack34_Push_ADDR (0x0044b750)
@@ -31,6 +33,12 @@ void rdMatrixStack44_Init(void);
 void rdMatrixStack44_Push(rdMatrix44* in);
 void rdMatrixStack44_Peek(rdMatrix44* out);
 void rdMatrixStack44_Pop(void);
+
+// Sets an indexed matrix-stack state global by selector (best guess).
+void rdMatrixStack_SetField_Maybe(int selector, int value);
+
+// Returns an indexed matrix-stack state global by selector (best guess).
+int rdMatrixStack_GetField_Maybe(int selector);
 rdMatrix44* rdMatrix44_ringBuffer_Get(void);
 void SetModelMVPAndTranslation(const rdMatrix44 *mvp, const rdVector3* translation);
 void rdMatrixStack34_Push(const rdMatrix34* mat);

--- a/src/Win95/Window.h
+++ b/src/Win95/Window.h
@@ -19,6 +19,9 @@
 #define Window_DisplaySettingsBox_ADDR (0x004246d0)
 
 #define Window_DisplaySettingsCallback_ADDR (0x00424700)
+#define Window_DisplaySettingsInitDialog_ADDR (0x00424760)
+#define Window_DisplaySettingsCommand_ADDR (0x00424a90)
+#define Window_DisplaySettingsPopulateModes_ADDR (0x00424e50)
 
 #define Window_SmushPlayCallback_ADDR (0x00425070)
 #define Window_PlayCinematic_ADDR (0x004252a0)
@@ -53,6 +56,15 @@ void Window_SetWindowed(int windowed);
 void Window_DisplaySettingsBox(HWND hwnd, swrMainDisplaySettings* displaySettings);
 
 int Window_DisplaySettingsCallback(HWND dialogBoxHwnd, unsigned int message, WPARAM infos, LPARAM displaySettings);
+
+// Initializes the display-settings dialog: populates the device, mode, and antialias combo boxes and option checkboxes.
+BOOL Window_DisplaySettingsInitDialog(HWND hDlg, WPARAM wParam, swrMainDisplaySettings* displaySettings);
+
+// Handles display-settings dialog commands, writing selections to the settings struct and registry on Accept.
+void Window_DisplaySettingsCommand(HWND hDlg, int controlId, WPARAM wParam, int notifyCode);
+
+// Repopulates the 3D-device and display-mode combo boxes for the selected draw device.
+void Window_DisplaySettingsPopulateModes(HWND hDlg, swrMainDisplaySettings* displaySettings);
 
 int Window_SmushPlayCallback(const SmushImage* image_info);
 int Window_PlayCinematic(char** znmFile);


### PR DESCRIPTION
Renderer/model/engine cluster of the naming sweep. Header-only across 10 headers (swrModel, swrViewport, rdModel, rdMatrix, rdClip, rdMatrixStack, std3D, Window, swrRender, swrObj), builds clean.

**33 newly-named**: rdModel scene build/fog/light path, rdClip face-3T clip pipeline, rdMatrix LU inverse trio, swrModel mesh/FX-anim helpers + the pod connection-mesh deformer, swrViewport camera helpers, Window display-settings dialog, std3D texture-format getters. `_Maybe` on the uncertain ones.

**5 divergence fixes** folded into the DB (already upstream under these names): the **DirectDraw Main/ZBuffer** trio — the DB called them `*MainSurface` but all three bodies operate on the z-surface (`GetZBuffer`), so the upstream `*ZBuffer` names are correct; plus `swrDisplay_SetWindowSize`, `swrViewport_ExtractViewTransform`, `rdMatrix_ToTransRotScale`.

One fragment at 0x409cf1 (mid-function tail, no prologue) left for a GUI pass.