### PR TITLE
swrObjHang/swrUI/swrSprite: name 32 front-end UI functions

### DIFF
--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -7,6 +7,10 @@
 #define swrObjHang_SetHangar2State_ADDR (0x004336d0)
 #define swrObjHang_SetHangar2_ADDR (0x004336f0)
 #define swrObjHang_SetUnused_ADDR (0x00433700)
+#define swrObjHang_OnSelectVehicle_Maybe_ADDR (0x00433720)
+#define swrObjHang_OnSelectPlanet_Maybe_ADDR (0x00433740)
+#define swrObjHang_EnterMultiplayerMenu_Maybe_ADDR (0x00433760)
+#define swrObjHang_SetState5_Maybe_ADDR (0x004337d0)
 #define swrRace_AnimateDisplayPod_ADDR (0x004337e0)
 #define swrObjHang_UpdateLoadScreen_ADDR (0x00434ea0)
 #define swrObjHang_UpdateLegalScreen_ADDR (0x00434ec0)
@@ -15,7 +19,9 @@
 #define swrObjHang_UpdateEnterName_ADDR (0x004367c0)
 #define swrObjHang_UpdateMainMenu_ADDR (0x00436860)
 #define swrObjHang_UpdateWattoShop_ADDR (0x004376c0)
+#define swrObjHang_PlayWattoVoiceLines_Maybe_ADDR (0x00437ea0)
 #define swrObjHang_UpdateLookAtVehicle_ADDR (0x00437f70)
+#define swrObjHang_UpdateInspectCamera_ADDR (0x00438d20)
 #define swrObjHang_UpdateJunkyard_ADDR (0x0043abc0)
 #define swrObjHang_UpdateVehicleSelectIntro_ADDR (0x0043c6f0)
 #define swrObjHang_UpdateTauntScene_ADDR (0x0043ca30)
@@ -24,10 +30,12 @@
 #define swrObjHang_UpdateScreenTransition_ADDR (0x0043da90)
 #define swrObjHang_UpdateHoloBillboardMatrix_ADDR (0x0043e210)
 #define swrObjHang_FadeOutAndAdvance_ADDR (0x0043e330)
+#define swrObjHang_FadeScreenFlash_Maybe_ADDR (0x0043e490)
 #define swrObjHang_UpdatePitDroidAnims_ADDR (0x0043e620)
 #define swrObjHang_AimHoloCamera_ADDR (0x0043f8e0)
 #define swrObjHang_UpdateHoloCameraTarget_ADDR (0x0043fbc0)
 #define swrObjHang_SwapSelectedPart_ADDR (0x00440800)
+#define swrUI_DebugColorsEqual_Maybe_ADDR (0x00440990)
 #define GetRequiredPlaceToProceed_ADDR (0x00440a00)
 #define isTrackUnlocked_ADDR (0x00440a20)
 #define isTrackPlayable_ADDR (0x00440aa0)
@@ -226,6 +234,21 @@
 #define swrScene_InitWorld_ADDR (0x00449040)
 #define swrScene_InitCameras_ADDR (0x004490a0)
 #define swrScene_Init_ADDR (0x004491f0)
+#define swrObjHang_LoadScreenAssets_ADDR (0x004586e0)
+#define swrObjHang_SetupScreenScene_ADDR (0x00459150)
+#define swrUI_ResetMenuInputBitsets_ADDR (0x0045a3e0)
+#define swrObjHang_EaseSine_Maybe_ADDR (0x0045a420)
+#define swrObjHang_LayoutVehicleSelectIcons_ADDR (0x0045a840)
+#define swrObjHang_ResetCameraAssignments_Maybe_ADDR (0x0045bb60)
+#define swrObjElmo_PlayRandomVoiceSfx_Maybe_ADDR (0x00467c80)
+#define swrObjElmo_Init_Maybe_ADDR (0x004686b0)
+#define swrObjHang_TickHolotableSpin_Maybe_ADDR (0x00469010)
+#define swrObjHang_TurnIconToCamera_Maybe_ADDR (0x00469070)
+#define swrObjHang_UpdateCantinaHolotable_ADDR (0x00469380)
+#define swrModel_GetNodeTranslation_Maybe_ADDR (0x00469b50)
+#define swrObjHang_StepTransition_ADDR (0x00469b90)
+#define swrObjHang_TickMenuRepeatDelay_Maybe_ADDR (0x00469bf0)
+#define swrObjHang_NavigateVehicleSelect_ADDR (0x00469c30)
 #define swrScene_SetObjectsLoaded_ADDR (0x004804a0)
 #define swrScene_ResetRenderState_ADDR (0x004834b0)
 
@@ -237,6 +260,18 @@ void swrObjHang_SetHangar2(swrObjHang* hang);
 
 void swrObjHang_SetUnused(void);
 
+// Menu callback that switches to the select-vehicle screen and sets a flag (best guess).
+void swrObjHang_OnSelectVehicle_Maybe(void);
+
+// Menu callback that switches to the select-planet screen (best guess).
+void swrObjHang_OnSelectPlanet_Maybe(void);
+
+// Menu callback that enters the multiplayer menu, firing page callbacks and pushing its page (best guess).
+void swrObjHang_EnterMultiplayerMenu_Maybe(void);
+
+// Sets a hangar menu state flag (best guess).
+void swrObjHang_SetState5_Maybe(void);
+
 void DrawTracks(swrObjHang* hang, char param_2);
 
 // hangar front-end per-screen update handlers (dispatched by swrObjHang_F0 on swrObjHang_STATE):
@@ -245,7 +280,13 @@ void swrObjHang_UpdateSplashScreen(swrObjHang* hang);
 void swrObjHang_UpdateEnterName(swrObjHang* hang);
 void swrObjHang_UpdateMainMenu(swrObjHang* hang);
 void swrObjHang_UpdateWattoShop(swrObjHang* hang); // parts / pit-droid shop
+
+// Plays gated Watto-shop voice lines for greeting versus parts banter (best guess).
+void swrObjHang_PlayWattoVoiceLines_Maybe(int hang);
 void swrObjHang_UpdateLookAtVehicle(swrObjHang* hang); // view-pod 3D screen
+
+// Drives the inspect-vehicle screen: orbit camera, per-part screen text, and cancel back to the main menu.
+void swrObjHang_UpdateInspectCamera(swrObjHang* hang);
 void swrObjHang_UpdateJunkyard(swrObjHang* hang); // used-parts screen
 
 // hangar menu navigation + shop (parts/truguts):
@@ -253,8 +294,14 @@ void swrObjHang_UpdateJunkyard(swrObjHang* hang); // used-parts screen
 int swrObjHang_UpdateScreenTransition(swrObjHang* hang, int param_2, int param_3);
 // Fades the active screen to black, then on completion commits the queued menu-state change.
 int swrObjHang_FadeOutAndAdvance(swrObjHang* hang);
+
+// Fades a screen-flash sprite's alpha down over three cycles, hides it, and returns done (best guess).
+int swrObjHang_FadeScreenFlash_Maybe(void);
 // Swaps the selected part between the pod and the junkyard inventory (models + truguts).
 void swrObjHang_SwapSelectedPart(swrObjHang* hang);
+
+// Returns whether two RGB triplets match when the debug flag is set (best guess).
+int swrUI_DebugColorsEqual_Maybe(char* a, char* b);
 // Updates the Watto-shop pit-droid Elmo animation states (idle droids vs. the focused one).
 void swrObjHang_UpdatePitDroidAnims(swrObjHang* hang);
 // Whether the hangar camera is still moving toward its target menu position.
@@ -374,7 +421,19 @@ void swrObjHang_LoadAllPilotSprites(void);
 
 void swrObjHang_InitTrackSprites(swrObjHang* hang, int initTracks);
 
+// Loads the scene assets for the current screen: clears sprites and nodes then loads UI, models, and puppets.
+void swrObjHang_LoadScreenAssets(swrObjHang* hang);
+
+// Sets up the current screen's scene and camera: places puppets, picks the camera state, and configures lighting.
+void swrObjHang_SetupScreenScene(swrObjHang* hang);
+
 int swrObjHang_F4(swrObjHang* hang, int* subEvents, int* p3, void* p4, int p5);
+
+// Resets the front-end menu input bitsets to their default state.
+void swrUI_ResetMenuInputBitsets(void);
+
+// Computes a cosine-based sine ease used by the holo-transition animators (best guess).
+float swrObjHang_EaseSine_Maybe(float t, float period);
 
 // Build a local player's menu (UI) input bitsets (swrUI_localPlayersInputPressedBitset /
 // DownBitset) for this frame by edge-detecting the player's held in-race input
@@ -383,6 +442,9 @@ void swrUI_UpdatePlayerMenuInput(int player);
 // Accumulate one menu-input bit for a player: set the pressed bit on a rising edge and
 // track the held bit (mask) in swrUI_localPlayersInputDownBitset. Called by the above.
 void swrUI_AccumulateMenuInputBit(int player, int held, unsigned int mask);
+
+// Lays out the vehicle and upgrade select icon ring positions for the three sub-screens.
+void swrObjHang_LayoutVehicleSelectIcons(swrObjHang* hang);
 
 // Galaxy-map / planet-select hologram screen.
 // One-time init of the whole swrObjHang object: resets the working game data to defaults,
@@ -419,6 +481,9 @@ void swrObjHang_StartRace(swrObjHang* hang, int* param_2, int param_3);
 void* swrObjHang_BuildRosterSinglePlayer(swrObjHang* hang, int* out);
 void* swrObjHang_BuildRosterMultiplayer(swrObjHang* hang, int* out);
 int swrObjHang_FindPlayerRacerSlot(swrObjHang* hang);
+
+// Clears the per-player camera assignment indices to -1 (best guess).
+void swrObjHang_ResetCameraAssignments_Maybe(void);
 // Assign a cMan camera to each local-human racer ('NAsn' sub-event); set up the camera->player map.
 void swrObjHang_AssignRacerCameras(swrObjHang* hang);
 void swrObjHang_InitCameraAssignments(swrObjHang* hang);
@@ -540,13 +605,25 @@ void swrObjElmo_F3(swrObjElmo* elmo);
 
 int swrObjElmo_F4(swrObjElmo* elmo, int* subEvents);
 
+// Initializes a fresh Elmo object, setting node pointers, zeroing vectors, and seeding random phase (best guess).
+void swrObjElmo_Init_Maybe(swrObjElmo* elmo, void* node, void* param_3, int type);
+
 // swrObjElmo behavior/animation (pit-droid / hangar character AI):
 // Sets the current animation state (maps a state command to an anim id, plays sounds).
 void swrObjElmo_SetAnimState(swrObjElmo* elmo, int animCmd);
+
+// Plays one of five random Elmo voice sounds when the sound flag gate allows it (best guess).
+void swrObjElmo_PlayRandomVoiceSfx_Maybe(int sfx1, int sfx2, int sfx3, int sfx4, int sfx5);
 // Look up the 'Elmo' entity by index, set its node transform + anim params, then SetAnimState.
 void swrObjElmo_SetTransformAndAnimById(int elmoId, int animCmd, rdVector3* param_3, rdVector3* param_4, float param_5, float param_6);
 // Look up the 'Elmo' entity by index and forward to swrObjElmo_SetAnimState.
 void swrObjElmo_SetAnimStateById(int elmoId, int animCmd);
+
+// Advances the holotable spin timer and updates its icon-spin value each frame (best guess).
+void swrObjHang_TickHolotableSpin_Maybe(void);
+
+// Rotates an object's facing vector toward the camera until it faces it, then reapplies its transform (best guess).
+void swrObjHang_TurnIconToCamera_Maybe(int obj);
 // Looks up the playback rate and duration for the current animation (per character type).
 void swrObjElmo_GetAnimTiming(swrObjElmo* elmo, float* outRate, float* outDuration);
 // Sets the arrived flag when within range of the walk target.
@@ -561,6 +638,21 @@ void swrObjElmo_SetTargetWaypoint(swrObjElmo* elmo, int waypoint);
 int swrObjElmo_TryTransition(swrObjElmo* elmo);
 // Smoothly turns the character's facing toward the target.
 void swrObjElmo_TurnToFaceTarget(swrObjElmo* elmo);
+
+// Animates the vehicle and track select holotable: lerps lighting, scales the projector and beam, and drives the holo light (best guess).
+void swrObjHang_UpdateCantinaHolotable(int param_1);
+
+// Copies the translation of an entity's indexed child node into the output (best guess).
+void swrModel_GetNodeTranslation_Maybe(rdVector3* out, int entity, int childIndex);
+
+// Advances the front-end screen-transition progress by a rate and clamps it to zero through one.
+float swrObjHang_StepTransition(float rate);
+
+// Decrements the menu key-repeat delay timer toward zero each frame (best guess).
+void swrObjHang_TickMenuRepeatDelay_Maybe(void);
+
+// Handles up/down vehicle-select navigation with key-repeat, UI sounds, and transition stepping.
+void swrObjHang_NavigateVehicleSelect(int player, float param_2, int param_3);
 
 // Frees a particle object: hides its model nodes, clears the node-array backref, swrObj_Free.
 void swrObjSmok_Free(swrObj* smok);

--- a/src/Swr/swrSprite.h
+++ b/src/Swr/swrSprite.h
@@ -12,6 +12,7 @@
 #define swrSprite_DisplayCursor_ADDR (0x00408220)
 
 #define swrSprite_GetTextureFromTGA_ADDR (0x004114d0)
+#define swrUI_GetMenuRoot_Maybe_ADDR (0x00411720)
 
 #define swrSprite_LoadAllSprites_ADDR (0x00412650)
 
@@ -84,6 +85,7 @@
 #define swrSprite_Draw_ADDR (0x0044F160)
 #define swrSprite_ResetCurrentMaterial_ADDR (0x0044F5F0)
 #define swrSprite_InitDrawing_ADDR (0x0044F600)
+#define swrSprite_SetDrawStateWord_Maybe_ADDR (0x0044f630)
 #define swrSprite_GetUIScale_ADDR (0x0044F640)
 
 #define AddDotToMiniMap_ADDR (0x0044FEF0)
@@ -103,6 +105,9 @@ void swrSprite_SetCursorVisibility(int visible);
 void swrSprite_DisplayCursor(void);
 
 swrSpriteTexture* swrSprite_GetTextureFromTGA(char* filename_tga, int id);
+
+// Returns the global UI tree root pointer (best guess).
+swrUI_unk* swrUI_GetMenuRoot_Maybe(void);
 
 void swrSprite_LoadAllSprites(void);
 
@@ -175,6 +180,9 @@ void rdProcEntry_Add2DQuad5(int, int, int, int, int, int, int, int, int, float, 
 void swrSprite_Draw(int* arg0, swrSpriteTexture*, RdMaterial**, float, float, float, float, int, int, int, int, int, int, int, short, float, float, int);
 void swrSprite_ResetCurrentMaterial();
 void swrSprite_InitDrawing();
+
+// Stores a 16-bit sprite draw-state global (best guess).
+void swrSprite_SetDrawStateWord_Maybe(unsigned int value);
 
 // Computes the 2D UI scale factors from the current framebuffer size.
 // out_xscale = screenWidth / 640, out_yscale = screenHeight / 480 (independent).

--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -58,6 +58,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_PopMenuPage_ADDR (0x004118b0)
 #define swrUI_ReparentElement_ADDR (0x00411910) // move an element under a new parent
 #define swrUI_BuildAuxPages_ADDR (0x004121f0) // build aux/overlay windows 0x81-0x89
+#define swrUI_InitAuxPageScale_Maybe_ADDR (0x00412630)
 #define swrUI_Shutdown_ADDR (0x00412e40) // UI teardown (free tree + sprite materials + hash table)
 #define swrUI_AddSprite_ADDR (0x00412fb0)
 #define swrUI_SetSpriteColor_ADDR (0x00413090)
@@ -95,6 +96,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_SetValueText_ADDR (0x00414ab0) // set the secondary value-text (+0x4f8) + value (+0x4fc)
 #define swrUI_SetValue_ADDR (0x00414ae0) // set an element's value field (+0x4fc)
 #define swrUI_GetValueText_ADDR (0x00414af0) // get the value-text (+0x4f8)
+#define swrUI_SetValue2_Maybe_ADDR (0x00414b30)
 #define swrUI_SetSize_ADDR (0x00414b40)
 #define swrUI_SetPos_ADDR (0x00414b60)
 #define swrUI_RunCallbacksScreenText_ADDR (0x00414b80)
@@ -130,6 +132,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_HandleKeyEvent_ADDR (0x00415640)
 #define swrUI_StartPageTransition_ADDR (0x004156a0) // arm the page slide-in (save home pos, offset off-screen)
 #define swrUI_ReplaceIndex_ADDR (0x004157d0)
+#define swrUI_ExchangeSlotValue2_Maybe_ADDR (0x004157f0)
 #define swrUI_SetBBox_ADDR (0x00415810)
 #define swrUI_DefaultElementProc_ADDR (0x00415850)
 #define swrUI_LabelProc_ADDR (0x00415b80) // basic Label (swrUI_NewLabel)
@@ -160,6 +163,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_IsElementFocused_ADDR (0x00417670)
 #define swrUI_SetHighlightState_ADDR (0x00417690)
 #define swrUI_GetPaddedTextBBox_ADDR (0x004176f0)
+#define swrUI_GetButtonBBoxFromText_Maybe_ADDR (0x00417740)
 #define swrUI_GetButtonRowBBox_ADDR (0x004177b0)
 #define swrUI_FramedTextProc_ADDR (0x00417940) // class 0xa (swrUI_NewFramedText; checkable/radio item)
 #define swrUI_3PatchBoxProc_ADDR (0x00417be0) // class 0xb (swrUI_New3PatchBox)
@@ -183,6 +187,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_Menu_MpPage89_ADDR (0x004196b0)
 #define swrUI_Menu_MpPage85_ADDR (0x00419700)
 #define swrUI_Menu_MpPage86_ADDR (0x00419770)
+#define swrUI_SetSpriteSelectionBBox_Maybe_ADDR (0x004197f0)
 #define swrUI_BuildPanelFrame_ADDR (0x00419830) // build the panel's 9-slice background sprites
 #define swrUI_BuildSliderSprites_ADDR (0x00419db0) // render a slider/scrollbar (track/fill/thumb/ticks) from its value
 #define swrUI_HandleSliderKey_ADDR (0x0041a640) // +/- (key) adjust of a slider value, clamped 0-100
@@ -211,6 +216,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_Menu_MpRaceSetup_ADDR (0x0041fc70)
 #define swrUI_Menu_MpRacerList_ADDR (0x004206b0)
 #define swrUI_Front_LoadTrackFromId_ADDR (0x00420930)
+#define swrUI_Menu_MpRacerListRefresh_Maybe_ADDR (0x00420960)
 #define swrUI_Front_HandleCircuits_ADDR (0x0043b0b0)
 #define swrUI_Front_TextMenu_ADDR (0x0043fce0)
 #define swrUI_Front_MenuAxisHorizontal_ADDR (0x00440150)
@@ -247,6 +253,9 @@ int swrUI_Menu_MpPage83(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_
 int swrUI_Menu_MpPage84(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_unk* ui2);
 int swrUI_Menu_MpPage85(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_unk* ui2);
 int swrUI_Menu_MpPage86(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_unk* ui2);
+
+// Writes a sprite selection rectangle, all-zero when collapsed (best guess).
+void swrUI_SetSpriteSelectionBBox_Maybe(int* bbox_out, int collapsed);
 int swrUI_Menu_MpPage88(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_unk* ui2);
 int swrUI_Menu_MpPage89(swrUI_unk* self, unsigned int msg, void* param_3, swrUI_unk* ui2);
 void swrUI_UpdateMouseState(void);
@@ -272,6 +281,9 @@ int swrUI_GetPageStackDepth(void);
 swrUI_unk* swrUI_GetCurrentPage(void);
 void swrUI_ReparentElement(swrUI_unk* parent, swrUI_unk* element);
 void swrUI_BuildAuxPages(void);
+
+// Initializes a UI layout or scale constant global (best guess).
+void swrUI_InitAuxPageScale_Maybe(void);
 int swrUI_AddSprite(swrUI_unk* ui, int index, int spriteId, int* rect, int flag, int flag2);
 swrUI_unk* swrUI_NewWindow(swrUI_unk* parent, int* rect, int id, swrUI_unk_F2* f2);
 swrUI_unk* swrUI_NewLabel(swrUI_unk* parent, int id, int font, char* text, int x, int y, int flags, int param8);
@@ -326,6 +338,9 @@ void swrUI_DrawText(int font, int x, int y, int color0, int color1, int color2, 
 void swrUI_DrawTextAligned(int font, char* text, short* bbox, unsigned int alignFlags, int color0, int color1, int color2, int color3, int unk9, int unk10, int unk11);
 // Write a padded text bbox: width + 0x13, height + 0x1d.
 void swrUI_GetPaddedTextBBox(int* bbox_out, char* text, int font);
+
+// Measures a text string and writes a padded button bounding box sized to fit it (best guess).
+void swrUI_GetButtonBBoxFromText_Maybe(int* bbox_out, char* text, int font);
 // Size a 1-3 button row from its labels; writes the row bbox and returns the uniform button width.
 unsigned int swrUI_GetButtonRowBBox(int* bbox_out, char* label1, char* label2, char* label3, int font);
 // Sum glyph advance widths over substring [start, end) of text.
@@ -406,6 +421,9 @@ int swrUI_RunCallbacks(swrUI_unk* ui, int forward1, int forward2, int forward3);
 
 int swrUI_ReplaceIndex(swrUI_unk* ui, int new_index);
 
+// Stores a new value in a UI element slot and returns the previous one (best guess).
+int swrUI_ExchangeSlotValue2_Maybe(swrUI_unk* ui, int value);
+
 void swrUI_SetBBox(swrUI_unk* ui, int x, int y, int x2, int y2);
 
 void swrUI_Enqueue(swrUI_unk* ui1, swrUI_unk* toEnqueue);
@@ -420,6 +438,9 @@ char* swrUI_replaceAllocatedStr(char* str, char* mondo_text);
 swrUI_unk* swrUI_GetByValue(swrUI_unk* ui, int value);
 
 void swrUI_Front_LoadTrackFromId(swrRace_TRACK trackId, char* buffer, size_t len);
+
+// Fires the multiplayer racer-list page callbacks (best guess).
+void swrUI_Menu_MpRacerListRefresh_Maybe(swrUI_unk* page, int param_2);
 
 void swrUI_Front_HandleCircuits(swrObjHang* hang);
 
@@ -468,6 +489,9 @@ void swrUI_ClearElementRefs(swrUI_unk* element);
 swrUI_unk* swrUI_FindByClass(swrUI_unk* root, int classId);
 void swrUI_SetValueText(swrUI_unk* ui, char* text, int value);
 char* swrUI_GetValueText(swrUI_unk* ui, char* out, int len);
+
+// Writes a value into a secondary value slot of a UI element (best guess).
+void swrUI_SetValue2_Maybe(swrUI_unk* ui, int value);
 int swrUI_SetSlotValue(swrUI_unk* ui, int index, int value);
 int swrUI_IsElementVisible(swrUI_unk* ui);
 void swrUI_SetUI4(swrUI_unk* ui);


### PR DESCRIPTION
Front-end UI cluster of the naming sweep. Header-only across swrObj.h / swrUI.h / swrSprite.h, builds clean.

**32 newly-named**: hangar/shop menu-button callbacks, vehicle-select icon layout + navigation, cantina holotable, screen asset/scene loaders, UI widget + sprite helpers. `_Maybe` on the uncertain ones.

**16 divergence fixes** folded into the DB (already upstream under these names, no diff here): the **swrUI_Front_*** family (our DB had dropped the `_Front_` qualifier on ~10 loaders), the **swapped swrUI_SetColorUnk3/Unk4** pair (DB had them transposed), `swrSprite_FreeSprites`, `swrModel_clearSceneModelsAndChildren`.

Two thin sprite wrappers handled as a real setter (`swrSprite_SetDrawStateWord`) + its `thunk_` forwarder.