### PR TITLE
swrSpline: reimplement the cursor + evaluation runtime (14 functions)

### DIFF
--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -5,6 +5,10 @@
 #include "macros.h"
 #include "swrAssetBuffer.h"
 #include "globals.h"
+#include "swr.h"
+
+#include <Primitives/rdMatrix.h>
+#include <Primitives/rdVector.h>
 
 // 0x00446fc0
 void swrSpline_LoadSpline(int index, unsigned short** b)
@@ -34,7 +38,7 @@ void swrSpline_LoadSpline(int index, unsigned short** b)
     // pointer to the control point array, which follows the 0x10 byte header.
     spline->control_points = (swrSplineControlPoint*)((char*)spline + sizeof(swrSpline));
 
-    spline->unk0 = SWAP16(spline->unk0);
+    spline->type = SWAP16(spline->type);
     // note: unk1 is intentionally left un-swapped, matching the original
     spline->num_control_points = SWAP32(spline->num_control_points);
     spline->num_segments = SWAP32(spline->num_segments);
@@ -78,6 +82,268 @@ char* swrSpline_LoadSplineById(char* splineBuffer)
     return splineBuffer;
 }
 
+// 0x0044e5e0
+int swrSpline_getControlPointIdFromProgress(swrSpline* spline, int progress, int startIndex)
+{
+    for (int i = startIndex; i < (int)spline->num_control_points; i++) {
+        if ((short)spline->control_points[i].progress == progress)
+            return i;
+    }
+    return -1;
+}
+
+// 0x0044e620
+int swrSpline_getControlPoint(void* cursor, int level)
+{
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    int branch = c->branchFlags;
+    if (branch == 0)
+        return c->nodeLookahead[level];
+    if (level != 0)
+        branch >>= (level & 0x1f);
+    swrSplineControlPoint* cp = &c->spline->control_points[c->nodeLookahead[level]];
+    return (short)cp->unk_set[branch];
+}
+
+// Cubic interpolation kernel. Builds the {t^3, t^2, t, 1} basis, multiplies it by the
+// spline-type basis matrix, and writes the requested components (mask bit 1 = position,
+// 2 = tangent, 4 = normal, 8 = up) into out[0..11] (3 floats each).
+// 0x0044e660
+void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeIndices, float* out)
+{
+    swrSpline* s = (swrSpline*)spline;
+    swrSplineControlPoint* cp = s->control_points;
+    rdVector4 tvec;
+    rdVector4 basis;
+
+    tvec.z = t;
+    tvec.y = t * t;
+    tvec.w = 1.0f;
+    tvec.x = tvec.y * t;
+
+    float* p0;
+    float* p1;
+    float* p2;
+    float* p3;
+    if (s->type == 0) {
+        rdMatrix_Multiply4(&basis, &tvec, &rdMatrix_unk5);
+        p0 = &cp[nodeIndices[0]].position.x;
+        p1 = &cp[nodeIndices[1]].position.x;
+        p2 = &cp[nodeIndices[2]].position.x;
+        p3 = &cp[nodeIndices[3]].position.x;
+    } else {
+        rdMatrix_Multiply4(&basis, &tvec, &rdMatrix_unk6);
+        p0 = &cp[nodeIndices[0]].position.x;
+        p1 = &cp[nodeIndices[0]].handle2.x;
+        p2 = &cp[nodeIndices[1]].handle1.x;
+        p3 = &cp[nodeIndices[1]].position.x;
+    }
+
+    if (mask & 1) {
+        out[0] = p0[0] * basis.x + p2[0] * basis.z + p1[0] * basis.y + p3[0] * basis.w;
+        out[1] = p1[1] * basis.y + p2[1] * basis.z + p0[1] * basis.x + p3[1] * basis.w;
+        out[2] = p1[2] * basis.y + p2[2] * basis.z + p0[2] * basis.x + p3[2] * basis.w;
+    }
+    if (mask & 8) {
+        if (s->type == 1) {
+            out[11] = 1.0f;
+            out[9] = 0.0f;
+            out[10] = 0.0f;
+        } else {
+            float* r0 = &cp[nodeIndices[0]].rotation.x;
+            float* r1 = &cp[nodeIndices[1]].rotation.x;
+            float* r2 = &cp[nodeIndices[2]].rotation.x;
+            float* r3 = &cp[nodeIndices[3]].rotation.x;
+            out[9] = r3[0] * basis.w + r0[0] * basis.x + r2[0] * basis.z + r1[0] * basis.y;
+            out[10] = r1[1] * basis.y + r2[1] * basis.z + r0[1] * basis.x + r3[1] * basis.w;
+            out[11] = r3[2] * basis.w + r1[2] * basis.y + r2[2] * basis.z + r0[2] * basis.x;
+        }
+    }
+    if (mask & 2) {
+        rdMatrix_Multiply4(&basis, &tvec, s->type == 0 ? &rdMatrix_unk3 : &rdMatrix_unk4);
+        out[3] = p0[0] * basis.x + p2[0] * basis.z + p1[0] * basis.y + p3[0] * basis.w;
+        out[4] = p1[1] * basis.y + p2[1] * basis.z + p0[1] * basis.x + p3[1] * basis.w;
+        out[5] = p1[2] * basis.y + p2[2] * basis.z + p0[2] * basis.x + p3[2] * basis.w;
+    }
+    if (mask & 4) {
+        rdMatrix_Multiply4(&basis, &tvec, s->type == 0 ? &rdMatrix_unk1 : &rdMatrix_unk2);
+        out[6] = p0[0] * basis.x + p2[0] * basis.z + p1[0] * basis.y + p3[0] * basis.w;
+        out[7] = p1[1] * basis.y + p2[1] * basis.z + p0[1] * basis.x + p3[1] * basis.w;
+        out[8] = p1[2] * basis.y + p2[2] * basis.z + p0[2] * basis.x + p3[2] * basis.w;
+    }
+}
+
+// Step the cursor one control point along the graph: direction 1 advances (next link),
+// direction 2 retreats (prev link). Shifts the node lookahead window and tracks the
+// branch taken in branchFlags; sets endFlag/startFlag at a dead end.
+// 0x0044eaa0
+void swrSpline_CursorStep(void* spline, int direction, void* cursor)
+{
+    swrSpline* s = (swrSpline*)spline;
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    swrSplineControlPoint* cp = s->control_points;
+
+    if ((short)direction == 1) {
+        c->startFlag = 0;
+        if (c->endFlag == 0) {
+            int lead = (s->type == 0) ? c->nodeLookahead[3] : c->nodeLookahead[1];
+            int nextCount = (short)cp[lead].next_count;
+            if (nextCount == 0) {
+                direction = -1;
+                c->endFlag = 1;
+                c->segmentT = 1.0f;
+            } else {
+                int branch = (c->branchSelector < nextCount) ? c->branchSelector : (c->branchSelector % nextCount);
+                direction = (short)(&cp[lead].next1)[branch];
+                int hist = c->branchFlags >> 1;
+                c->branchFlags = (s->type == 0) ? (hist | (branch << 2)) : (hist | branch);
+            }
+        }
+        if (c->endFlag == 0) {
+            c->nodeLookahead[0] = c->nodeLookahead[1];
+            if (s->type != 0) {
+                c->nodeLookahead[1] = direction;
+                return;
+            }
+            c->nodeLookahead[1] = c->nodeLookahead[2];
+            c->nodeLookahead[2] = c->nodeLookahead[3];
+            c->nodeLookahead[3] = direction;
+        }
+    } else {
+        c->endFlag = 0;
+        if (c->startFlag == 0) {
+            int tail = c->nodeLookahead[0];
+            int prevCount = (short)cp[tail].prev_count;
+            if (prevCount == 0) {
+                direction = -1;
+                c->startFlag = 1;
+                c->segmentT = 0.0f;
+            } else {
+                int branch = c->branchSelector;
+                direction = (short)(&cp[tail].prev1)[(branch < prevCount) ? branch : (branch % prevCount)];
+                c->branchFlags = (s->type == 0) ? ((c->branchFlags & 3) << 1) : 0;
+                if (tail != (short)cp[direction].next1)
+                    c->branchFlags |= 1;
+            }
+        }
+        if (c->startFlag == 0) {
+            if (s->type == 0) {
+                c->nodeLookahead[3] = c->nodeLookahead[2];
+                c->nodeLookahead[2] = c->nodeLookahead[1];
+            }
+            int old = c->nodeLookahead[0];
+            c->nodeLookahead[0] = direction;
+            c->nodeLookahead[1] = old;
+        }
+    }
+}
+
+// Advance the cursor parameter by velocity * dt, crossing segment boundaries (stepping
+// the cursor) as needed, then evaluate position + tangent + up into out and cache the
+// tangent length.
+// 0x0044ec40
+void swrSpline_CursorEvaluate(void* cursor, float* out)
+{
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+
+    if ((c->velocity > 0.0f && c->endFlag == 0) || (c->velocity < 0.0f && c->startFlag == 0)) {
+        float step = c->velocity * (float)swrRace_deltaTimeSecs;
+        c->segmentT += step;
+        if (step >= 0.0f) {
+            if (step > 0.0f)
+                c->startFlag = 0;
+        } else {
+            c->endFlag = 0;
+        }
+    }
+
+    while (c->segmentT >= 1.0f) {
+        if (c->endFlag != 0)
+            break;
+        c->segmentT -= 1.0f;
+        swrSpline_CursorStep(c->spline, 1, c);
+    }
+    while (c->segmentT < 0.0f) {
+        if (c->startFlag != 0)
+            break;
+        c->segmentT += 1.0f;
+        swrSpline_CursorStep(c->spline, 2, c);
+    }
+    if (c->segmentT < 0.0f)
+        c->segmentT = 0.0f;
+    if (c->segmentT > 1.0f)
+        c->segmentT = 1.0f;
+
+    swrSpline_Interpolate(c->spline, 0x0b, c->segmentT, c->nodeLookahead, out);
+    c->tangentLength = rdVector_Len3((rdVector3*)(out + 3));
+}
+
+// Evaluate the cursor's current point into a position + orientation matrix, building the
+// basis from the path tangent (forward) and the interpolated up vector.
+// 0x0044ed80
+void swrSpline_EvaluateToMatrix(void* cursor, rdMatrix44* out)
+{
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    rdVector3 right;
+    rdVector3 upAxis;
+    rdVector3 oldTranslation;
+    rdVector3 sample[4]; // position, tangent, normal (unused here), up
+
+    swrSpline_CursorEvaluate(c, &sample[0].x);
+    float tangentLen = rdVector_Len3(&sample[1]);
+    if (tangentLen < (float)0.0001) {
+        // tangent collapses at a segment endpoint; sample just inside the segment instead
+        float t = (0.5f <= c->segmentT) ? 0.999f : 0.001f;
+        swrSpline_Interpolate(c->spline, 0x02, t, c->nodeLookahead, &sample[0].x);
+    }
+    rdVector_Cross3(&right, &sample[1], &sample[3]);
+    rdVector_Cross3(&upAxis, &right, &sample[1]);
+    rdVector_Normalize3Acc(&right);
+    rdVector_Normalize3Acc(&upAxis);
+    rdVector_Normalize3Acc(&sample[1]);
+    out->vA.w = 0.0f;
+    out->vB.w = 0.0f;
+    out->vC.w = 0.0f;
+    out->vD.w = 1.0f;
+    rdMatrix_SetColumn(out, 0, &right);
+    rdMatrix_SetColumn(out, 1, &sample[1]);
+    rdMatrix_SetColumn(out, 2, &upAxis);
+    rdMatrix_GetColumn(out, 3, &oldTranslation); // original reads the old translation (unused)
+    rdMatrix_SetColumn(out, 3, &sample[0]);
+}
+
+// 0x0044eeb0
+void swrSpline_EvaluateAtOffset(void* cursor, rdMatrix44* out, float t)
+{
+    swrSplineCursor tmp = *(swrSplineCursor*)cursor;
+    tmp.segmentT += t;
+    tmp.velocity = 0.0f;
+    swrSpline_EvaluateToMatrix(&tmp, out);
+}
+
+// 0x0044eef0
+void swrSpline_CursorSeek(void* cursor, int nodeIndex)
+{
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    swrSpline* s = c->spline;
+    swrSplineControlPoint* cp = s->control_points;
+
+    c->nodeLookahead[0] = nodeIndex;
+    c->nodeLookahead[1] = nodeIndex;
+    c->nodeLookahead[2] = nodeIndex;
+    c->nodeLookahead[3] = nodeIndex;
+    if (cp[nodeIndex].next_count != 0) {
+        int n1 = cp[nodeIndex].next1;
+        c->nodeLookahead[1] = n1;
+        if (s->type == 0 && cp[n1].next_count != 0) {
+            int n2 = cp[n1].next1;
+            c->nodeLookahead[2] = n2;
+            if (cp[n2].next_count != 0)
+                c->nodeLookahead[3] = cp[n2].next1;
+        }
+    }
+}
+
 // Active track's total spline length, cached by swrSpline_TraceProgress during bake.
 // 0x0047e870
 float swrSpline_GetTrackLength(void)
@@ -85,10 +351,177 @@ float swrSpline_GetTrackLength(void)
     return swrSpline_trackLength;
 }
 
-// 0x0044eeb0
-void swrSpline_EvaluateAtOffset(void* cursor, rdMatrix44* out, float t)
+// 0x0047e880
+void* swrSpline_CursorInit(void* cursor, swrSpline* spline)
 {
-    HANG("TODO");
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    c->spline = spline;
+    c->velocity = 0.0f;
+    c->tangentLength = 0.0f;
+    c->segmentT = 0.0f;
+    c->endFlag = 0;
+    c->startFlag = 0;
+    c->branchSelector = 0;
+    c->branchFlags = 0;
+    swrSpline_CursorSeek(c, 0);
+    return c;
+}
+
+// Seed the cursor to a track-progress value (progress / 10 selects the band/node, the
+// remainder becomes the segment parameter) and fill its node lookahead chain.
+// 0x0047e8b0
+void swrSpline_CursorSeekToProgress(void* cursor, int progress)
+{
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    swrSpline* s = c->spline;
+    swrSplineControlPoint* cp = s->control_points;
+    int band = progress / 10;
+
+    if (band < (int)s->num_control_points) {
+        c->nodeLookahead[0] = band;
+        int n1 = cp[band].next1;
+        c->nodeLookahead[1] = n1;
+        if (s->type != 1) {
+            int n2 = cp[n1].next1;
+            c->nodeLookahead[2] = n2;
+            c->nodeLookahead[3] = cp[n2].next1;
+        }
+        c->branchFlags = 0;
+        c->segmentT = ((float)progress - (float)band * 10.0f) * 0.1f;
+        return;
+    }
+
+    for (int node = 0; node < (int)s->num_control_points; node++) {
+        for (int slot = 0; slot < 8; slot++) {
+            if ((short)cp[node].unk_set[slot] != band)
+                continue;
+            c->nodeLookahead[0] = node;
+            c->branchFlags = slot;
+            c->segmentT = ((float)progress - (float)band * 10.0f) * 0.1f;
+            int n1 = (&cp[node].next1)[slot & 1];
+            c->nodeLookahead[1] = n1;
+            if (s->type != 1) {
+                int n2 = (&cp[n1].next1)[(slot >> 1) & 1];
+                c->nodeLookahead[2] = n2;
+                c->nodeLookahead[3] = (&cp[n2].next1)[(slot >> 2) & 1];
+            }
+            return;
+        }
+    }
+}
+
+// March the cursor along the spline until the point projects onto the segment between the
+// current sample and the next (advance while the point is ahead of the tangent plane,
+// then back off by fine steps), mapping a world position to a spline parameter.
+// 0x0047eb60
+void swrSpline_ProjectPoint(void* cursor, rdVector3* point)
+{
+    swrSplineCursor* c = (swrSplineCursor*)cursor;
+    rdMatrix44 m;
+    int moved = 0;
+
+    swrSpline_EvaluateToMatrix(c, &m);
+    int done;
+    do {
+        done = 1;
+        // advance while the sample point is behind the target along the path tangent (vB)
+        if (m.vD.z * m.vB.z + m.vD.y * m.vB.y + m.vD.x * m.vB.x < m.vB.x * point->x + m.vB.y * point->y + m.vB.z * point->z) {
+            float prevT = c->segmentT;
+            c->segmentT += 0.01f;
+            swrSpline_EvaluateToMatrix(c, &m);
+            done = (prevT == c->segmentT); // clamped at the path end -> stop
+            moved = 1;
+        }
+    } while (!done);
+
+    if (!moved) {
+        // target is behind the start sample: retreat by fine steps instead
+        c->segmentT -= 0.01f;
+        swrSpline_EvaluateToMatrix(c, &m);
+        do {
+            done = 1;
+            if (m.vB.x * point->x + m.vB.y * point->y + m.vB.z * point->z < m.vD.z * m.vB.z + m.vD.y * m.vB.y + m.vD.x * m.vB.x) {
+                float prevT = c->segmentT;
+                c->segmentT -= 0.01f;
+                swrSpline_EvaluateToMatrix(c, &m);
+                if (prevT != c->segmentT)
+                    done = 0;
+            }
+        } while (!done);
+        c->segmentT += 0.01f;
+        swrSpline_EvaluateToMatrix(c, &m);
+    }
+}
+
+// Walk every forward path through the spline graph (node -> next branches, up to 3 levels
+// deep for multi-segment types), subdividing each into fixed 1/step increments and invoking
+// callback(cursor, step, arg3, arg4) at each sample.
+// 0x0047ee20
+void swrSpline_ForEachSample(swrSpline* spline, float step, void* arg3, void* arg4, void* callback)
+{
+    void (*cb)(void*, float, void*, void*) = (void (*)(void*, float, void*, void*))callback;
+    swrSplineControlPoint* cp = spline->control_points;
+    float inc = 1.0f / step;
+    swrSplineCursor cursor;
+    swrSplineCursor* c = (swrSplineCursor*)swrSpline_CursorInit(&cursor, spline);
+
+    for (int node = 0; node < (int)spline->num_control_points; node++) {
+        swr_noop4();
+        c->nodeLookahead[0] = node;
+        c->branchFlags = 0;
+        for (int i = 0; i < (short)cp[node].next_count; i++) {
+            c->branchFlags = (c->branchFlags & ~1u) | (i != 0 ? 1u : 0u);
+            int n1 = (short)(&cp[c->nodeLookahead[0]].next1)[i];
+            c->nodeLookahead[1] = n1;
+            if (spline->type == 1) {
+                c->segmentT = 0.0f;
+                do {
+                    cb(c, step, arg3, arg4);
+                    c->segmentT += inc;
+                } while (c->segmentT < 1.0f);
+            } else if ((short)cp[n1].next_count > 0) {
+                for (int j = 0; j < (short)cp[c->nodeLookahead[1]].next_count; j++) {
+                    c->branchFlags = (c->branchFlags & ~2u) | (j != 0 ? 2u : 0u);
+                    int n2 = (short)(&cp[c->nodeLookahead[1]].next1)[j];
+                    c->nodeLookahead[2] = n2;
+                    if (n2 != c->nodeLookahead[0] && (short)cp[n2].next_count > 0) {
+                        for (int k = 0; k < (short)cp[c->nodeLookahead[2]].next_count; k++) {
+                            c->branchFlags = (c->branchFlags & ~4u) | (k != 0 ? 4u : 0u);
+                            int n3 = (short)(&cp[c->nodeLookahead[2]].next1)[k];
+                            c->nodeLookahead[3] = n3;
+                            if (n3 != c->nodeLookahead[1]) {
+                                c->segmentT = 0.0f;
+                                do {
+                                    cb(c, step, arg3, arg4);
+                                    c->segmentT += inc;
+                                } while (c->segmentT < 1.0f);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// spline_progress_values packs two per-node regions in one array: the [node] entry
+// (.x = arc-length progress, .y = segment delta) and a 10-float scratch block at
+// +0xfc (stride 5 rdVector2 per node). Clear both for one node.
+// 0x0047f6c0
+void swrSpline_ResetNodeProgress(int nodeIndex)
+{
+    float* state = &spline_progress_values[nodeIndex * 5 + 0xfc].x;
+    for (int i = 0; i < 10; i++)
+        state[i] = 0.0f;
+    spline_progress_values[nodeIndex].x = 0.0f;
+    spline_progress_values[nodeIndex].y = 0.0f;
+}
+
+// Returns the .rdata sample-spacing constant at 0x004adf40 (0.0f in retail).
+// 0x0047f800
+float swrSpline_GetSampleSpacing_Maybe(void)
+{
+    return 0.0f;
 }
 
 // 0x00480170

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -106,8 +106,8 @@ int swrSpline_getControlPoint(void* cursor, int level)
 }
 
 // Cubic interpolation kernel. Builds the {t^3, t^2, t, 1} basis, multiplies it by the
-// spline-type basis matrix, and writes the requested components (mask bit 1 = position,
-// 2 = tangent, 4 = normal, 8 = up) into out[0..11] (3 floats each).
+// spline-type basis matrix, and writes the components selected by mask
+// (swrSpline_INTERP_FLAGS) into out[0..11] (3 floats each).
 // 0x0044e660
 void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeIndices, float* out)
 {
@@ -125,7 +125,7 @@ void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeI
     float* p1;
     float* p2;
     float* p3;
-    if (s->type == 0) {
+    if (s->type == SPLINE_TYPE_BSPLINE) {
         rdMatrix_Multiply4(&basis, &tvec, &rdMatrix_unk5);
         p0 = &cp[nodeIndices[0]].position.x;
         p1 = &cp[nodeIndices[1]].position.x;
@@ -139,13 +139,13 @@ void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeI
         p3 = &cp[nodeIndices[1]].position.x;
     }
 
-    if (mask & 1) {
+    if (mask & SPLINE_INTERP_POSITION) {
         out[0] = p0[0] * basis.x + p2[0] * basis.z + p1[0] * basis.y + p3[0] * basis.w;
         out[1] = p1[1] * basis.y + p2[1] * basis.z + p0[1] * basis.x + p3[1] * basis.w;
         out[2] = p1[2] * basis.y + p2[2] * basis.z + p0[2] * basis.x + p3[2] * basis.w;
     }
-    if (mask & 8) {
-        if (s->type == 1) {
+    if (mask & SPLINE_INTERP_UP) {
+        if (s->type == SPLINE_TYPE_BEZIER_FLAT) {
             out[11] = 1.0f;
             out[9] = 0.0f;
             out[10] = 0.0f;
@@ -159,14 +159,14 @@ void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeI
             out[11] = r3[2] * basis.w + r1[2] * basis.y + r2[2] * basis.z + r0[2] * basis.x;
         }
     }
-    if (mask & 2) {
-        rdMatrix_Multiply4(&basis, &tvec, s->type == 0 ? &rdMatrix_unk3 : &rdMatrix_unk4);
+    if (mask & SPLINE_INTERP_TANGENT) {
+        rdMatrix_Multiply4(&basis, &tvec, s->type == SPLINE_TYPE_BSPLINE ? &rdMatrix_unk3 : &rdMatrix_unk4);
         out[3] = p0[0] * basis.x + p2[0] * basis.z + p1[0] * basis.y + p3[0] * basis.w;
         out[4] = p1[1] * basis.y + p2[1] * basis.z + p0[1] * basis.x + p3[1] * basis.w;
         out[5] = p1[2] * basis.y + p2[2] * basis.z + p0[2] * basis.x + p3[2] * basis.w;
     }
-    if (mask & 4) {
-        rdMatrix_Multiply4(&basis, &tvec, s->type == 0 ? &rdMatrix_unk1 : &rdMatrix_unk2);
+    if (mask & SPLINE_INTERP_NORMAL) {
+        rdMatrix_Multiply4(&basis, &tvec, s->type == SPLINE_TYPE_BSPLINE ? &rdMatrix_unk1 : &rdMatrix_unk2);
         out[6] = p0[0] * basis.x + p2[0] * basis.z + p1[0] * basis.y + p3[0] * basis.w;
         out[7] = p1[1] * basis.y + p2[1] * basis.z + p0[1] * basis.x + p3[1] * basis.w;
         out[8] = p1[2] * basis.y + p2[2] * basis.z + p0[2] * basis.x + p3[2] * basis.w;
@@ -186,7 +186,7 @@ void swrSpline_CursorStep(void* spline, int direction, void* cursor)
     if ((short)direction == 1) {
         c->startFlag = 0;
         if (c->endFlag == 0) {
-            int lead = (s->type == 0) ? c->nodeLookahead[3] : c->nodeLookahead[1];
+            int lead = (s->type == SPLINE_TYPE_BSPLINE) ? c->nodeLookahead[3] : c->nodeLookahead[1];
             int nextCount = (short)cp[lead].next_count;
             if (nextCount == 0) {
                 direction = -1;
@@ -196,12 +196,12 @@ void swrSpline_CursorStep(void* spline, int direction, void* cursor)
                 int branch = (c->branchSelector < nextCount) ? c->branchSelector : (c->branchSelector % nextCount);
                 direction = (short)(&cp[lead].next1)[branch];
                 int hist = c->branchFlags >> 1;
-                c->branchFlags = (s->type == 0) ? (hist | (branch << 2)) : (hist | branch);
+                c->branchFlags = (s->type == SPLINE_TYPE_BSPLINE) ? (hist | (branch << 2)) : (hist | branch);
             }
         }
         if (c->endFlag == 0) {
             c->nodeLookahead[0] = c->nodeLookahead[1];
-            if (s->type != 0) {
+            if (s->type != SPLINE_TYPE_BSPLINE) {
                 c->nodeLookahead[1] = direction;
                 return;
             }
@@ -221,13 +221,13 @@ void swrSpline_CursorStep(void* spline, int direction, void* cursor)
             } else {
                 int branch = c->branchSelector;
                 direction = (short)(&cp[tail].prev1)[(branch < prevCount) ? branch : (branch % prevCount)];
-                c->branchFlags = (s->type == 0) ? ((c->branchFlags & 3) << 1) : 0;
+                c->branchFlags = (s->type == SPLINE_TYPE_BSPLINE) ? ((c->branchFlags & 3) << 1) : 0;
                 if (tail != (short)cp[direction].next1)
                     c->branchFlags |= 1;
             }
         }
         if (c->startFlag == 0) {
-            if (s->type == 0) {
+            if (s->type == SPLINE_TYPE_BSPLINE) {
                 c->nodeLookahead[3] = c->nodeLookahead[2];
                 c->nodeLookahead[2] = c->nodeLookahead[1];
             }
@@ -274,7 +274,7 @@ void swrSpline_CursorEvaluate(void* cursor, float* out)
     if (c->segmentT > 1.0f)
         c->segmentT = 1.0f;
 
-    swrSpline_Interpolate(c->spline, 0x0b, c->segmentT, c->nodeLookahead, out);
+    swrSpline_Interpolate(c->spline, SPLINE_INTERP_POSITION | SPLINE_INTERP_TANGENT | SPLINE_INTERP_UP, c->segmentT, c->nodeLookahead, out);
     c->tangentLength = rdVector_Len3((rdVector3*)(out + 3));
 }
 
@@ -294,7 +294,7 @@ void swrSpline_EvaluateToMatrix(void* cursor, rdMatrix44* out)
     if (tangentLen < (float)0.0001) {
         // tangent collapses at a segment endpoint; sample just inside the segment instead
         float t = (0.5f <= c->segmentT) ? 0.999f : 0.001f;
-        swrSpline_Interpolate(c->spline, 0x02, t, c->nodeLookahead, &sample[0].x);
+        swrSpline_Interpolate(c->spline, SPLINE_INTERP_TANGENT, t, c->nodeLookahead, &sample[0].x);
     }
     rdVector_Cross3(&right, &sample[1], &sample[3]);
     rdVector_Cross3(&upAxis, &right, &sample[1]);
@@ -335,7 +335,7 @@ void swrSpline_CursorSeek(void* cursor, int nodeIndex)
     if (cp[nodeIndex].next_count != 0) {
         int n1 = cp[nodeIndex].next1;
         c->nodeLookahead[1] = n1;
-        if (s->type == 0 && cp[n1].next_count != 0) {
+        if (s->type == SPLINE_TYPE_BSPLINE && cp[n1].next_count != 0) {
             int n2 = cp[n1].next1;
             c->nodeLookahead[2] = n2;
             if (cp[n2].next_count != 0)
@@ -381,7 +381,7 @@ void swrSpline_CursorSeekToProgress(void* cursor, int progress)
         c->nodeLookahead[0] = band;
         int n1 = cp[band].next1;
         c->nodeLookahead[1] = n1;
-        if (s->type != 1) {
+        if (s->type != SPLINE_TYPE_BEZIER_FLAT) {
             int n2 = cp[n1].next1;
             c->nodeLookahead[2] = n2;
             c->nodeLookahead[3] = cp[n2].next1;
@@ -400,7 +400,7 @@ void swrSpline_CursorSeekToProgress(void* cursor, int progress)
             c->segmentT = ((float)progress - (float)band * 10.0f) * 0.1f;
             int n1 = (&cp[node].next1)[slot & 1];
             c->nodeLookahead[1] = n1;
-            if (s->type != 1) {
+            if (s->type != SPLINE_TYPE_BEZIER_FLAT) {
                 int n2 = (&cp[n1].next1)[(slot >> 1) & 1];
                 c->nodeLookahead[2] = n2;
                 c->nodeLookahead[3] = (&cp[n2].next1)[(slot >> 2) & 1];
@@ -473,7 +473,7 @@ void swrSpline_ForEachSample(swrSpline* spline, float step, void* arg3, void* ar
             c->branchFlags = (c->branchFlags & ~1u) | (i != 0 ? 1u : 0u);
             int n1 = (short)(&cp[c->nodeLookahead[0]].next1)[i];
             c->nodeLookahead[1] = n1;
-            if (spline->type == 1) {
+            if (spline->type == SPLINE_TYPE_BEZIER_FLAT) {
                 c->segmentT = 0.0f;
                 do {
                     cb(c, step, arg3, arg4);

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -26,12 +26,14 @@
 // arc-length progress and tessellates each segment).
 #define swrSpline_GetTrackLength_ADDR (0x0047e870)
 #define swrSpline_CursorInit_ADDR (0x0047e880)
+#define swrSpline_CursorSeekToProgress_ADDR (0x0047e8b0)
 #define swrSpline_ProjectPoint_ADDR (0x0047eb60)
 #define swrSpline_ForEachSample_ADDR (0x0047ee20)
 #define swrSpline_TraceProgress_ADDR (0x0047f060)
 #define swrSpline_BuildProgressTable_ADDR (0x0047f470)
 #define swrSpline_ResetNodeProgress_ADDR (0x0047f6c0)
 #define swrSpline_Build_ADDR (0x0047f6f0)
+#define swrSpline_GetSampleSpacing_Maybe_ADDR (0x0047f800)
 #define swrSpline_CollectNearbyPoints_ADDR (0x00480170)
 
 void swrSpline_LoadSpline(int index, unsigned short** b);
@@ -76,6 +78,10 @@ float swrSpline_GetTrackLength(void);
 // the cursor.
 void* swrSpline_CursorInit(void* cursor, swrSpline* spline);
 
+// Seed the cursor to a track-progress value: progress / 10 selects the band/node and
+// the remainder becomes the segment parameter, then fill the node lookahead chain.
+void swrSpline_CursorSeekToProgress(void* cursor, int progress);
+
 // Advance the cursor to the point on the spline nearest the given world point
 // (used to map a world position back to a spline parameter / progress).
 void swrSpline_ProjectPoint(void* cursor, rdVector3* point);
@@ -97,6 +103,9 @@ void swrSpline_ResetNodeProgress(int nodeIndex);
 // Top level post-load processing (called by LoadTrackSpline): resets junction
 // nodes, builds the progress table, then tessellates.
 void swrSpline_Build(swrSpline* spline, int unk);
+
+// Returns the .rdata sample-spacing constant (0.0f in retail).
+float swrSpline_GetSampleSpacing_Maybe(void);
 
 // Returns the integrated track/spline length (swrSpline_trackLength, set by swrSpline_TraceProgress).
 float swrSpline_GetTrackLength(void);

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -52,7 +52,7 @@ int swrSpline_getControlPoint(void* cursor, int level);
 
 // Core cubic interpolation kernel. Builds the {t^3, t^2, t, 1} basis, applies
 // the spline-type basis matrices, and writes the components selected by mask
-// (bit 1 = position, bit 2 = tangent, bit 4 = normal, bit 8 = up) into out.
+// (swrSpline_INTERP_FLAGS) into out.
 void swrSpline_Interpolate(void* spline, unsigned char mask, float t, int* nodeIndices, float* out);
 
 // Step the cursor to the next (direction 1) or previous (direction 2) control

--- a/src/types.h
+++ b/src/types.h
@@ -3166,7 +3166,8 @@ extern "C"
 
     typedef struct swrSpline
     {
-        uint16_t unk0;
+        uint16_t type; // 0 = uniform cubic B-spline (4-node window); 1 = Bezier without
+                       // per-node normal; other = Bezier (handle1/handle2 + rotation normal)
         uint16_t unk1;
         uint32_t num_control_points;
         uint32_t num_segments;

--- a/src/types.h
+++ b/src/types.h
@@ -3166,8 +3166,7 @@ extern "C"
 
     typedef struct swrSpline
     {
-        uint16_t type; // 0 = uniform cubic B-spline (4-node window); 1 = Bezier without
-                       // per-node normal; other = Bezier (handle1/handle2 + rotation normal)
+        uint16_t type; // swrSpline_TYPE (kept 16-bit to match the on-disk header)
         uint16_t unk1;
         uint32_t num_control_points;
         uint32_t num_segments;

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -118,6 +118,25 @@ typedef enum swrLoader_TYPE
     swrLoader_TYPE_TEXTURE_BLOCK = 3
 } swrLoader_TYPE;
 
+// swrSpline curve-type selector (swrSpline.type, 16-bit on disk). Picks the basis
+// matrices and control-point layout used by swrSpline_Interpolate.
+typedef enum swrSpline_TYPE
+{
+    SPLINE_TYPE_BSPLINE = 0, // uniform cubic B-spline over a 4-node window
+    SPLINE_TYPE_BEZIER_FLAT = 1, // Bezier (handle1/handle2), no per-node normal (flat +Z up)
+    SPLINE_TYPE_BEZIER = 2, // Bezier with interpolated rotation normal; any value > 1 takes this path
+} swrSpline_TYPE;
+
+// Component selector mask for swrSpline_Interpolate: which sample fields to write
+// into the 12-float output (3 floats each).
+typedef enum swrSpline_INTERP_FLAGS
+{
+    SPLINE_INTERP_POSITION = 0x1, // out[0..2]
+    SPLINE_INTERP_TANGENT = 0x2, // out[3..5]
+    SPLINE_INTERP_NORMAL = 0x4, // out[6..8]
+    SPLINE_INTERP_UP = 0x8, // out[9..11]
+} swrSpline_INTERP_FLAGS;
+
 typedef enum swrModel_NodeType
 {
     NODE_MESH_GROUP = 0x3064,


### PR DESCRIPTION
Reimplements the spline cursor/evaluation runtime from named-only into faithful C bodies (all reverse-hooked, compile + disasm-faithful, structs already typed in types.h):

- `getControlPointIdFromProgress`, `getControlPoint`
- `Interpolate` (cubic basis kernel: pos/tangent/normal/up, B-spline & Bezier)
- `CursorStep` / `CursorEvaluate` / `CursorSeek` / `CursorInit` / `CursorSeekToProgress`
- `EvaluateToMatrix` / `EvaluateAtOffset`
- `ProjectPoint` (map a world point to a spline parameter)
- `ForEachSample` (graph walk + per-sample callback)
- `ResetNodeProgress`, `GetSampleSpacing_Maybe`

Also names the `swrSpline` curve-type selector (`type`, was `unk0`) since the new bodies branch on it, and adds `_ADDR` + prototypes for `CursorSeekToProgress` (0x47e8b0) and `GetSampleSpacing_Maybe` (0x47f800).

Built + linked clean. Left the heavier post-load baking (`Build`/`BuildProgressTable`/`TraceProgress`/`CollectNearbyPoints`) for a follow-up - they pull in a couple of unnamed globals + the uncarved sample callbacks.