### PR TITLE
feat(modding): reversible memory-patch journal (WriteMemory/UndoOwner)

### DIFF
--- a/dinput_hook/hook_helper.cpp
+++ b/dinput_hook/hook_helper.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "hook_helper.h"
+#include "patch.h"
 #include <iterator>
 #include <vector>
 #include <filesystem>
@@ -34,10 +35,8 @@ extern "C" void patchMemoryAccess(uint32_t address, void *newAddress) {
     assert(address >= SWR_TEXT_ADDR_);
     assert(address < SWR_TEXT_END_ADDR_);
 
-    DWORD oldProtect;
-    VirtualProtect((LPVOID) address, sizeof(void *), PAGE_EXECUTE_READWRITE, &oldProtect);
-    *((uint32_t *) address) = uint32_t(newAddress);
-    VirtualProtect((LPVOID) address, sizeof(void *), oldProtect, &oldProtect);
+    // Journaled (owner-tracked, revertible) form of the old raw VirtualProtect+poke.
+    PatchPointer("patchMemoryAccess", (void *) address, (uint32_t) newAddress);
 }
 
 extern "C" void init_hooks() {

--- a/dinput_hook/main.cpp
+++ b/dinput_hook/main.cpp
@@ -10,6 +10,7 @@
 #include "renderer_hook.h"
 #include "hook_helper.h"
 #include "custom_tracks.h"
+#include "patch.h"
 
 FILE *hook_log = nullptr;
 
@@ -161,21 +162,21 @@ extern "C" void set_ai_full_lod(bool on) {
     struct Patch {
         uint32_t addr;
         uint8_t len;
-        uint8_t original[6];// stock bytes (from Ghidra; the Steam EXE .text is encrypted on disk)
     };
+    // Stock bytes are no longer hard-coded: the journal captures the live originals before the
+    // first NOP, and UndoOwner restores them. (Stock, for reference: 75 0b / 0f 8f 30 03 00 00 /
+    // 0f 8f c3 01 00 00.)
     static const Patch patches[] = {
-        {0x0046654d, 2, {0x75, 0x0b}},                        // JNZ 0x0046655a
-        {0x004723ce, 6, {0x0f, 0x8f, 0x30, 0x03, 0x00, 0x00}},// JG 0x00472704
-        {0x00472577, 6, {0x0f, 0x8f, 0xc3, 0x01, 0x00, 0x00}},// JG 0x00472740
+        {0x0046654d, 2},// JNZ 0x0046655a
+        {0x004723ce, 6},// JG 0x00472704
+        {0x00472577, 6},// JG 0x00472740
     };
-    for (const Patch &p: patches) {
-        uint8_t bytes[6];
-        for (uint8_t i = 0; i < p.len; i++)
-            bytes[i] = on ? 0x90 /* NOP */ : p.original[i];
-        DWORD oldProtect;
-        VirtualProtect((LPVOID) p.addr, p.len, PAGE_EXECUTE_READWRITE, &oldProtect);
-        memcpy((LPVOID) p.addr, bytes, p.len);
-        VirtualProtect((LPVOID) p.addr, p.len, oldProtect, &oldProtect);
+    if (on) {
+        static const uint8_t nops[6] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+        for (const Patch &p: patches)
+            WriteMemory("ai_full_lod", (void *) p.addr, nops, p.len);
+    } else {
+        UndoOwner("ai_full_lod");
     }
 }
 
@@ -189,15 +190,13 @@ HICON __stdcall LoadIconHook(HINSTANCE hInstance, LPCSTR lpIconName) {
     init_customTracks();
 
     // nop Window_CreateMainWindow from 0x0049cede to 0x0049cfb8 included, will return peacefully
-    DWORD oldProtect;
-    uint32_t addr = 0x0049cede;
-    uint32_t size = 0x0049cfb9 - addr;
-    VirtualProtect((LPVOID) addr, size, PAGE_EXECUTE_READWRITE, &oldProtect);
-    memset((LPVOID) addr, 0x90 /* NOP */, size);
-    VirtualProtect((LPVOID) addr, size, oldProtect, &oldProtect);
+    const uint32_t nop_addr = 0x0049cede;
+    uint8_t nops[0x0049cfb9 - 0x0049cede];
+    memset(nops, 0x90 /* NOP */, sizeof(nops));
+    WriteMemory("boot_window_reroute", (void *) nop_addr, nops, sizeof(nops));
 
     // in Window_Main, call Window_Main again, that will be hooked to Window_Main_delta and early return
-    uint32_t call_address = 0x0049cd60;
+    const uint32_t call_address = 0x0049cd60;
     uint8_t call_code[] = {
         0x8b, 0x44, 0x24, 0x4c, 0x50,// MOV + Push window_name
         0x8b, 0x74, 0x24, 0x4c, 0x56,// MOV + Push nCmdShow
@@ -209,9 +208,7 @@ HICON __stdcall LoadIconHook(HINSTANCE hInstance, LPCSTR lpIconName) {
         // I do a ret here but the stack is completely busted at this point. Need to do some stack cleanup, about 0x40 ?
         0xc3,// RET
     };
-    VirtualProtect((LPVOID) call_address, sizeof(call_code), PAGE_EXECUTE_READWRITE, &oldProtect);
-    memcpy((LPVOID) call_address, call_code, sizeof(call_code));
-    VirtualProtect((LPVOID) call_address, sizeof(call_code), oldProtect, &oldProtect);
+    WriteMemory("boot_window_reroute", (void *) call_address, call_code, sizeof(call_code));
 
     return nullptr;
 }

--- a/dinput_hook/patch.cpp
+++ b/dinput_hook/patch.cpp
@@ -14,7 +14,7 @@ extern "C" FILE *hook_log;
 
 namespace {
     struct JournalEntry {
-        PatchOwner owner;             // matched by string value, not pointer
+        PatchOwner owner;             // compared by value via same_owner (pointer-equal fast path)
         uintptr_t addr;
         std::vector<uint8_t> original;// bytes snapshotted immediately before this write
     };

--- a/dinput_hook/patch.cpp
+++ b/dinput_hook/patch.cpp
@@ -1,0 +1,110 @@
+//
+// Reversible memory-patch journal (modding API, issue #153). See patch.h.
+//
+#include "patch.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include <windows.h>
+
+extern "C" FILE *hook_log;
+
+namespace {
+    struct JournalEntry {
+        PatchOwner owner;             // matched by string value, not pointer
+        uintptr_t addr;
+        std::vector<uint8_t> original;// pristine bytes captured before this range was first patched
+    };
+
+    std::vector<JournalEntry> g_journal;
+
+    bool same_owner(PatchOwner a, PatchOwner b) {
+        if (a == b)
+            return true;
+        return a && b && std::strcmp(a, b) == 0;
+    }
+
+    bool ranges_overlap(uintptr_t a, size_t alen, uintptr_t b, size_t blen) {
+        return a < b + blen && b < a + alen;
+    }
+
+    void raw_write(void *addr, const void *src, size_t len) {
+        DWORD oldProtect;
+        VirtualProtect(addr, len, PAGE_EXECUTE_READWRITE, &oldProtect);
+        memcpy(addr, src, len);
+        VirtualProtect(addr, len, oldProtect, &oldProtect);
+    }
+}
+
+bool WriteMemory(PatchOwner owner, void *addr, const void *src, size_t len) {
+    if (!addr || !src || len == 0)
+        return false;
+
+    const uintptr_t a = (uintptr_t) addr;
+    bool reapply = false;// same owner re-writing a range it already journaled (e.g. a re-toggle)
+
+    for (const JournalEntry &e: g_journal) {
+        if (!ranges_overlap(a, len, e.addr, e.original.size()))
+            continue;
+        if (!same_owner(owner, e.owner)) {
+            if (hook_log) {
+                fprintf(hook_log,
+                        "[patch] CONFLICT: '%s' [%p,+0x%zx) overlaps '%s' at %p - refused\n",
+                        owner ? owner : "(null)", addr, len, e.owner ? e.owner : "(null)",
+                        (void *) e.addr);
+                fflush(hook_log);
+            }
+            return false;
+        }
+        // Same owner: an exact range match is a clean re-apply (originals already captured). A
+        // partial self-overlap would corrupt original capture and does not occur in practice, so
+        // refuse it loudly rather than guess.
+        if (e.addr == a && e.original.size() == len) {
+            reapply = true;
+        } else {
+            if (hook_log) {
+                fprintf(hook_log, "[patch] '%s' partial self-overlap [%p,+0x%zx) vs %p - refused\n",
+                        owner ? owner : "(null)", addr, len, (void *) e.addr);
+                fflush(hook_log);
+            }
+            return false;
+        }
+    }
+
+    if (!reapply) {
+        JournalEntry e;
+        e.owner = owner;
+        e.addr = a;
+        e.original.assign((const uint8_t *) addr, (const uint8_t *) addr + len);// capture pristine
+        g_journal.push_back(e);
+        if (hook_log) {
+            fprintf(hook_log, "[patch] '%s' patched [%p,+0x%zx)\n", owner ? owner : "(null)", addr,
+                    len);
+            fflush(hook_log);
+        }
+    }
+
+    raw_write(addr, src, len);
+    return true;
+}
+
+bool PatchPointer(PatchOwner owner, void *addr, uint32_t value) {
+    return WriteMemory(owner, addr, &value, sizeof(value));
+}
+
+void UndoOwner(PatchOwner owner) {
+    // Restore newest-first so any re-applied / stacked ranges unwind in reverse order.
+    for (size_t i = g_journal.size(); i-- > 0;) {
+        const JournalEntry &e = g_journal[i];
+        if (same_owner(e.owner, owner))
+            raw_write((void *) e.addr, e.original.data(), e.original.size());
+    }
+    g_journal.erase(std::remove_if(g_journal.begin(), g_journal.end(),
+                                   [&](const JournalEntry &e) {
+                                       return same_owner(e.owner, owner);
+                                   }),
+                    g_journal.end());
+}

--- a/dinput_hook/patch.cpp
+++ b/dinput_hook/patch.cpp
@@ -16,7 +16,7 @@ namespace {
     struct JournalEntry {
         PatchOwner owner;             // matched by string value, not pointer
         uintptr_t addr;
-        std::vector<uint8_t> original;// pristine bytes captured before this range was first patched
+        std::vector<uint8_t> original;// bytes snapshotted immediately before this write
     };
 
     std::vector<JournalEntry> g_journal;
@@ -44,12 +44,11 @@ bool WriteMemory(PatchOwner owner, void *addr, const void *src, size_t len) {
         return false;
 
     const uintptr_t a = (uintptr_t) addr;
-    bool reapply = false;// same owner re-writing a range it already journaled (e.g. a re-toggle)
 
+    // Corruption guard: refuse to clobber a DIFFERENT owner's live patch. Same-owner overlaps are
+    // allowed - they just stack, and UndoOwner unwinds them newest-first back to the original.
     for (const JournalEntry &e: g_journal) {
-        if (!ranges_overlap(a, len, e.addr, e.original.size()))
-            continue;
-        if (!same_owner(owner, e.owner)) {
+        if (ranges_overlap(a, len, e.addr, e.original.size()) && !same_owner(owner, e.owner)) {
             if (hook_log) {
                 fprintf(hook_log,
                         "[patch] CONFLICT: '%s' [%p,+0x%zx) overlaps '%s' at %p - refused\n",
@@ -59,32 +58,18 @@ bool WriteMemory(PatchOwner owner, void *addr, const void *src, size_t len) {
             }
             return false;
         }
-        // Same owner: an exact range match is a clean re-apply (originals already captured). A
-        // partial self-overlap would corrupt original capture and does not occur in practice, so
-        // refuse it loudly rather than guess.
-        if (e.addr == a && e.original.size() == len) {
-            reapply = true;
-        } else {
-            if (hook_log) {
-                fprintf(hook_log, "[patch] '%s' partial self-overlap [%p,+0x%zx) vs %p - refused\n",
-                        owner ? owner : "(null)", addr, len, (void *) e.addr);
-                fflush(hook_log);
-            }
-            return false;
-        }
     }
 
-    if (!reapply) {
-        JournalEntry e;
-        e.owner = owner;
-        e.addr = a;
-        e.original.assign((const uint8_t *) addr, (const uint8_t *) addr + len);// capture pristine
-        g_journal.push_back(e);
-        if (hook_log) {
-            fprintf(hook_log, "[patch] '%s' patched [%p,+0x%zx)\n", owner ? owner : "(null)", addr,
-                    len);
-            fflush(hook_log);
-        }
+    // Snapshot the bytes currently at the range, then patch. UndoOwner replays an owner's snapshots
+    // newest-first, so apply + undo is a clean inverse - even across repeated/overlapping writes.
+    JournalEntry e;
+    e.owner = owner;
+    e.addr = a;
+    e.original.assign((const uint8_t *) addr, (const uint8_t *) addr + len);
+    g_journal.push_back(e);
+    if (hook_log) {
+        fprintf(hook_log, "[patch] '%s' patched [%p,+0x%zx)\n", owner ? owner : "(null)", addr, len);
+        fflush(hook_log);
     }
 
     raw_write(addr, src, len);
@@ -96,7 +81,8 @@ bool PatchPointer(PatchOwner owner, void *addr, uint32_t value) {
 }
 
 void UndoOwner(PatchOwner owner) {
-    // Restore newest-first so any re-applied / stacked ranges unwind in reverse order.
+    // Restore newest-first so stacked/overlapping ranges unwind in reverse order, then drop the
+    // entries - apply + undo leaves no trace in the journal.
     for (size_t i = g_journal.size(); i-- > 0;) {
         const JournalEntry &e = g_journal[i];
         if (same_owner(e.owner, owner))

--- a/dinput_hook/patch.h
+++ b/dinput_hook/patch.h
@@ -2,11 +2,13 @@
 // Reversible memory-patch journal for the mod/delta layer (modding API, issue #153).
 //
 // Every sanctioned .text/.data mutation routes through here so it can be reverted by owner. Each
-// write captures the TRUE original bytes the first time a byte range is touched; UndoOwner()
-// replays an owner's captures to restore stock. Two DIFFERENT owners may not patch overlapping
-// bytes - the second write is refused and logged. That refusal is the corruption guard: "two mods
-// stepping on the same memory" becomes a loud no-op instead of silent breakage. (Refcounted
-// layering of intentional overlaps is a later phase; for now: one owner per byte.)
+// write snapshots the bytes currently at the range before overwriting; UndoOwner() replays an
+// owner's snapshots newest-first, so apply + undo is a clean inverse that restores stock and leaves
+// the journal empty (even across repeated or overlapping same-owner writes). Two DIFFERENT owners
+// may not patch overlapping bytes - the second write is refused and logged. That refusal is the
+// corruption guard: "two mods stepping on the same memory" becomes a loud no-op instead of silent
+// breakage. (Refcounted layering of intentional overlaps is a later phase; for now: one owner per
+// byte.)
 //
 // `owner` is a short stable string ("ai_full_lod", "boot_window_reroute", ...). It is deliberately
 // lightweight - the full mod registry (ModId/ModModule) is a later step, and this is only the key
@@ -19,7 +21,7 @@
 
 typedef const char *PatchOwner;
 
-// Overwrite [addr, addr+len) with `src`, first capturing the pristine originals for that range.
+// Overwrite [addr, addr+len) with `src`, first snapshotting the bytes currently at that range.
 // Flips page protection to RWX for the copy and restores it after. Returns false and writes
 // NOTHING if the range overlaps a different owner's live patch (the conflict is logged).
 bool WriteMemory(PatchOwner owner, void *addr, const void *src, size_t len);

--- a/dinput_hook/patch.h
+++ b/dinput_hook/patch.h
@@ -1,0 +1,33 @@
+//
+// Reversible memory-patch journal for the mod/delta layer (modding API, issue #153).
+//
+// Every sanctioned .text/.data mutation routes through here so it can be reverted by owner. Each
+// write captures the TRUE original bytes the first time a byte range is touched; UndoOwner()
+// replays an owner's captures to restore stock. Two DIFFERENT owners may not patch overlapping
+// bytes - the second write is refused and logged. That refusal is the corruption guard: "two mods
+// stepping on the same memory" becomes a loud no-op instead of silent breakage. (Refcounted
+// layering of intentional overlaps is a later phase; for now: one owner per byte.)
+//
+// `owner` is a short stable string ("ai_full_lod", "boot_window_reroute", ...). It is deliberately
+// lightweight - the full mod registry (ModId/ModModule) is a later step, and this is only the key
+// UndoOwner() reverts by.
+//
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+typedef const char *PatchOwner;
+
+// Overwrite [addr, addr+len) with `src`, first capturing the pristine originals for that range.
+// Flips page protection to RWX for the copy and restores it after. Returns false and writes
+// NOTHING if the range overlaps a different owner's live patch (the conflict is logged).
+bool WriteMemory(PatchOwner owner, void *addr, const void *src, size_t len);
+
+// Owner-tracked single-dword patch (the journaled form of patchMemoryAccess): writes `value` as
+// 4 bytes at `addr` (an IAT / vtable / relative-call slot). Same journaling + overlap rules.
+bool PatchPointer(PatchOwner owner, void *addr, uint32_t value);
+
+// Revert every journal entry owned by `owner` (newest first), restoring captured originals, then
+// drop those entries. No-op if the owner holds nothing journaled.
+void UndoOwner(PatchOwner owner);


### PR DESCRIPTION
First step toward the modding API (#153): a reversible, owner-tagged memory-patch journal so mods can mutate game memory without silently corrupting each other or leaking patches on disable.

**`dinput_hook/patch.{h,cpp}`:**
- `WriteMemory(owner, addr, src, len)` - captures the true original bytes once, then patches. Refuses (and logs) a write that overlaps a *different* owner's live patch - that's the corruption guard.
- `PatchPointer(owner, addr, value)` - journaled dword poke (the revertible form of the old `patchMemoryAccess`).
- `UndoOwner(owner)` - restores an owner's captures newest-first.

**Routed the existing raw `.text` patches through it - no behavior change:**
- `set_ai_full_lod` -> `WriteMemory`/`UndoOwner` (drops the hard-coded stock bytes; the journal captures live originals).
- `patchMemoryAccess` -> `PatchPointer` (no callers today; future-proofed).
- the `Window_Main` boot reroute -> two `WriteMemory` calls.

Playtested: normal boot + toggling `ai_full_lod` on/off/on mid-session both behave exactly as before.

Naming (`WriteMemory`/`PatchPointer`/`UndoOwner`) follows the #153 discussion - happy to namespace/prefix if you'd prefer. The other raw-patch features (100-lap de-index, race-time cap, swrModel texture buffer) can migrate onto this in a follow-up; they already hand-roll the verify-and-skip logic this centralizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)