### PR TITLE
cifr/swrControl/swrSpline/+util: name ~48 misc functions

### DIFF
--- a/src/Main/swrControl.h
+++ b/src/Main/swrControl.h
@@ -37,6 +37,7 @@
 #define swrControl_FindKeyName_ADDR (0x00407d90)
 #define swrControl_SelectSavedJoystick_ADDR (0x00407de0)
 #define swrControl_IsKeyStringControl_ADDR (0x00408020)
+#define swrControl_ClearPollState_Maybe_ADDR (0x004081c0)
 
 // Force feedback (DirectInput effects loaded from data/bundle*.fcr via cifr_*).
 #define swrControl_LoadForceEffects_ADDR (0x00409d70)
@@ -110,6 +111,9 @@ int stdControl_isAxisAboveDeadzone(int axisId, int direction, float value, float
 
 // Snapshot all 256 key states and drain the buffered-key (WndProc) queue.
 void swrControl_SnapshotKeyboard(void);
+
+// Clears the unified accept/cancel control-poll accumulators and returns one (best guess).
+int swrControl_ClearPollState_Maybe(void);
 
 // Input rebinding / device-scan helpers:
 unsigned int swrControl_ScanPressedButtons(int device, int returnBitmask); // scan kbd 0x200-3 / joystick buttons for presses

--- a/src/Main/swrMain.h
+++ b/src/Main/swrMain.h
@@ -15,10 +15,15 @@
 // Per-frame loop helpers (driven by swrMain2_GuiAdvance).
 #define swrMain_ProcessDebugKeys_ADDR (0x004104f0)
 #define swrMain_UpdateNetworkTick_ADDR (0x0041c1d0)
+#define swrMain_GuiAdvance_ADDR (0x00424140)
+#define swrMain_UpdateInRaceLoopSfx_ADDR (0x00426920)
 #define swrMain_RunFrame_ADDR (0x00445980)
 
 int Main_Startup(char* cmdline);
 void Main_Shutdown(void);
+
+// Dispatches the per-frame GUI advance through the function pointer.
+void swrMain_GuiAdvance(void);
 
 void Main_ShutdownError(void);
 int Main_ParseCmdLine(char* cmdline);
@@ -39,4 +44,7 @@ void swrMain_ProcessDebugKeys(void);
 // Per-frame network update pacer (gated by Main_nut_delay_ms; drives swrMultiplayer_InRace).
 void swrMain_UpdateNetworkTick(void);
 
+
+// Keeps the in-race looping sound effects alive each tick.
+void swrMain_UpdateInRaceLoopSfx(void);
 #endif // SWR_MAIN_H

--- a/src/Platform/cifr.h
+++ b/src/Platform/cifr.h
@@ -11,8 +11,10 @@
 // feedback layer (swrControl_PlayForceEffect etc.).
 
 #define cifr_Init_ADDR (0x00403e10)
+#define cifr_ReinitEffects_Maybe_ADDR (0x00403f00)
 #define cifr_LoadProjectFile_ADDR (0x00403f30)
 #define cifr_LoadAllEffects_ADDR (0x00403fd0)
+#define cifr_ReleaseAllEffects_ADDR (0x00404040)
 #define cifr_CreateEffect_ADDR (0x004040a0)
 #define cifr_ReleaseEffect_ADDR (0x00404190)
 #define cifr_StartEffect_ADDR (0x004041c0)
@@ -24,15 +26,25 @@
 #define cifr_SetMagnitude_ADDR (0x00404400)
 #define cifr_GetDuration_ADDR (0x004044a0)
 #define cifr_SetDuration_ADDR (0x004044e0)
+#define cifr_SetCustomForceData_Maybe_ADDR (0x00404590)
+#define cifr_QueryEffectStatus_Maybe_ADDR (0x00404640)
+#define cifr_GetForceFeedbackState_Maybe_ADDR (0x00404670)
+#define cifr_InitEffectSlot_Maybe_ADDR (0x004046e0)
 
 // Initialize the 6 effect slots and select the force-feedback device.
 void cifr_Init(void* effects);
+
+// Tears down and reinitializes the controller's force-feedback effect slots when enabled (best guess).
+void cifr_ReinitEffects_Maybe(void* controller);
 
 // Load an Immersion .fcr project file and record each effect's name per slot.
 int cifr_LoadProjectFile(void* effects, char* projectFile, void* nameIndices, void* nameTable);
 
 // Create and download all of a controller's effects to the device.
 int cifr_LoadAllEffects(void* controller);
+
+// Releases every downloaded DirectInput effect across the six slots and counts the successes.
+int cifr_ReleaseAllEffects(void* controller);
 
 // Create + download one effect (its DirectInput effect interfaces) to device.
 int cifr_CreateEffect(void* effect, void* params, void* device);
@@ -60,5 +72,17 @@ int cifr_SetMagnitude(void* effect, int percent, int deferred);
 // Get / set the effect duration in milliseconds (-1 = infinite).
 int cifr_GetDuration(void* effect);
 int cifr_SetDuration(void* effect, int durationMs, int deferred);
+
+// Reallocates and copies a per-effect custom force buffer, then downloads it via SetParameters (best guess).
+int cifr_SetCustomForceData_Maybe(void* effect, unsigned int size, void* data, int deferred);
+
+// Queries one effect's DirectInput status (best guess).
+int cifr_QueryEffectStatus_Maybe(void* effect, void* outStatus);
+
+// Queries an effect's status and issues a device-level force-feedback command, copying back a status byte (best guess).
+int cifr_GetForceFeedbackState_Maybe(void* effect);
+
+// Initializes one effect slot to its default fields and frees its custom-force buffer (best guess).
+void cifr_InitEffectSlot_Maybe(void* effect);
 
 #endif // CIFR_H

--- a/src/Primitives/rdMatrix.h
+++ b/src/Primitives/rdMatrix.h
@@ -32,6 +32,8 @@
 #define rdMatrix_TransformPoint44_ADDR (0x00480690)
 #define rdMatrix_ToTransRotScale_ADDR (0x00480730)
 #define rdMatrix_FromTransRotScale_ADDR (0x00480850)
+#define ProjectPointOntoPlane_ADDR (0x00480890)
+#define ClosestPointOnSegment_ADDR (0x004808f0)
 
 #define rdMatrix_BuildViewMatrix_ADDR (0x00483690)
 
@@ -80,6 +82,12 @@ void rdMatrix_Copy44(rdMatrix44* out, const rdMatrix44* in);
 void rdMatrix_TransformPoint44(rdVector4* a1, const rdVector4* a2, const rdMatrix44* a3);
 void rdMatrix_ToTransRotScale(const rdMatrix44* mat, rdVector3* translation, rdMatrix44* rotation, rdVector3* scale);
 void rdMatrix_FromTransRotScale(rdMatrix44* mat, const rdVector3* translation, const rdMatrix44* rotation, const rdVector3* scale);
+
+// Projects a point onto a plane along the plane normal and writes the result.
+void ProjectPointOntoPlane(float* plane, rdVector3* point, rdVector3* out);
+
+// Computes the closest point on a segment to a point, clamping to the endpoints.
+void ClosestPointOnSegment(rdVector3* point, rdVector3* segStart, rdVector3* segEnd, rdVector3* out);
 
 void rdMatrix_BuildViewMatrix(rdMatrix44* viewMatrix_out, rdMatrix44* world);
 

--- a/src/Swr/swrAssetBuffer.h
+++ b/src/Swr/swrAssetBuffer.h
@@ -10,8 +10,11 @@
 #define swrAssetBuffer_GetNewIndex_ADDR (0x00445b60)
 #define swrAssetBuffer_CheckOverflow_ADDR (0x00445b90)
 #define swrAssetBuffer_RemainingSize_ADDR (0x00445bf0)
+#define ResetModelPreviewState_Maybe_ADDR (0x00445c00)
 #define swrAssetBuffer_InvalidateTexturesBelow_ADDR (0x004475d0)
 #define swrAssetBuffer_GetStats_ADDR (0x00448d10)
+#define swrAssetBuffer_ReserveRegionA_Maybe_ADDR (0x00448d40)
+#define swrAssetBuffer_ReserveRegionB_Maybe_ADDR (0x00448d60)
 
 void swrAssetBuffer_ResetToIndex(int index);
 void swrAssetBuffer_SetBuffer(char* buffer);
@@ -20,7 +23,16 @@ BOOL swrAssetBuffer_InBounds(char* ptr);
 int swrAssetBuffer_GetNewIndex(unsigned int offset);
 void swrAssetBuffer_CheckOverflow(void);
 int swrAssetBuffer_RemainingSize(void);
+
+// Resets the single-model preview scene: zeroes the preview transform, sets the background color, and configures fog (best guess).
+void ResetModelPreviewState_Maybe(void);
 void swrAssetBuffer_InvalidateTexturesBelow(char* ptr);
 void swrAssetBuffer_GetStats(int* out1, int* out2, int* out3);
+
+// Reserves a 64-byte-aligned scratch region from the asset buffer (best guess).
+void swrAssetBuffer_ReserveRegionA_Maybe(void);
+
+// Reserves a second 64-byte-aligned scratch region from the asset buffer (best guess).
+void swrAssetBuffer_ReserveRegionB_Maybe(void);
 
 #endif // SWRASSETBUFFER_H

--- a/src/Swr/swrConfig.h
+++ b/src/Swr/swrConfig.h
@@ -41,6 +41,8 @@
 #define swrConfig_BuildMouseMenu_ADDR (0x0040d2c0)
 #define swrConfig_BuildKeyboardMenu_ADDR (0x0040dd10)
 #define swrConfig_RefreshMappingMenu_ADDR (0x0040b740)
+#define swrConfig_RefreshConfigListMenu_Maybe_ADDR (0x0040c260)
+#define swrConfig_RefreshPlayerListMenu_Maybe_ADDR (0x0040c4e0)
 #define swrConfig_SetMappingRowText_ADDR (0x0040c670)
 
 int swrConfig_WriteMappings(char* dirname);
@@ -71,6 +73,12 @@ void swrConfig_BuildAudioMenu(swrUI_unk* page);
 void swrConfig_RefreshAudioMenu(swrUI_unk* page);
 void swrConfig_BuildForceFeedbackMenu(swrUI_unk* page);
 void swrConfig_RefreshForceFeedbackMenu(swrUI_unk* page);
+
+// Refreshes the config-file selection list, enumerating config and wheel-map files (best guess).
+void swrConfig_RefreshConfigListMenu_Maybe(swrUI_unk* page);
+
+// Refreshes the player-profile selection list and sets the Current Player screen text (best guess).
+void swrConfig_RefreshPlayerListMenu_Maybe(swrUI_unk* page);
 
 void swrConfig_BuildJoystickMenu(swrUI_unk* page);
 void swrConfig_BuildMouseMenu(swrUI_unk* page);

--- a/src/Swr/swrEvent.h
+++ b/src/Swr/swrEvent.h
@@ -157,6 +157,7 @@ swrEventManager eventManagerMain[][9] = {
 #define swrEvent_FreeObjs_ADDR (0x00450db0)
 
 #define swrEvent_FindNearestObjects_ADDR (0x00450e70)
+#define swrEvent_UpdateTimedSound_Maybe_ADDR (0x00451020)
 
 void  swrEvent_AllocateAndLoadObjs(int event, int count);
 void swrEvent_ClearObjs(int event);
@@ -191,5 +192,8 @@ void* swrEvent_AllocObj(int event);
 void swrEvent_FreeObjs(int event);
 
 int swrEvent_FindNearestObjects(int event, rdVector3* pos, float maxDistSq, void* excludeObj, int maxResults, float* outDistances, rdVector3* outDeltas, void** outObjects);
+
+// Drives a delta-time accumulator toward a threshold and plays a one-shot event sound when it crosses (best guess).
+void swrEvent_UpdateTimedSound_Maybe(int entity, float targetValue);
 
 #endif // SWREVENT_H

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -45,12 +45,17 @@
 #define swrSprite_UpdateLensFlareSpriteSettings_ADDR (0x0042BA20)
 #define UpdateSunAndLensFlareSprites2_ADDR (0x0042BB50)
 #define UpdateSunAndLensFlareSprites_ADDR (0x0042C1A0)
+#define SetSunSpriteAlpha_Maybe_ADDR (0x0042c2d0)
+#define SetSunSprite_ADDR (0x0042c2e0)
+#define SetLensFlareSprite_ADDR (0x0042c380)
+#define ResetSunAndLensFlareSprites_ADDR (0x0042c3e0)
 
 #define ResetPlayerSpriteValues_ADDR (0x0042C400)
 #define SetPlayerSpritePositionOnMap_ADDR (0x0042C420)
 #define ResetLightStreakSprites_ADDR (0x0042C460)
 #define InitLightStreak_ADDR (0x0042C490)
 #define SetLightStreakSpriteIDs_ADDR (0x0042C4E0)
+#define ResetWorldSpriteCount_Maybe_ADDR (0x0042c500)
 
 #define swrText_CreateTextEntry2_ADDR (0x0042C7A0)
 #define UpdateLightStreakSprites_ADDR (0x0042C800)
@@ -85,6 +90,7 @@
 #define swrModel_PointInTriangle_ADDR (0x00441040)
 #define swrModel_RecordClosestHit_ADDR (0x00441390)
 #define swrModel_TestTriangleEdges_ADDR (0x004414e0)
+#define IntersectSegmentPlane_ADDR (0x00441710)
 #define swrModel_ClipAndTestTriangle_ADDR (0x00441810)
 #define swrModel_CollideSphereTriangle_ADDR (0x00442090)
 #define IntersectRayPlane_ADDR (0x00442470)
@@ -180,6 +186,11 @@
 #define swrModel_LoadPuppet_ADDR (0x0045CE10)
 
 #define swrModel_SwapSceneModels_ADDR (0x0045cf30)
+#define BuildBasisFromDirection_ADDR (0x00481100)
+#define BuildLookAtTransform_ADDR (0x00481220)
+#define swrModel_ComputeNodeWorldMatrix_Maybe_ADDR (0x004816f0)
+#define swrModel_ComputeNodeChainMatrix_Maybe_ADDR (0x004819b0)
+#define DistanceToNearestPoint_Maybe_ADDR (0x00482e60)
 
 void* swrModel_AllocMaterial(unsigned int offset, unsigned int byteSize);
 
@@ -224,11 +235,26 @@ void swrModel_NodeSetColorsOnAllMaterials(swrModel_Node* a1_pJdge0x10, int a2, i
 void swrSprite_UpdateLensFlareSpriteSettings(int16_t id, int a2, int a3, float a4, float width, float a6, uint8_t r, uint8_t g, uint8_t b);
 void UpdateSunAndLensFlareSprites2(int a1, int a2, int a3);
 void UpdateSunAndLensFlareSprites(swrViewport* a1);
+
+// Sets just the alpha component of a sun sprite's color (best guess).
+void SetSunSpriteAlpha_Maybe(int index, unsigned char alpha);
+
+// Stores the sprite id, world position, clamp values, and rgba color for a sun sprite.
+void SetSunSprite(int index, int spriteId, float* position, int param4, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
+
+// Stores the sprite id, params, and rgb color for a lens-flare sprite of a sun.
+void SetLensFlareSprite(int sunIndex, int flareIndex, int spriteId, int param4, int param5, unsigned char r, unsigned char g, unsigned char b);
+
+// Resets all lens-flare and sun sprite ids to clear the sprite state.
+void ResetSunAndLensFlareSprites(void);
 void ResetPlayerSpriteValues();
 void SetPlayerSpritePositionOnMap(int player_id, const rdVector3* position, int unknown_value);
 void ResetLightStreakSprites();
 void InitLightStreak(int index, rdVector3* position);
 void SetLightStreakSpriteIDs(int index, int sprite_id1, int sprite_id2);
+
+// Clears the world-sprite occlusion count sampled by the HUD (best guess).
+void ResetWorldSpriteCount_Maybe(void);
 
 void swrText_CreateTextEntry2(int16_t screen_x, int16_t screen_y, char r, char g, char b, char a, char* screenText);
 void UpdateLightStreakSprites(swrViewport* a1);
@@ -266,6 +292,9 @@ void swrModel_NodeInit(swrModel_Node* node, uint32_t base_flags);
 int swrModel_PointInTriangle(float* origin, float* a, float* b, float* c, rdVector3* edgeAB, rdVector3* edgeBC, rdVector3* edgeCA);
 void swrModel_RecordClosestHit(float distSq, float* point, float* hitPoint, float* normal);
 void swrModel_TestTriangleEdges(float* point, float* a, float* b, float* c, float* p5, void* face);
+
+// Solves and writes the intersection point of a segment with a plane.
+void IntersectSegmentPlane(rdVector3* out, rdVector3* segStart, rdVector3* segEnd, rdVector3* planeNormal, float planeDist);
 void swrModel_ClipAndTestTriangle(float* normal, float* a, float* b, float* c, void* p5, void* face, void* p7);
 void swrModel_CollideSphereTriangle(float* faceNormal, float* a, float* b, float* c, float* point);
 // ray = {origin[3], dir[3], maxDist} (the swrModel_collisionRay* globals laid out contiguously)
@@ -356,6 +385,12 @@ void swrModel_NodeSetAnimationFlagsAndSpeed(swrModel_Node* node, swrModel_Animat
 int swrModel_PointInTriangle2(float* origin, float* a, float* b, float* c, rdVector3* edgeAB, rdVector3* edgeBC, rdVector3* edgeCA);
 float swrModel_ClosestPointOnTriangleImpl(float* query, float* a, float* b, float* c, float maxDistSq, float* outPoint, float* outNormal);
 
+// Builds an orthonormal basis and offset origin from a direction and up vector.
+void BuildBasisFromDirection(rdVector3* outBasis, rdVector3* origin, rdVector3* direction, rdVector3* up, float length);
+
+// Builds a yaw/pitch/roll look-at orientation and writes both the transform struct and matrix.
+void BuildLookAtTransform(rdVector3* from, rdVector3* to, rdMatrix44* outMatrix, swrTranslationRotation* outTR, float roll);
+
 void swrModel_NodeSetLodDistances(swrModel_NodeLODSelector* node, float* a2);
 void swrModel_SetupFaceNormal(int vertexArray, int faceOut, int i0, int i1, int i2); // rdMath_CalcSurfaceNormal + store the 3 vertex indices
 
@@ -382,4 +417,13 @@ void swrModel_LoadPuppet(MODELID model, INGAME_MODELID index, int a3, float a4);
 
 void swrModel_SwapSceneModels(int index, int index2);
 
+
+// Walks the node tree accumulating transforms and writes the target node's world matrix (best guess).
+void swrModel_ComputeNodeWorldMatrix_Maybe(swrModel_Node* target, float* outMatrix, swrModel_Node* node, rdMatrix44* parentMatrix);
+
+// Walks a node-pointer list, multiplying billboard-node transforms into the output matrix (best guess).
+void swrModel_ComputeNodeChainMatrix_Maybe(int* nodeList, rdMatrix44* outMatrix);
+
+// Returns the distance from a point to the nearest point in a global set, or a default when empty (best guess).
+float DistanceToNearestPoint_Maybe(rdVector3* point);
 #endif // SWRMODEL_H

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -24,17 +24,23 @@
 #define swrObjHang_UpdateScreenTransition_ADDR (0x0043da90)
 #define swrObjHang_UpdateHoloBillboardMatrix_ADDR (0x0043e210)
 #define swrObjHang_FadeOutAndAdvance_ADDR (0x0043e330)
+#define UpdateUICameraPlacements_ADDR (0x0043e5b0)
 #define swrObjHang_UpdatePitDroidAnims_ADDR (0x0043e620)
+#define ComputeModelViewBounds_ADDR (0x0043e6f0)
+#define LoadUpgradeModelsIntoScene_Maybe_ADDR (0x0043e840)
 #define swrObjHang_AimHoloCamera_ADDR (0x0043f8e0)
 #define swrObjHang_UpdateHoloCameraTarget_ADDR (0x0043fbc0)
 #define swrObjHang_SwapSelectedPart_ADDR (0x00440800)
+#define compare3Chars_ADDR (0x004409d0)
 #define GetRequiredPlaceToProceed_ADDR (0x00440a00)
 #define isTrackUnlocked_ADDR (0x00440a20)
 #define isTrackPlayable_ADDR (0x00440aa0)
 #define VerifySelectedTrack_ADDR (0x00440af0)
 #define swrObjHang_IsCameraMoving_ADDR (0x00440b50)
 #define resetInRaceInputBuffer_ADDR (0x00440d90)
+#define getInRaceInputBufferEntry_Maybe_ADDR (0x00440de0)
 #define updateInRaceInputBitsets_ADDR (0x00440df0)
+#define setInRaceInputState_Maybe_ADDR (0x00441010)
 #define swrObjJudge_PollPause_ADDR (0x00445680)
 #define GetPauseState_ADDR (0x00445690)
 #define GetPauseMenuScrollInOut_ADDR (0x004456a0)
@@ -44,6 +50,7 @@
 #define enablePause_ADDR (0x004457b0)
 #define pollPauseInput_ADDR (0x004457d0)
 #define updatePauseMenu_ADDR (0x00445860)
+#define enablePauseOverlay_Maybe_ADDR (0x00445960)
 #define swrObj_Free_ADDR (0x00450e30)
 #define swrObjcMan_UpdateLighting_ADDR (0x00451160)
 #define swrObjcMan_LoadLightingFromBehavior_ADDR (0x00451800)
@@ -226,6 +233,10 @@
 #define swrScene_InitWorld_ADDR (0x00449040)
 #define swrScene_InitCameras_ADDR (0x004490a0)
 #define swrScene_Init_ADDR (0x004491f0)
+#define RecordLoadedModel_Maybe_ADDR (0x00465820)
+#define swrObjTrig_AddTriggerDescriptions_ADDR (0x0047d380)
+#define swrObjTrig_InitColorBands_Maybe_ADDR (0x0047d890)
+#define swrObjTrig_ApplyNodeRegionColor_Maybe_ADDR (0x0047da10)
 #define swrScene_SetObjectsLoaded_ADDR (0x004804a0)
 #define swrScene_ResetRenderState_ADDR (0x004834b0)
 
@@ -253,10 +264,22 @@ void swrObjHang_UpdateJunkyard(swrObjHang* hang); // used-parts screen
 int swrObjHang_UpdateScreenTransition(swrObjHang* hang, int param_2, int param_3);
 // Fades the active screen to black, then on completion commits the queued menu-state change.
 int swrObjHang_FadeOutAndAdvance(swrObjHang* hang);
+
+// Advances each UI camera-placement entry's animation value by a mode-selected offset of the time.
+void UpdateUICameraPlacements(float time);
 // Swaps the selected part between the pod and the junkyard inventory (models + truguts).
 void swrObjHang_SwapSelectedPart(swrObjHang* hang);
+
+// Returns whether the first three characters of two strings match.
+int compare3Chars(char* a, char* b);
 // Updates the Watto-shop pit-droid Elmo animation states (idle droids vs. the focused one).
 void swrObjHang_UpdatePitDroidAnims(swrObjHang* hang);
+
+// Computes the AABBs of three model nodes and derives UI camera framing values from them.
+void ComputeModelViewBounds(void);
+
+// Builds the upgrade-info rows and loads the upgrade pod-part models into the hangar shop scene (best guess).
+void LoadUpgradeModelsIntoScene_Maybe(swrObjHang* hang);
 // Whether the hangar camera is still moving toward its target menu position.
 int swrObjHang_IsCameraMoving(swrObjHang* hang);
 // Moves the menu selection/camera to the adjacent valid item in the current room.
@@ -286,9 +309,15 @@ int VerifySelectedTrack(swrObjHang* hang, int selectedTrackIdx);
 // Clear the in-race input accumulation buffer and return its base pointer.
 // Companion to updateInRaceInputBitsets.
 void* resetInRaceInputBuffer(void);
+
+// Returns the indexed entry from the in-race input buffer (best guess).
+int getInRaceInputBufferEntry_Maybe(int index);
 // Build the per-player rising-edge / held / released in-race input bitsets
 // (inRaceLocalPlayerInputBitset1/2/3) from the raw per-action input bytes.
 void updateInRaceInputBitsets(void);
+
+// Stores a value into the in-race input state global (best guess).
+void setInRaceInputState_Maybe(int value);
 
 void swrObjJudge_PollPause();
 int GetPauseState();
@@ -299,6 +328,9 @@ void requestUnpause(void); // begin the unpause slide-out (pauseState = 3)
 void endPause(void); // finish unpausing: clear state, fire the 'All!' event, stop rumble
 void enablePause(void); // re-enable pausing (clears pauseDisabled)
 void updatePauseMenu(void); // per-frame: animate the menu slide-in/out, then update the UI
+
+// Activates the pause or options overlay, calling an init helper and setting a game-setting flag (best guess).
+void enablePauseOverlay_Maybe(void);
 float GetPauseMenuScrollInOut(void); // current pause-menu slide amount (InRace_PauseMenu_ScrollInOut)
 
 void swrObj_Free(swrObj* obj);
@@ -463,6 +495,9 @@ void swrObjSmok_AddFireballModelsToScene();
 void AddFireballToModelScene();
 
 void LoadTrackModels(swrObjJdge* judge);
+
+// Increments a counter and stores a value into a small loaded-model record (best guess).
+void RecordLoadedModel_Maybe(void* record, int value);
 
 void swrObjJdge_InitSplineCursor(swrObjJdge* judge);
 
@@ -642,6 +677,15 @@ void swrObjTrig_HandleCrashHitTrigger(swrObjTrig* a1, swrRace* a2);
 void swrObjTrig_Handle314Or501Trigger(swrObjTrig* obj, int index);
 
 swrModel_Node* swrObjTrig_AddNodeToScene(swrModel_TriggerDescription*, int, int);
+
+// Walks the trigger-description list, registering each and applying per-type node, animation, and transform setup.
+void swrObjTrig_AddTriggerDescriptions(swrModel_TriggerDescription* descriptions, int param2);
+
+// Computes the position threshold globals per planet id for the region-color routine (best guess).
+void swrObjTrig_InitColorBands_Maybe(void);
+
+// Maps a node's position to a region color and applies it to the node (best guess).
+unsigned int swrObjTrig_ApplyNodeRegionColor_Maybe(swrModel_Node* node);
 
 void swrObjTrig_FindAndInitializeTriggersInNode(swrModel_NodeTransformed* node);
 swrModel_Node* swrObjTrig_CreateTriggerSceneNode();

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -221,6 +221,7 @@
 #define swrRace_CopyProfileFromSave_ADDR (0x0044e500)
 #define swrRace_CopyProfileToSave_ADDR (0x0044e530)
 #define swrRace_SaveCurrentProfile_ADDR (0x0044e560)
+#define nullsub_477c27_ADDR (0x00477c27)
 
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4);
 
@@ -329,6 +330,9 @@ void swrRace_ApplyGravity(swrRace* player, float* a, float b);
 int swrRace_BoostCharge(int player);
 
 void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotion, rdVector3* pRDot);
+
+// An empty stub taking four ints and returning immediately.
+void nullsub_477c27(int player, int a, int b, int c);
 // Extracts pitch + signed-roll angles of a forward/right basis relative to a reference (down) vector.
 void swrRace_ComputeTiltAngles(rdVector3* fwd, rdVector3* right, rdVector3* ref, rdVector3* out);
 // Builds a surface-aligned basis from the pod forward + surface normal and accumulates the heading/tilt

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -26,13 +26,17 @@
 // arc-length progress and tessellates each segment).
 #define swrSpline_GetTrackLength_ADDR (0x0047e870)
 #define swrSpline_CursorInit_ADDR (0x0047e880)
+#define swrSpline_CursorSeekToProgress_ADDR (0x0047e8b0)
+#define swrSpline_ProjectPointStub_Maybe_ADDR (0x0047eb50)
 #define swrSpline_ProjectPoint_ADDR (0x0047eb60)
 #define swrSpline_ForEachSample_ADDR (0x0047ee20)
 #define swrSpline_TraceProgress_ADDR (0x0047f060)
 #define swrSpline_BuildProgressTable_ADDR (0x0047f470)
 #define swrSpline_ResetNodeProgress_ADDR (0x0047f6c0)
 #define swrSpline_Build_ADDR (0x0047f6f0)
+#define swrSpline_GetSampleSpacing_Maybe_ADDR (0x0047f800)
 #define swrSpline_CollectNearbyPoints_ADDR (0x00480170)
+#define swr_SetFixedDeltaTime_ADDR (0x00480480)
 
 void swrSpline_LoadSpline(int index, unsigned short** b);
 
@@ -76,6 +80,12 @@ float swrSpline_GetTrackLength(void);
 // the cursor.
 void* swrSpline_CursorInit(void* cursor, swrSpline* spline);
 
+// Maps a progress value to a control-point band and seeds the cursor node, branch, and lookahead window.
+void swrSpline_CursorSeekToProgress(void* cursor, int progress);
+
+// A stubbed spline helper that writes zero and returns zero (best guess).
+int swrSpline_ProjectPointStub_Maybe(void* cursor, int* out);
+
 // Advance the cursor to the point on the spline nearest the given world point
 // (used to map a world position back to a spline parameter / progress).
 void swrSpline_ProjectPoint(void* cursor, rdVector3* point);
@@ -98,6 +108,9 @@ void swrSpline_ResetNodeProgress(int nodeIndex);
 // nodes, builds the progress table, then tessellates.
 void swrSpline_Build(swrSpline* spline, int unk);
 
+// Returns the spline sample-spacing constant (best guess).
+float swrSpline_GetSampleSpacing_Maybe(void);
+
 // Returns the integrated track/spline length (swrSpline_trackLength, set by swrSpline_TraceProgress).
 float swrSpline_GetTrackLength(void);
 
@@ -105,5 +118,8 @@ float swrSpline_GetTrackLength(void);
 // (x,y) offset from center into outPoints (up to maxPoints); `density` controls the sample spacing.
 // Returns the number of points found. Used to draw the track outline on the in-race minimap.
 int swrSpline_CollectNearbyPoints(swrSpline* spline, float* center, float range, int maxPoints, rdVector2* outPoints, float density);
+
+// Stores the fixed delta time in seconds into its global.
+void swr_SetFixedDeltaTime(double seconds);
 
 #endif // SWRSPLINE_H

--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -169,6 +169,7 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_HandleTextEntryKey_ADDR (0x00418120) // text-entry edit handler (insert/erase/cursor/commit)
 #define swrUI_DrawCaret_ADDR (0x004184d0) // draw/blink the text caret sprite (0xfa)
 #define swrUI_GetSubstringWidth_ADDR (0x00418680)
+#define ReadRLEData_ADDR (0x00418700)
 #define swrUI_ClearGroupChecked_ADDR (0x00418b70)
 #define swrUI_ApplyListColors_ADDR (0x00418bc0) // propagate the list's 5 color sets to its items
 #define swrUI_BuildHighlightSprites_ADDR (0x00418cb0)
@@ -212,11 +213,15 @@ FUN_0041ac00  swrUI_RaceResultRowProc
 #define swrUI_Menu_MpRacerList_ADDR (0x004206b0)
 #define swrUI_Front_LoadTrackFromId_ADDR (0x00420930)
 #define swrUI_Front_HandleCircuits_ADDR (0x0043b0b0)
+#define swrUI_Front_SeekToCurrentTrack_Maybe_ADDR (0x0043b1d0)
 #define swrUI_Front_TextMenu_ADDR (0x0043fce0)
 #define swrUI_Front_MenuAxisHorizontal_ADDR (0x00440150)
 #define swrUI_Front_DrawRecord_ADDR (0x004403e0)
+#define playUISound_ADDR (0x00440550)
 #define swrUI_Front_GetTrackNameFromId_ADDR (0x00440620)
 #define swrUI_Front_BeatEverything1stPlace_ADDR (0x00440bc0)
+#define swrObjHang_SelectDemoTracks_Maybe_ADDR (0x00440c10)
+#define swrUI_Front_DispatchPageCallbacks_Maybe_ADDR (0x00440d50)
 #define swrUI_Front_LoadPlanetModels_ADDR (0x00457C20)
 #define swrUI_Front_LoadMapPartModels_ADDR (0x00457CF0)
 #define swrUI_Front_LoadUIElements_ADDR (0x00457ed0)
@@ -330,6 +335,9 @@ void swrUI_GetPaddedTextBBox(int* bbox_out, char* text, int font);
 unsigned int swrUI_GetButtonRowBBox(int* bbox_out, char* label1, char* label2, char* label3, int font);
 // Sum glyph advance widths over substring [start, end) of text.
 int swrUI_GetSubstringWidth(char* text, int font, unsigned int start, int end);
+
+// Reads RLE-compressed records from a file, expanding repeat packets and literal runs until the count is met.
+int ReadRLEData(void* file, void* dest, int elementSize, int count);
 // Hit-test a point against the element's bbox (+0x24).
 int swrUI_ElementContainsPoint(swrUI_unk* ui, int x, int y);
 // True when ui is the focused element.
@@ -423,15 +431,27 @@ void swrUI_Front_LoadTrackFromId(swrRace_TRACK trackId, char* buffer, size_t len
 
 void swrUI_Front_HandleCircuits(swrObjHang* hang);
 
+// Counts playable tracks up to the active one and leaves that as the menu selected index (best guess).
+void swrUI_Front_SeekToCurrentTrack_Maybe(swrObjHang* hang);
+
 void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText);
 
 void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY);
 
 void swrUI_Front_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5);
 
+// Selects per-sound volume, pitch, and loop parameters by id and plays the UI sound.
+void playUISound(int soundId);
+
 char* swrUI_Front_GetTrackNameFromId(int trackId);
 
 bool swrUI_Front_BeatEverything1stPlace(swrObjHang* hang);
+
+// Sets demo mode and randomly picks up to five unlocked tracks for attract-mode playback (best guess).
+void swrObjHang_SelectDemoTracks_Maybe(swrObjHang* hang);
+
+// Runs the current page's id-2 and id-4 widget callbacks with the matching arguments (best guess).
+void swrUI_Front_DispatchPageCallbacks_Maybe(int arg2, int arg4);
 
 void swrUI_Front_LoadPlanetModels();
 void swrUI_Front_LoadMapPartModels();

--- a/src/Swr/swrWeather.h
+++ b/src/Swr/swrWeather.h
@@ -192,6 +192,7 @@
 // =====================================================================================
 
 #define swrWeather_RenderParticles_ADDR (0x0042cca0)
+#define swrSprite_SetStreakEndpoints_Maybe_ADDR (0x0042d330)
 
 #define swrWeather_HideAllParticles_ADDR (0x0042d380)
 
@@ -212,6 +213,9 @@
 #define swrWeather_ResetParticles_ADDR (0x0042d470)
 
 void swrWeather_RenderParticles(void* viewport);
+
+// Forwards into the sprite secondary-endpoint setter for a light streak (best guess).
+void swrSprite_SetStreakEndpoints_Maybe(float value);
 
 void swrWeather_HideAllParticles(void);
 


### PR DESCRIPTION
Final cluster of the naming sweep (asset / spline / input / config / util + unprefixed math). Header-only, builds clean.

Newly-named across ~13 headers: cifr force-feedback effect slots, swrControl/swrConfig menu + poll helpers, swrSpline cursor/progress traversal, swrObjTrig color bands, swrAssetBuffer region reserves, swrModel node-matrix walkers, swrEvent timed sound, and the unprefixed geometry/util helpers (ProjectPointOntoPlane, ClosestPointOnSegment, BuildBasisFromDirection, BuildLookAtTransform, IntersectSegmentPlane, ReadRLEData, compare3Chars, playUISound, swr_SetFixedDeltaTime). `_Maybe` on the uncertain ones.

Divergence fixes folded into the DB (already upstream): `stdConfFile_readAndApplyConf`, `stdConfig_getKeymap_id`, `stdControl_isAxisAboveDeadzone`, **`stdControl_Shutdown`** (DB had `Startup` at this addr — wrong; body releases all DirectInput devices), `swrMain2_GuiAdvance` (resolves a collision with the `swrMain_GuiAdvance` dispatcher), `swrUI_Front_*` + the `swrSpline` control-point getters.

Excluded as out of scope: ~27 CRT/stdlib entries. One pre-existing DB dup (`swrPlayerHUD_SampleOcclusion` at two addresses) and 3 mis-carved fragments left for a Ghidra GUI pass.