### PR TITLE
feat(multiplayer): per-player "disable pod collision" (ghost mode)

### DIFF
--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -6,12 +6,14 @@
 
 extern "C" {
 #include <Swr/swrObj.h>
+#include <Swr/swrRace.h>
 #include <globals.h>
 
 extern FILE* hook_log;
 }
 
 #include "../hook_helper.h"
+#include "../imgui_utils.h" // imgui_state.mp_disable_collision (the debug-menu toggle)
 
 // The pod's cockpit->engine cables (unk344_nodeArray[10] and [11]) are bent into a curve each
 // frame by swrRace's connection-mesh deformer (FUN_00481c30 @ 0x481c30). That deformation is
@@ -89,6 +91,32 @@ void __cdecl swrRace_AnimateDisplayPod_delta(swrModel_Node** nodes, void* transf
     for (int i = 10; i <= 13; i++)
         if (nodes[i])
             cable_bend_by_node[nodes[i]] = amplitude;
+}
+
+// Multiplayer "no collision" / ghost mode. swrRace_ResolvePodCollision (called each physics step
+// from swrObjTest_SuperUnk) finds the nearest pod and resolves a pod-to-pod collision, pushing both
+// pods apart and bleeding speed off both. When the local player turns collision off in multiplayer,
+// skip it so they pass straight through other racers.
+//
+// We skip it for EVERY pod, not just the local one: the function mutates BOTH pods it resolves, and
+// remote pods run their physics locally too -- so skipping only the local pod still lets a remote
+// pod's call bump us via the other-pod side (confirmed in-game). Skipping all pods means our pod can
+// never be pushed by a collision on our machine. Remote pod positions come from the network anyway,
+// so dropping their local collision response desyncs nothing; track/wall collision is a separate
+// path (swrRace_CollideTrack / UpdateWallContact / UpdateGroundContact) and is untouched. This is
+// per-player by nature -- it governs collisions on OUR machine -- so if everyone in a lobby enables
+// it, nobody collides. Not reimplemented in src (declared in swrRace.h), so the original is called
+// back through its address via this typedef.
+typedef void(__cdecl* swrRace_ResolvePodCollision_t)(swrRace* player);
+
+void __cdecl swrRace_ResolvePodCollision_delta(swrRace* player) {
+    if (imgui_state.mp_disable_collision && multiplayer_enabled != 0 && player != nullptr) {
+        // Mirror the original's "no pod nearby" outcome: it always clears speedLoss before the
+        // collision test, so do the same here instead of leaving a stale value from a prior hit.
+        player->speedLoss = 0.0f;
+        return;
+    }
+    hook_call_original((swrRace_ResolvePodCollision_t) swrRace_ResolvePodCollision_ADDR, player);
 }
 
 float swrRace_GetCableBendAmplitude(const swrModel_Node* node) {

--- a/dinput_hook/game_deltas/swrRace_delta.h
+++ b/dinput_hook/game_deltas/swrRace_delta.h
@@ -10,6 +10,10 @@ void swrRace_AnimateDisplayPod_delta(swrModel_Node** nodes, void* transform, int
                                      float a5, float a6, float a7, int animated, float a9,
                                      float a10);
 
+// Multiplayer "no collision" toggle: skips pod-to-pod collision (all pods, on this machine) so the
+// local player passes through other racers; track/wall collision is kept. Hooked by address.
+void swrRace_ResolvePodCollision_delta(swrRace* player);
+
 // Cable-curve amplitude for a curently-curved cable node (-1.0 = not a curved cable). Consumed by
 // the renderer to bend the cable mesh in the GL path.
 float swrRace_GetCableBendAmplitude(const swrModel_Node* node);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -115,6 +115,9 @@ void read_settings_ini() {
     imgui_state.show_pod_names =
         GetPrivateProfileIntW(L"settings", L"show_pod_names", 1, ini_path.c_str());
 
+    imgui_state.mp_disable_collision =
+        GetPrivateProfileIntW(L"settings", L"mp_disable_collision", 0, ini_path.c_str());
+
     g_window_mode =
         GetPrivateProfileIntW(L"settings", L"window_mode", WINDOW_MODE_WINDOWED, ini_path.c_str());
     if (g_window_mode < WINDOW_MODE_WINDOWED || g_window_mode > WINDOW_MODE_FULLSCREEN)
@@ -151,6 +154,9 @@ void save_settings_ini() {
 
     WritePrivateProfileStringW(L"settings", L"show_pod_names",
                                imgui_state.show_pod_names ? L"1" : L"0", ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"mp_disable_collision",
+                               imgui_state.mp_disable_collision ? L"1" : L"0", ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"window_mode", std::to_wstring(g_window_mode).c_str(),
                                ini_path.c_str());
@@ -774,6 +780,13 @@ void opengl_render_imgui() {
 
         if (ImGui::Checkbox("Overhead racer labels (MP names / SP place)",
                             &imgui_state.show_pod_names)) {
+            save_settings_ini();
+        }
+
+        // Multiplayer: skip pod-to-pod collision for the local player (pass through other racers).
+        // Track/wall collision is unaffected. Per-player: if everyone enables it, nobody collides.
+        if (ImGui::Checkbox("Multiplayer: disable pod collision",
+                            &imgui_state.mp_disable_collision)) {
             save_settings_ini();
         }
 

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -38,6 +38,8 @@ typedef struct ImGuiState {
     bool show_fps_overlay = false;// pinned top-right FPS readout + frame-time graph
     bool show_fps_graph = true;// graph beneath the FPS overlay number
     bool show_pod_names = true;// draw the overhead racer labels (MP player names / SP place numbers)
+    bool mp_disable_collision = false;// in multiplayer, skip pod-to-pod collision for the local
+                                   // player so they pass through other racers (track collision kept)
 
     bool enable_picking_texture_when_hovering = false;
     bool pick_through_transparent_objects = true;

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1461,6 +1461,12 @@ extern "C" void init_renderer_hooks() {
     hook_function("swrRace_AnimateDisplayPod", (uint32_t) swrRace_AnimateDisplayPod_ADDR,
                   (uint8_t *) swrRace_AnimateDisplayPod_delta);
 
+    // Multiplayer "disable pod collision": when the local player turns it on, skip pod-to-pod
+    // collision resolution for their pod so they pass through other racers. Hooked by address (not
+    // reimplemented); the original is called back through swrRace_ResolvePodCollision_ADDR.
+    hook_function("swrRace_ResolvePodCollision", (uint32_t) swrRace_ResolvePodCollision_ADDR,
+                  (uint8_t *) swrRace_ResolvePodCollision_delta);
+
     // 100-lap support: de-index swrObjJdge_F2's fixed 5-slot per-lap split-time array so lap
     // counts above 5 no longer corrupt the score struct (the real hardcoded 5-lap limit). The
     // hangar menu cap was also raised to 100 in tracks_delta.c.


### PR DESCRIPTION
Opt-in **"Multiplayer: disable pod collision"** toggle -- lets a player pass through other racers (ghost mode).

`swrRace_ResolvePodCollision` (the pod-to-pod step, called each physics tick from `swrObjTest_SuperUnk`) finds the nearest pod, shoves both apart and bleeds speed off both. When the toggle is on in multiplayer it's skipped for **every** pod on the machine -- not just the local one: remote pods run their physics locally too, and the function mutates *both* pods it resolves, so skipping only the local pod still let a remote pod's call bump us via the other-pod side. Remote positions come from the network, so dropping the local collision response desyncs nothing; track/wall collision is a separate path and is untouched. `speedLoss` is zeroed on skip to mirror the original's "no pod nearby" reset.

Per-player (a fully collision-free race = everyone enables it); default off; single-player untouched. `swrRace_ResolvePodCollision` isn't reimplemented, so it's hooked by address. Playtested in a 2-player race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)