### PR TITLE
fix: render rain/snow at modern resolutions

### DIFF
--- a/dinput_hook/game_deltas/swrWeather_delta.cpp
+++ b/dinput_hook/game_deltas/swrWeather_delta.cpp
@@ -1,0 +1,101 @@
+#include "swrWeather_delta.h"
+
+#include <windows.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+extern FILE *hook_log;
+}
+
+// LAYER 2: lift the high-resolution weather-despawn deadlock. See swrWeather_delta.h and the
+// KNOWN ISSUES block in src/Swr/swrWeather.h for why this exact byte edit fixes it.
+//
+// The two patched dwords are the float immediates inside these instructions:
+//   0x0042B868  MOV dword ptr [ESI], 0xC47A0000   ; *outScreenX = -1000.0f   (imm @ 0x0042B86A)
+//   0x0042B87F  MOV dword ptr [EDI], 0xC47A0000   ; *outScreenY = -1000.0f   (imm @ 0x0042B881)
+// 0xC47A0000 (LE: 00 00 7A C4) = -1000.0f, 0xFF800000 (LE: 00 00 80 FF) = -INFINITY.
+void swrWeather_PatchHiResParticleSentinel() {
+    struct SentinelSite {
+        uint32_t address;          // address of the 4-byte float immediate (not the opcode)
+        uint8_t original[4];       // -1000.0f
+        uint8_t patched[4];        // -INFINITY
+    };
+
+    static const SentinelSite sites[] = {
+        {0x0042b86a, {0x00, 0x00, 0x7a, 0xc4}, {0x00, 0x00, 0x80, 0xff}}, // *outScreenX sentinel
+        {0x0042b881, {0x00, 0x00, 0x7a, 0xc4}, {0x00, 0x00, 0x80, 0xff}}, // *outScreenY sentinel
+    };
+
+    int patched = 0;
+    const int total = (int) (sizeof(sites) / sizeof(sites[0]));
+    for (const SentinelSite &site: sites) {
+        uint8_t *code = (uint8_t *) site.address;
+        if (std::memcmp(code, site.original, 4) != 0) {
+            if (std::memcmp(code, site.patched, 4) == 0)
+                continue; // already patched
+            fprintf(hook_log,
+                    "[swrWeather_PatchHiResParticleSentinel] unexpected bytes at %p; aborting patch. "
+                    "Weather will not render at screen_width >= 1000.\n",
+                    (void *) code);
+            fflush(hook_log);
+            return;
+        }
+
+        DWORD old_protect = 0;
+        VirtualProtect(code, 4, PAGE_EXECUTE_READWRITE, &old_protect);
+        std::memcpy(code, site.patched, 4);
+        VirtualProtect(code, 4, old_protect, &old_protect);
+        patched++;
+    }
+
+    fprintf(hook_log,
+            "[swrWeather_PatchHiResParticleSentinel] patched %d/%d projection sentinels "
+            "(-1000.0f -> -INF); weather now respawns at any resolution.\n",
+            patched, total);
+    fflush(hook_log);
+}
+
+// LAYER 3-A: force the point-sprite path so moving snow stays visible. See swrWeather_delta.h.
+//
+// The streak-mode selection in swrWeather_RenderParticles:
+//   0042d20a  83 7C 24 40 03  CMP dword ptr [ESP+0x40], 3   ; |dy| (px) vs threshold
+//   0042d20f  7D 16           JGE 0x0042d227                ; >= 3 -> streak path
+//   0042d211  83 F8 03        CMP EAX, 3                    ; |dx| (px) vs threshold
+//   0042d214  7D 11           JGE 0x0042d227                ; >= 3 -> streak path
+//   0042d216  ...             CALL swrSprite_UnsetFlag(id, 0x4000)  ; < 3 -> point path
+// NOP the two JGE bytes so neither jump is taken and the point path always runs.
+void swrWeather_PatchForcePointParticles() {
+    // One 12-byte site spanning both CMP/JGE pairs; only the two JGE opcodes change (7D xx -> 90 90).
+    const uint32_t address = 0x0042d20a;
+    static const uint8_t original[12] = {0x83, 0x7c, 0x24, 0x40, 0x03, 0x7d, 0x16,
+                                         0x83, 0xf8, 0x03, 0x7d, 0x11};
+    static const uint8_t patched[12] = {0x83, 0x7c, 0x24, 0x40, 0x03, 0x90, 0x90,
+                                        0x83, 0xf8, 0x03, 0x90, 0x90};
+
+    uint8_t *code = (uint8_t *) address;
+    if (std::memcmp(code, original, sizeof(original)) != 0) {
+        if (std::memcmp(code, patched, sizeof(patched)) == 0) {
+            fprintf(hook_log, "[swrWeather_PatchForcePointParticles] already patched.\n");
+            fflush(hook_log);
+            return;
+        }
+        fprintf(hook_log,
+                "[swrWeather_PatchForcePointParticles] unexpected bytes at %p; aborting patch. "
+                "Snow will keep vanishing when the pod moves.\n",
+                (void *) code);
+        fflush(hook_log);
+        return;
+    }
+
+    DWORD old_protect = 0;
+    VirtualProtect(code, sizeof(patched), PAGE_EXECUTE_READWRITE, &old_protect);
+    std::memcpy(code, patched, sizeof(patched));
+    VirtualProtect(code, sizeof(patched), old_protect, &old_protect);
+
+    fprintf(hook_log,
+            "[swrWeather_PatchForcePointParticles] forced point-sprite path; moving snow now "
+            "renders as points instead of the broken hi-res streak path.\n");
+    fflush(hook_log);
+}

--- a/dinput_hook/game_deltas/swrWeather_delta.h
+++ b/dinput_hook/game_deltas/swrWeather_delta.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Weather (rain/snow) rendering fixes for modern high-resolution displays.
+//
+// See the KNOWN ISSUES block in src/Swr/swrWeather.h for the full Layer 1/2/3 analysis.
+//
+// LAYER 2 fix (this file): at screen_width >= 1000 the weather particle pool stops respawning and
+// weather vanishes. swrViewport_ProjectToScreen seeds its out screen X/Y with a -1000.0f sentinel
+// and only overwrites it when the point projects in-bounds; swrWeather_RenderParticles despawns a
+// particle when its screen X < -screen_width. With the sentinel pinned at -1000.0f the despawn
+// never fires for >= 1000-px-wide screens (-1000.0 < -1000.0 is false), so off-screen particles
+// are stuck "active but invisible" forever and the pool never recycles. Patching the sentinel to
+// -INF makes the despawn fire at any resolution. Empirically verified (DDrawCompat reproduces the
+// same threshold as dgVoodoo2, so it is the EXE, not the DirectDraw wrapper).
+//
+// Applied as a verified in-place byte patch at startup (mirrors swrObjJdge_PatchRaceTimeCap): two
+// 4-byte float immediates inside swrViewport_ProjectToScreen, 0xC47A0000 (-1000.0f) -> 0xFF800000
+// (-INF). The function's other callers (HUD distance text, rearview, world sprites, target
+// indicators) use the output only as a sprite coordinate that the sprite renderer clips naturally,
+// so -INF vs -1000.0f is a no-op for them.
+void swrWeather_PatchHiResParticleSentinel();
+
+// LAYER 3-A fix (snow vanishes when the pod moves): swrWeather_RenderParticles picks a render mode
+// per flake from its per-frame screen movement -- < 3 px uses the point-sprite path (renders fine),
+// >= 3 px sets sprite flag 0x4000 and uses the streak/motion-blur path (renders nothing at modern
+// resolutions). The 3 px threshold is absolute, not resolution-scaled, so at high resolution any
+// camera motion pushes every flake past it -> all snow flips to the broken streak path and
+// disappears (parked = visible, moving = gone; slight motion straddles the threshold = flicker).
+//
+// Until the streak draw path is fixed, force the point-sprite path: NOP the two JGE branches that
+// select the streak path (at 0x0042d20f / 0x0042d214 inside swrWeather_RenderParticles) so the code
+// always falls through to swrSprite_UnsetFlag(0x4000). Moving snow then renders as points (the same
+// way it already renders when parked) instead of vanishing. Scoped to the weather particle loop.
+void swrWeather_PatchForcePointParticles();

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "./game_deltas/swrObjJdge_delta.h"
 #include "./game_deltas/swrMultiplayer_delta.h"
 #include "./game_deltas/swrPlayerHUD_delta.h"
+#include "./game_deltas/swrWeather_delta.h"
 #include "./game_deltas/swrObjHang_delta.h"
 #include "./game_deltas/swrRace_delta.h"
 
@@ -1465,6 +1466,19 @@ extern "C" void init_renderer_hooks() {
     // counts above 5 no longer corrupt the score struct (the real hardcoded 5-lap limit). The
     // hangar menu cap was also raised to 100 in tracks_delta.c.
     swrObjJdge_PatchLapTimeOverflow();
+
+    // High-res weather (Layer 2): patch swrViewport_ProjectToScreen's -1000.0f off-screen sentinel
+    // to -INF so the weather particle pool keeps despawning/respawning at screen_width >= 1000.
+    // Without this, rain/snow renders for one cycle then vanishes on modern displays. See
+    // swrWeather_delta.h / the KNOWN ISSUES block in src/Swr/swrWeather.h.
+    swrWeather_PatchHiResParticleSentinel();
+
+    // High-res weather (Layer 3-A): snow vanishes the moment the pod moves because at high
+    // resolution any camera motion pushes each flake's per-frame screen movement past the absolute
+    // 3-px streak threshold, flipping it to the streak path (sprite flag 0x4000) which renders
+    // nothing at modern resolutions. Force the working point-sprite path until the streak draw is
+    // fixed, so moving snow renders as points instead of disappearing.
+    swrWeather_PatchForcePointParticles();
 
     // 5+ laps in multiplayer: the MP lobby's host lap stepper was the only thing still capping the
     // count at 5 (the race itself shares the crash-safe single-player path above). Give it free-play

--- a/src/Swr/swrWeather.h
+++ b/src/Swr/swrWeather.h
@@ -127,49 +127,44 @@
 //     - Tested: snow renders correctly at 1920x1080 on Howler Gorge and Andobi
 //       Mountain Run.
 //
-// LAYER 3 -- REMAINING ARTIFACTS AFTER LAYER 2 PATCH (partially understood):
+// LAYER 3 -- ARTIFACTS AFTER LAYER 2 PATCH (3-A root-caused + fixed; 3-B open):
 //
 //   With Layer 2 patched, two artifacts remain:
 //
-//     A. Snow particles flicker / fail to render during sharp camera turns. On the
-//        N64 and Dreamcast versions the corresponding behaviour is visible motion
-//        blur (streaks). On PC after the Layer 2 patch the streak flag (swrSprite
-//        flag 0x4000, set in swrWeather_RenderParticles when |delta_screen| >= 3
-//        per frame) does not produce the trail effect during turns; particles
-//        instead appear and disappear as they cross the viewport edges.
+//     A. Snow/rain vanish the moment the camera moves (parked = renders fine,
+//        any motion = flickers then disappears). ROOT-CAUSED + FIXED.
 //
-//     B. Rain (planetId == 4) only renders intermittently even after the Layer 2
-//        patch. Forcing swrWeather_SetStretchFactor(1.0) so rain uses the
-//        point-particle path makes it somewhat visible but still mostly broken,
-//        suggesting rain's very high vertical velocity (vy = 1000 for heavy rain)
-//        makes particles cross the viewport in a single frame and immediately
-//        cycle through despawn->respawn faster than they can render coherently.
+//        swrWeather_RenderParticles picks a render mode per particle from its
+//        per-frame screen movement: < 3 px uses the point-sprite path (clears
+//        sprite flag 0x4000) and renders fine; >= 3 px sets flag 0x4000 and takes
+//        the "streak" path. That 3 px threshold is absolute, never scaled by
+//        resolution, so at high resolution any camera motion pushes every particle
+//        past it and the whole field flips to the streak path (slight motion
+//        straddles the threshold -> the flicker).
 //
-//   Two candidate causes, neither yet root-caused:
+//        And the streak path renders NOTHING: it is a stub, not a bug. The PC port
+//        never implemented the N64/Dreamcast motion-blur streaks. Trace: instance
+//        flag 0x4000 -> swrSprite_Draw2 (0x428030) maps it to draw flag 0x400000 ->
+//        swrSprite_Draw (0x44f160) routes 0x400000 to swr_noop2 (0x426910, a single
+//        RET). So a streaking sprite emits zero geometry at any resolution, and the
+//        streak endpoints the code computes + stores (swrSprite_array[id].unk0x4 /
+//        unk0x6, normalized to 320x240 by swrSprite_SetStreakEndpoints_Maybe) are
+//        dead data. (An earlier guess of a precision bug in the streak math was
+//        wrong -- there is no streak draw to be buggy.)
 //
-//     1. Inherent particle cycle rate at modern resolutions. With Layer 2 fixed,
-//        particles despawn the moment they project off-screen. At 1920x1080 the
-//        camera basis vectors during a turn project particles across the viewport
-//        edges far more often than at the engine's design resolution (640x480 or
-//        320x240), so the spawn/despawn cycle becomes too rapid to look stable.
-//        The N64/Dreamcast versions did not exhibit this because their native
-//        resolution kept particles inside the viewport for many more frames.
+//        FIX (3-A): force the working point-sprite path -- NOP the two JGE branches
+//        in swrWeather_RenderParticles (0x0042d20f / 0x0042d214) that select the
+//        streak path, so moving particles render as points exactly like parked
+//        ones. This is the faithful PC behaviour (PC only ever had point
+//        particles); restoring real streaks would mean implementing the cut
+//        feature, not fixing a bug.
 //
-//     2. A streak-rendering bug in the sprite render primitive FUN_0044f670
-//        (0x0044f670), which has explicit flag-0x4000 handling that reads sprite
-//        secondary endpoints from sprite_struct + 0x2 / + 0x4 (written by
-//        FUN_0042d330 -> FUN_004286c0 at DAT_00e9ba64 + sprite_id * 0x20). The
-//        streak path multiplies coordinates by param_5 and adds (param_3 -
-//        local_3c) offsets; one of these intermediate computations may have a
-//        precision or sign issue at modern resolutions, but tracing has not yet
-//        confirmed which.
-//
-//   An attempted fix (NOP-ing the 4 viewport-bounds-box checks in
-//   swrViewport_ProjectToScreen at 0x0042B994, 0x0042B9B6, 0x0042B9D1, 0x0042B9F6,
-//   so that real projected coords are always written instead of letting the
-//   sentinel persist for off-screen points) produced no visible change. So
-//   Layer 3's cause is NOT just sentinel data flowing into the streak endpoint
-//   computation -- it lives elsewhere.
+//     B. Rain (planetId == 4) renders only intermittently even after 3-A. STILL
+//        OPEN. Rain's very high vertical velocity (vy = 1000 for heavy rain) drops
+//        a particle through the viewport in ~1 frame, and respawn is only
+//        probabilistic per frame, so density stays sparse. Candidate workaround:
+//        force swrWeather_SetStretchFactor(1.0) for planetId == 4 (point path) and/
+//        or clamp the per-frame displacement; not yet implemented.
 //
 // SECONDARY (real, but neither a Layer 2 nor Layer 3 root cause): the bpp dispatch
 //   in the occlusion pixel-sampling (here and in swrPlayerHUD_SampleOcclusion) has
@@ -180,15 +175,16 @@
 //   but particles are SetVisible(1) regardless of occlusion outcome, so they do not
 //   by themselves prevent rendering.
 //
-// MODERN FIX SUMMARY (for a swr_reimpl.dll hook or direct EXE patch):
-//   - Layer 2 (snow at high res): patch the two 4-byte sentinel immediates listed
-//     above. 8 bytes total. Closes the primary "no weather at high res" bug.
-//   - Layer 3 (rain + snow flicker on turn): no patch yet. Suggested follow-up
-//     work: instrument FUN_0044f670 to log its streak path inputs (param_3,
-//     param_5, sprite secondary endpoints) at 1920x1080 vs 640x480 while a snow
-//     track is rendered mid-turn; the divergence will identify the streak bug.
-//     For rain specifically, consider patching swrPlayerHUD_SetupTrackOverlay to
-//     force stretch_factor = 1.0 for planetId == 4 as a partial workaround.
+// MODERN FIX SUMMARY (implemented as reversible EXE byte-patches in
+// dinput_hook/game_deltas/swrWeather_delta.cpp, applied at renderer init):
+//   - Layer 2 (no weather at high res): swrWeather_PatchHiResParticleSentinel
+//     patches the two 4-byte sentinel immediates above (-1000.0f -> -INF). 8 bytes.
+//     Closes the primary "no weather at high res" bug.
+//   - Layer 3-A (weather vanishes when the pod moves):
+//     swrWeather_PatchForcePointParticles NOPs the two streak-select JGEs so the
+//     point-sprite path always runs. Snow/rain render as points while moving.
+//   - Layer 3-B (rain intermittent) and real motion-blur streaks (a cut PC
+//     feature, stubbed by swr_noop2) are not addressed; see Layer 3 above.
 // =====================================================================================
 
 #define swrWeather_RenderParticles_ADDR (0x0042cca0)


### PR DESCRIPTION
Rain/snow don't render on modern high-res displays. Two reversible EXE byte-patches in a new `swrWeather_delta`, applied at renderer init:

**Layer 2 - no weather at screen_width >= 1000.** `swrViewport_ProjectToScreen` seeds its off-screen sentinel at `-1000.0f` and the particle despawn test is `screenX < -screen_width`, so at `screen_width >= 1000` the despawn never fires (`-1000.0 < -1000.0` is false), the pool stops recycling, and weather vanishes after one cycle. Patch the two sentinel immediates to `-INF` so despawn fires at any resolution. (The old dgVoodoo theory is wrong - DDrawCompat reproduces the same threshold, so it's the EXE.)

**Layer 3-A - snow/rain vanish the moment the pod moves.** The per-particle render mode is chosen by an absolute 3px screen-movement threshold; at high res any camera motion exceeds it, flipping every particle to the streak path (sprite flag `0x4000`). That path turns out to be a stub: instance flag `0x4000` -> draw flag `0x400000` (`swrSprite_Draw2`) -> `swrSprite_Draw` routes it to `swr_noop2` (a single `RET`), so a streaking sprite emits no geometry at any resolution - the PC port never implemented the N64/Dreamcast motion-blur streaks. NOP the two `JGE` branches that select the streak path so the working point-sprite path always runs; moving weather then renders as points (PC's only-ever behaviour).

Both patches byte-verify the site before writing and no-op (logged) if the signature doesn't match. Also corrected the Layer 3 notes in `swrWeather.h` (they guessed a precision bug in the streak math; it's actually the `swr_noop2` stub).

Playtested at 1920x1080: snow and rain now render both parked and moving. Real motion-blur streaks would be a separate feature (reimplementing the cut path), and rain is still a touch sparse (Layer 3-B, noted in the header) - both good follow-ups rather than blockers here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)