### PR TITLE
swrSound: reimplement 9 cache/mixer/config functions

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -1154,6 +1154,7 @@ swrRace_airbrake_upgrade_health 0x00e35aac char
 swrRace_cooling_upgrade_health 0x00e35aad char
 swrRace_repair_upgrade_health 0x00e35aae char
 
+sound_sfx_volume 0x00e364a5 uint8_t
 sound_music_volume 0x00e364a6 short
 g_aBeatTracksGlobal 0x00e364ac uint8_t[4]
 

--- a/src/Swr/swrSound.c
+++ b/src/Swr/swrSound.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h> // sprintf
 
+#include <stdlib.h> // malloc, free
 #include <string.h>
 
 // 0x00421D90
@@ -83,6 +84,13 @@ IA3dSource* swrSound_CreateSourceFromFile(char* wave_filename)
     if (source != NULL)
         swrSound_ReleaseSource(source);
     return NULL;
+}
+
+// True if `entry` is the descriptor currently bound to the streaming source.
+// 0x00423190
+int swrSound_IsStreamingEntry(void* entry)
+{
+    return swrSoundStream_entry == entry;
 }
 
 // Look up a sound descriptor by wav filename in the sound-name hashtable.
@@ -810,6 +818,14 @@ unsigned int swrSound_GetHardwareFlags(void)
     return Sound_A3Dinitted ? a3dCaps_hardware.dwFlags : 0;
 }
 
+// Set the min/max distance used to attenuate the next spatial sfx (the PlaySpatial path).
+// 0x004270f0
+void swrSound_SetSpatialOrigin_Maybe(float minDist, float maxDist)
+{
+    swrSound_spatialMinDist = minDist;
+    swrSound_spatialMaxDist = maxDist;
+}
+
 // Maps a (category, variant, id) sfx request to a loaded sound's handle. The per-category remap
 // table only validates the id (a negative entry -> no such sfx); the actual ".wav" filename is
 // built from the category prefix (+ a variant prefix for categories 0-1) and the raw id, tried
@@ -947,6 +963,41 @@ void swrSound_ClearSfxFlag(int index, unsigned int mask)
     swrSound_sfxFlags[index] &= ~mask;
 }
 
+// Apply the default audio configuration: enable each feature only if the hardware
+// reports support for it, reset gains, and set the initial sfx/music volumes.
+// 0x004220b0
+void swrSound_SetDefaultConfig(void)
+{
+    Main_sound = swrSound_Ready;
+    Sound_enabled_3d = (swrSound_Ready != 0 && Sound_HardwareDetected != 0) ? 1 : 0;
+    Main_hiRes_sound = 0;
+    Main_doppler_sound = swrSound_Ready;
+    Main_sound_reflections = (swrSound_Ready != 0 && Sound_FirstReflexionsSupport != 0) ? 1 : 0;
+    Main_sound_gain_adjust = 1.0f;
+    swrSound_SetMainGain(1.0f);
+    swrRace_music_enabled = 0;
+    Main_sound_reverb = 0;
+    swrRace_voices_enabled = swrSound_Ready;
+    sound_sfx_volume = 0xe1;
+    *(unsigned char*) &sound_music_volume = 200; // original sets only the low byte
+}
+
+// Allocate the bank's descriptor array (count entries of 0x4c bytes each), zero it,
+// and reset the live count to 0. Returns 1 on success, 0 if the allocation failed.
+// 0x00422770
+int swrSound_AllocBank(int count)
+{
+    char* bank = (char*) swrSound_bank;
+    void* entries = malloc(count * 0x4c);
+    *(void**) (bank + 0x28) = entries;
+    if (entries == NULL)
+        return 0;
+    memset(entries, 0, count * 0x4c);
+    *(int*) (bank + 0x24) = count;
+    *(int*) (bank + 0x20) = 0;
+    return 1;
+}
+
 // 0x00422a90
 void* swrSound_GetEntry(int index)
 {
@@ -1013,6 +1064,13 @@ void swrSound_MarkSfxPlayed(int category, int variant, int soundId, int id)
 
 // A3D 3D-positional playback (distance attenuation, occlusion, panning). Reverse-hook stub for now;
 // reimplemented separately (it pulls in the perspective-projection + occlusion-ray helpers).
+// True for the sound id ranges that play as looping sfx (0x8e-0xa5, plus 0x22).
+// 0x004269c0
+int swrSound_IsLoopingSfxId_Maybe(int soundId)
+{
+    return (soundId > 0x8d && soundId < 0xa6) || soundId == 0x22;
+}
+
 // 0x00426d80
 void swrSound_PlaySpatial(int soundId, short param2, float param3, float gain, rdVector3* position, int param6, unsigned int flags)
 {
@@ -1105,6 +1163,47 @@ void swrSound_PlaySfxThenDelayed(int category, int variant, int id, int delayedC
     swrSound_delayedSfxId = delayedId;
 }
 
+// Reset the runtime voice mixer (clear every channel) and re-arm it on the next update.
+// 0x00449d60
+void swrSound_Reset(void)
+{
+    swrSound_ResetChannels();
+    swrSound_unk_init = 1;
+}
+
+// Silence the first requested voice playing `soundId`; rewind its source if it is live.
+// 0x00449da0
+void swrSound_StopVoiceById(int soundId)
+{
+    if (swrSound_unk_init == 0 || swrSound_Initted == 0)
+        return;
+    for (int i = 0; i < 8; i++) {
+        if (swrSound_voicesRequested[i].id == soundId) {
+            swrSound_voicesRequested[i].volume = 0;
+            if (swrSound_voicesRequested[i].activeSoundId >= 0) {
+                swrSound_Rewind(swrSound_voicesRequested[i].source);
+                return;
+            }
+        }
+    }
+}
+
+// Reset one voice slot to its idle defaults (no sound, unity pitch, default pan).
+// 0x00449e00
+void swrSound_ResetChannel(void* channel)
+{
+    swrSound* c = (swrSound*) channel;
+    c->activeSoundId = -1;
+    c->id = -1;
+    c->unk08 = 0;
+    c->startFrame = -1;
+    c->priority = 0;
+    c->pitch = 1.0f;
+    c->pan = 0x40;
+    c->source = NULL;
+    c->dedicatedSource = 0;
+}
+
 // Zeroes the computed gain of every requested-voice slot (the per-frame voice mixer rebuilds them).
 // 0x00449e30
 void swrSound_ResetRequestedVoices(void)
@@ -1126,6 +1225,19 @@ void swrSound_RewindChannels(void)
             if (voice->unk08 == 0 && voice->activeSoundId >= 0)
                 swrSound_Rewind(voice->source);
         }
+    }
+}
+
+// Reset all eight live and requested voices to idle, and clear the backup-voice slots.
+// 0x00449ea0
+void swrSound_ResetChannels(void)
+{
+    for (int i = 0; i < 8; i++) {
+        swrSound_ResetChannel(&swrSound_voicesLive[i]);
+        swrSound_ResetChannel(&swrSound_voicesRequested[i]);
+        swrSound_voicesBackup[i].source = NULL;
+        swrSound_voicesBackup[i].dedicatedSource = 0;
+        swrSound_voicesBackup[i].unk24 = 1;
     }
 }
 

--- a/src/Swr/swrSound.h
+++ b/src/Swr/swrSound.h
@@ -228,7 +228,7 @@ void swrSound_UpdateIfEnabled(void);
 // flag setter, and the spatial reference-point setter used by the PlaySpatial path.
 int swrSound_IsLoopingSfxId_Maybe(int soundId);
 void swrSound_SetUpdateFlag_Maybe(unsigned char flag);
-void swrSound_SetSpatialOrigin_Maybe(int param1, int param2);
+void swrSound_SetSpatialOrigin_Maybe(float minDist, float maxDist);
 
 // Play two file-backed sources together: a one-shot (introWav) and a positioned
 // loop (loopWav); enable != 0 starts/updates, == 0 stops (best guess, low confidence).


### PR DESCRIPTION
Closes out a batch of named-only swrSound functions into real bodies (all reverse-hooked, compile + disasm-faithful):

- `swrSound_AllocBank` - allocate + zero the descriptor array
- `swrSound_SetDefaultConfig` - default audio config, each feature gated on hardware support
- `swrSound_ResetChannel` / `ResetChannels` / `Reset` - voice-mixer reset
- `swrSound_StopVoiceById` - silence/rewind a requested voice
- `swrSound_SetSpatialOrigin_Maybe` - set the spatial min/max attenuation distance
- `swrSound_IsStreamingEntry` / `IsLoopingSfxId_Maybe` - predicates

Side changes: named the sfx-volume byte (`sound_sfx_volume @ 0xe364a5`, right before `sound_music_volume`), and fixed `swrSound_SetSpatialOrigin_Maybe`'s placeholder `(int,int)` prototype to `(float,float)` since it writes the float distance globals.

Built + linked clean. Left the heavier cache/playback funcs (RegisterSound/LoadSound/Update/PlaySpatial/Startup) for a follow-up.