### PR TITLE
reimpl(swrModel): node/mesh API + in-game sprite placement (17 fns)

### DIFF
--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -1241,19 +1241,64 @@ void swrModel_NodeSetRotationByEulerAngles(swrModel_NodeTransformed* node, float
 // 0x0042B560
 swrModel_MeshMaterial* swrModel_NodeFindFirstMeshMaterial(swrModel_Node* node)
 {
-    HANG("TODO");
+    if (node == NULL)
+        return NULL;
+
+    if (swrModel_NodeGetFlags(node) == NODE_MESH_GROUP) {
+        for (int i = 0; i < (int) node->num_children; i++) {
+            swrModel_MeshMaterial* material = node->children.meshes[i]->mesh_material;
+            if (material != NULL)
+                return material;
+        }
+    } else if (swrModel_NodeGetFlags(node) & NODE_HAS_CHILDREN) {
+        for (int i = 0; i < (int) swrModel_NodeGetNumChildren(node); i++) {
+            swrModel_MeshMaterial* material = swrModel_NodeFindFirstMeshMaterial(node->children.nodes[i]);
+            if (material != NULL)
+                return material;
+        }
+    }
+    return NULL;
 }
 
 // 0x0042B5E0
 void swrModel_MeshMaterialSetColors(swrModel_MeshMaterial* a1, int16_t a2, int16_t a3, int16_t a4, int16_t a5_G, int16_t a6, int16_t a7)
 {
-    HANG("TODO");
+    if (a1 == NULL)
+        return;
+
+    swrModel_Material* material = a1->material;
+    if (material == NULL)
+        return;
+
+    // a2/a3 are the low/high bytes of unk8; a4..a7 are the RGBA primitive_color. A negative
+    // argument means "leave this channel unchanged".
+    if (a2 >= 0)
+        *(uint8_t*) &material->unk8 = (uint8_t) a2;
+    if (a3 >= 0)
+        *((uint8_t*) &material->unk8 + 1) = (uint8_t) a3;
+    if (a4 >= 0)
+        material->primitive_color[0] = (uint8_t) a4;
+    if (a5_G >= 0)
+        material->primitive_color[1] = (uint8_t) a5_G;
+    if (a6 >= 0)
+        material->primitive_color[2] = (uint8_t) a6;
+    if (a7 >= 0)
+        material->primitive_color[3] = (uint8_t) a7;
 }
 
 // 0x0042B640
 void swrModel_NodeSetColorsOnAllMaterials(swrModel_Node* a1_pJdge0x10, int a2, int a3, int a4, int a5_G, int a6, int a7)
 {
-    HANG("TODO");
+    if (a1_pJdge0x10 == NULL)
+        return;
+
+    if (swrModel_NodeGetFlags(a1_pJdge0x10) == NODE_MESH_GROUP) {
+        for (int i = 0; i < (int) a1_pJdge0x10->num_children; i++)
+            swrModel_MeshMaterialSetColors(a1_pJdge0x10->children.meshes[i]->mesh_material, a2, a3, a4, a5_G, a6, a7);
+    } else if (swrModel_NodeGetFlags(a1_pJdge0x10) & NODE_HAS_CHILDREN) {
+        for (int i = 0; i < (int) swrModel_NodeGetNumChildren(a1_pJdge0x10); i++)
+            swrModel_NodeSetColorsOnAllMaterials(a1_pJdge0x10->children.nodes[i], a2, a3, a4, a5_G, a6, a7);
+    }
 }
 
 // functions for placing sprites onto the screen while ingame (like player positions, sun and lens flares, light streaks)
@@ -1315,13 +1360,15 @@ void DisableIngameSprites()
 // 0x00431710
 void swrModel_NodeSetTransformFromTranslationRotation(swrModel_NodeTransformed* node, swrTranslationRotation* arg4)
 {
-    HANG("TODO");
+    rdMatrix44 transform;
+    rdMatrix_SetTransform44(&transform, arg4);
+    swrModel_NodeSetTransform(node, &transform);
 }
 
 // 0x00431740
 void swrModel_NodeSetSelectedChildNode(swrModel_NodeSelector* node, int a2)
 {
-    HANG("TODO");
+    node->selected_child_node = a2;
 }
 
 // 0x00431770
@@ -1380,13 +1427,20 @@ void swrModel_MeshGetCollisionData(swrModel_Mesh* mesh, int disable, swrModel_Co
 // 0x00431820
 void swrModel_MeshGetAABB(swrModel_Mesh* mesh, float* aabb)
 {
-    HANG("TODO");
+    aabb[0] = mesh->aabb[0];
+    aabb[1] = mesh->aabb[1];
+    aabb[2] = mesh->aabb[2];
+    aabb[3] = mesh->aabb[3];
+    aabb[4] = mesh->aabb[4];
+    aabb[5] = mesh->aabb[5];
 }
 
 // 0x00431850
 swrModel_Mesh* swrModel_NodeGetMesh(swrModel_NodeMeshGroup* node, int a2)
 {
-    HANG("TODO");
+    // callers pass a NODE_MESH_GROUP swrModel_Node: its child mesh array sits at the same offset
+    // (0x18) as swrModel_NodeMeshGroup::cached_model_matrix.
+    return ((swrModel_Node*) node)->children.meshes[a2];
 }
 
 // Classifies a mesh material's collision facing from its swrModel_MeshMaterial::type bits, telling
@@ -1460,7 +1514,27 @@ void swrModel_NodeInit(swrModel_Node* node, uint32_t base_flags)
 // 0x0044FC00
 void swrModel_MeshMaterialSetTextureUVOffset(swrModel_MeshMaterial* a1, float a2, float a3)
 {
-    HANG("TODO");
+    if (a1 == NULL)
+        return;
+
+    swrModel_MaterialTexture* texture = a1->material_texture;
+    a1->type |= 0x8000;
+    if (texture == NULL)
+        return;
+
+    // scroll the texture window by (a2, a3) in fractions of the texture resolution, wrapping the
+    // resulting offset into [0, res).
+    a1->texture_offset[0] = (int16_t) (texture->res[0] * a2 + a1->texture_offset[0]);
+    if (a1->texture_offset[0] > texture->res[0])
+        a1->texture_offset[0] -= texture->res[0];
+    if (a1->texture_offset[0] < 0)
+        a1->texture_offset[0] += texture->res[0];
+
+    a1->texture_offset[1] = (int16_t) (texture->res[1] * a3 + a1->texture_offset[1]);
+    if (a1->texture_offset[1] > texture->res[1])
+        a1->texture_offset[1] -= texture->res[1];
+    if (a1->texture_offset[1] < 0)
+        a1->texture_offset[1] += texture->res[1];
 }
 
 // 0x00454BC0
@@ -1484,13 +1558,58 @@ void swrModel_ReloadAnimations()
 // 0x0047BD80
 void swrModel_NodeSetAnimationFlagsAndSpeed(swrModel_Node* node, swrModel_AnimationFlags flags_to_disable, swrModel_AnimationFlags flags_to_enable, float speed)
 {
-    HANG("TODO");
+    if (node == NULL || (swrModel_NodeGetFlags(node) & NODE_HAS_CHILDREN) == 0)
+        return;
+
+    if (swrModel_NodeGetFlags(node) == NODE_TRANSFORMED_WITH_PIVOT) {
+        // animation types 8 (axis-angle rotation) and 9 (translation)
+        for (int animation_type = 8; animation_type <= 9; animation_type++) {
+            swrModel_Animation* anim = swrModel_FindLoadedAnimation(node, animation_type);
+            if (anim == NULL)
+                continue;
+
+            anim->flags = (anim->flags & ~flags_to_disable) | flags_to_enable;
+            // reverse direction if the animation is currently playing forwards
+            swrModel_AnimationSetSpeed(anim, anim->animation_speed > 0.0f ? -speed : speed);
+        }
+    }
+
+    for (int i = 0; i < (int) swrModel_NodeGetNumChildren(node); i++)
+        swrModel_NodeSetAnimationFlagsAndSpeed(node->children.nodes[i], flags_to_disable, flags_to_enable, speed);
 }
 
 // 0x00482000
 int swrModel_NodeComputeFirstMeshAABB(swrModel_Node* node, float* aabb, int a3)
 {
-    HANG("TODO");
+    if (node == NULL)
+        return 0;
+
+    // a3 & 1 marks a recursive call; only the top-level call resets the accumulated transform.
+    if ((a3 & 1) == 0)
+        rdMatrix_SetIdentity44(&cman_unk_mat44);
+
+    uint32_t flags = swrModel_NodeGetFlags(node);
+    if ((flags & NODE_HAS_CHILDREN) == 0) {
+        if (flags != NODE_MESH_GROUP)
+            return 0;
+
+        swrModel_MeshGetAABB(*node->children.meshes, aabb);
+        rdMatrix_Transform3((rdVector3*) aabb, (rdVector3*) aabb, &cman_unk_mat44);
+        rdMatrix_Transform3((rdVector3*) (aabb + 3), (rdVector3*) (aabb + 3), &cman_unk_mat44);
+        return 1;
+    }
+
+    if (flags == NODE_TRANSFORMED_WITH_PIVOT || flags == NODE_TRANSFORMED) {
+        rdMatrix44 transform;
+        swrModel_NodeGetTransform((swrModel_NodeTransformed*) node, &transform);
+        rdMatrix_Multiply44Acc(&cman_unk_mat44, &transform);
+    }
+
+    for (int i = 0; i < (int) swrModel_NodeGetNumChildren(node); i++) {
+        if (swrModel_NodeComputeFirstMeshAABB(node->children.nodes[i], aabb, a3 | 1))
+            return 1;
+    }
+    return 0;
 }
 
 // 0x00447370
@@ -1555,7 +1674,28 @@ void swrModel_NodeModifyFlags(swrModel_Node* node, int flag_id, int value, char 
 // 0x00481B30
 void swrModel_NodeSetLodDistances(swrModel_NodeLODSelector* node, float* a2)
 {
-    HANG("TODO");
+    if (node == NULL || a2 == NULL)
+        return;
+
+    uint32_t flags = swrModel_NodeGetFlags(&node->node);
+    if (flags == NODE_LOD_SELECTOR) {
+        // a2 is a list of LOD switch distances terminated by a negative value. The first slot is
+        // always forced to 0, and the terminator slot is set to -1.
+        unsigned int i = 0;
+        if (a2[0] >= 0.0f) {
+            do {
+                swrModel_NodeSetLodDistance(node, i, i == 0 ? 0.0f : a2[i]);
+                i++;
+            } while (a2[i] >= 0.0f);
+        }
+        swrModel_NodeSetLodDistance(node, i, -1.0f);
+    }
+
+    if (flags & NODE_HAS_CHILDREN) {
+        uint32_t num_children = swrModel_NodeGetNumChildren(&node->node);
+        for (uint32_t i = 0; i < num_children; i++)
+            swrModel_NodeSetLodDistances((swrModel_NodeLODSelector*) node->node.children.nodes[i], a2);
+    }
 }
 
 // 0x00431750

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -1312,31 +1312,49 @@ void swrSprite_UpdateLensFlareSpriteSettings(int16_t id, int a2, int a3, float a
 // 0x0042C400
 void ResetPlayerSpriteValues()
 {
-    HANG("TODO");
+    for (int i = 0; i < 20; i++)
+        player_sprite_unknown_values[i] = -9999;
 }
 
 // 0x0042C420
 void SetPlayerSpritePositionOnMap(int player_id, const rdVector3* position, int unknown_value)
 {
-    HANG("TODO");
+    player_sprite_unknown_values[player_id] = unknown_value;
+    player_sprite_positions_on_map[player_id].x = position->x;
+    player_sprite_positions_on_map[player_id].y = position->y;
+    player_sprite_positions_on_map[player_id].z = position->z;
 }
 
 // 0x0042C460
 void ResetLightStreakSprites()
 {
-    HANG("TODO");
+    for (int i = 0; i < 10; i++) {
+        lightStreakSpriteIDs2[i] = -1;
+        lightStreakSpriteIDs1[i] = -1;
+    }
+    for (int i = 0; i < 40; i++)
+        light_streak_valid[i] = 0;
 }
 
 // 0x0042C490
 void InitLightStreak(int index, rdVector3* position)
 {
-    HANG("TODO");
+    if (index < 40) {
+        light_streak_positions[index].x = position->x;
+        light_streak_positions[index].y = position->y;
+        light_streak_positions[index].z = position->z;
+        light_streak_depth_values[index] = -1000.0f;
+        light_streak_valid[index] = 1;
+    }
 }
 
 // 0x0042C4E0
 void SetLightStreakSpriteIDs(int index, int sprite_id1, int sprite_id2)
 {
-    HANG("TODO");
+    if (index < 10) {
+        lightStreakSpriteIDs1[index] = sprite_id1;
+        lightStreakSpriteIDs2[index] = sprite_id2;
+    }
 }
 
 // 0x0042C7A0
@@ -1354,7 +1372,7 @@ void UpdateLightStreakSprites(swrViewport* a1)
 // 0x0042D510
 void DisableIngameSprites()
 {
-    HANG("TODO");
+    InRaceSpritesEnabled = 0;
 }
 
 // 0x00431710


### PR DESCRIPTION
Fills 17 `HANG` stubs in `swrModel.c` with reverse-hook bodies, two coherent groups:

**Node/mesh manipulation API (11)** — `NodeFindFirstMeshMaterial`, `MeshMaterialSetColors`, `NodeSetColorsOnAllMaterials`, `NodeSetTransformFromTranslationRotation`, `NodeSetSelectedChildNode`, `MeshGetAABB`, `NodeGetMesh`, `MeshMaterialSetTextureUVOffset`, `NodeSetAnimationFlagsAndSpeed`, `NodeComputeFirstMeshAABB`, `NodeSetLodDistances`.

**In-game sprite/HUD placement (6)** — `ResetPlayerSpriteValues`, `SetPlayerSpritePositionOnMap`, `ResetLightStreakSprites`, `InitLightStreak`, `SetLightStreakSpriteIDs`, `DisableIngameSprites`.

No new globals or header changes — all globals already in `data_symbols`, node-type magic uses the existing `swrModel_NodeType` enum. Verified with a full `dinput_hook.dll` link and disasm spot-checks vs the original.

Two notes for review:
- `MeshMaterialSetTextureUVOffset`: the decompile drops the `res*offset` multiply (shows as `unaff_ESI/EDI`) — recovered from the disasm. It also sets `type |= 0x8000` (matches `OR CH,0x80` = bit 15), though the struct comment on `type` says `0x80` — might be worth fixing that comment.
- `NodeGetMesh` is declared taking `swrModel_NodeMeshGroup*`, but its one caller passes a `NODE_MESH_GROUP` node; `children.meshes` sits at the same offset as `cached_model_matrix`, so I cast to `swrModel_Node*` for the read.

Deferred the float-heavy consumers in the same section (`UpdateLensFlareSpriteSettings`, `UpdateLightStreakSprites`, `swrText_CreateTextEntry2` — all need broken-FP arg recovery) to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)