### PR TITLE
swrViewport: reimplement 6 viewport setup + camera functions

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -336,6 +336,9 @@ ai_spread 0x004c7080 float
 
 Main_sound_3dimpact 0x004c7aa8 int = -1
 
+swrViewport_active 0x004c7cdc swrViewport* # the viewport currently being rendered (set by swrViewport_Activate)
+swrViewport_defaultScaledRect 0x004c7ce0 int[4] # default scaled-viewport rect copied into a viewport's [0x10..0x1f] block by swrViewport_Init
+
 Main_sound_gain_const 0x004c7d70 float = 0.8
 Main_sound_doppler_scale 0x004c7d74 float = 1.0
 Main_sound_rolloff 0x004c7d78 float = 0.15
@@ -536,6 +539,7 @@ swrSprite_unk2_a 0x0050b70b char
 
 currentUnkCameraStructPtr 0x0050C034 swrUnkCameraStruct*
 unkCameraArrayIndex 0x0050C038 int
+swrViewport_cameraApplied 0x0050c03c int # 0 when the active camera was just (re)selected, set to 1 by swrViewport_UpdateCameras once its transform is applied
 swrViewport_force320x240 0x0050c058 int # when nonzero, swrViewport_SetViewport forces a 320x240 viewport
 
 swrRace_DebugLevel 0x0050c040 int
@@ -1448,6 +1452,7 @@ swrWeather_particlePositions 0x00e99860 rdVector3[80]
 swrWeather_particleScreenPositions 0x00e9a000 rdVector2[80]
 swrWeather_particleSpriteIds 0x00e9a280 int[80]
 swrWeather_particleStates 0x00e9a960 char[80]
+swrViewport_force320x240Quadrant 0x00e9a9b0 int # quadrant index (0-3) cycled by swrRace_UpdateInRaceMenu while force320x240 is active; bit0 hides the right half, bit1 hides the bottom half in swrViewport_ComputeScreenRect
 
 # Galaxy-map planet data (8 planets). Populated by swrObjHang_Init, consumed by DrawHoloPlanet.
 # Sun/moon sprite pool (@0x00e293c4) + sun/moon and preview-model node arrays are identified but

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -86,7 +86,6 @@
 #define swrModel_NodeModifyFlags_ADDR (0x00431A50)
 #define swrModel_NodeGetFlags1Or2_ADDR (0x00431B00)
 #define swrModel_NodeInit_ADDR (0x00431B20)
-#define swrViewport_SetRootNode_Maybe_ADDR (0x00431b90)
 #define swrViewport_ResetCameraState_Maybe_ADDR (0x00431ba0)
 
 // Sphere / ray vs mesh collision (the swept-collision pipeline).
@@ -298,9 +297,6 @@ swrModel_Behavior* swrModel_MeshGetBehavior(swrModel_Mesh* mesh);
 void swrModel_NodeModifyFlags(swrModel_Node* node, int flag_id, int value, char modify_children, int modify_op);
 uint32_t swrModel_NodeGetFlags1Or2(swrModel_Node* node, int flag_id);
 void swrModel_NodeInit(swrModel_Node* node, uint32_t base_flags);
-
-// Stores the root node pointer on a viewport (best guess).
-void swrViewport_SetRootNode_Maybe(swrViewport* viewport, swrModel_Node* node);
 
 // Resets the camera and view globals to their default scale, field of view, and flags (best guess).
 void swrViewport_ResetCameraState_Maybe(void);

--- a/src/Swr/swrViewport.c
+++ b/src/Swr/swrViewport.c
@@ -2,15 +2,33 @@
 
 #include <globals.h>
 #include <macros.h>
+#include <swr.h>
 #include <General/stdMath.h>
 #include <Primitives/rdMatrix.h>
+#include <Swr/swrModel.h>
+#include <Unknown/rdMatrixStack.h>
 
 // 0x00428B40
 void swrViewport_SetCameraIndex(short a1, swrViewport* mesh)
 {
-    HANG("TODO");
+    if (mesh != NULL) {
+        if (swrModel_MeshGetBehavior((swrModel_Mesh*)mesh) != (swrModel_Behavior*)0xffffffff) {
+            int behavior = (int)swrModel_MeshGetBehavior((swrModel_Mesh*)mesh);
+            *(unsigned int*)&unkCameraArray[behavior].flags &= ~1u;
+        }
+        if (a1 == -1) {
+            unkCameraArrayIndex = -1;
+            return;
+        }
+        swrViewport_SetRootNode_Maybe(mesh, a1);
+        *(unsigned int*)&unkCameraArray[unkCameraArrayIndex].flags |= 1u;
+        swrViewport_cameraApplied = 0;
+    }
 }
 
+// Deferred: decoded, but it calls swrCam_CamState_GetOffsetTransform /
+// swrCam_CamState_ApplyToViewport and BuildLookAtTransform, which are not
+// reimplemented yet, so a real body would not link into dinput_hook.
 // 0x00429540
 void swrViewport_UpdateCameras()
 {
@@ -75,6 +93,12 @@ void swrViewport_SetNodeFlags(swrViewport* a1, int flag, int value)
     }
 }
 
+// 0x00431b90
+void swrViewport_SetRootNode_Maybe(swrViewport* viewport, int cameraIndex)
+{
+    viewport->unkCameraIndex = cameraIndex;
+}
+
 // 0x00482EE0
 void swrViewport_UpdateUnknown(swrViewport* viewport)
 {
@@ -114,11 +138,30 @@ void swrViewport_ComputeClipMatrix(swrViewport* unk)
     swrViewport_UpdateUnknown(unk);
 }
 
-// TODO: body deferred -- Ghidra lost the float args (reads uninitialized regs); needs runtime verification.
 // 0x004830E0
 void swrViewport_ComputeScreenRect(swrViewport* a1)
 {
-    HANG("TODO");
+    // Scale the pixel viewport rect into the rasterizer's fixed-point space:
+    // logical 320x240 maps to screen pixels (screenWidth/320, screenHeight/240),
+    // stored as a center/half-extent pair (x1/y1 = 2*half + 8, x2/y2 = 2*center).
+    double scaleX = swrDisplay_screenWidth * 0.003125;
+    double scaleY = swrDisplay_screenHeight * 0.004166666666666667;
+    int sx1 = (int)(a1->viewport_x1 * scaleX);
+    int sy1 = (int)(a1->viewport_y1 * scaleY);
+    int sx2 = (int)(a1->viewport_x2 * scaleX);
+    int sy2 = (int)(a1->viewport_y2 * scaleY);
+    a1->viewport_scaled_x1 = (short)((sx2 - sx1) * 2 + 8);
+    a1->viewport_scaled_x2 = (short)((sx2 + sx1) * 2);
+    a1->viewport_scaled_y1 = (short)((sy2 - sy1) * 2 + 8);
+    a1->viewport_scaled_y2 = (short)((sy2 + sy1) * 2);
+    if (swrViewport_force320x240 != 0) {
+        a1->viewport_scaled_x1 = 0x500;
+        a1->viewport_scaled_y1 = 0x3c0;
+        a1->viewport_scaled_x2 = (swrViewport_force320x240Quadrant & 1) ? 0 : 0x500;
+        a1->viewport_scaled_y2 = (swrViewport_force320x240Quadrant & 2) ? 0 : 0x3c0;
+    }
+    a1->unk14 = 0x92;
+    a1->unk1c = 0x36c;
 }
 
 // 0x004831D0
@@ -150,9 +193,44 @@ void swrViewport_Enable(int viewportIndex, int cameraIndex)
 }
 
 // 0x00483270
-void swrViewport_Init(int)
+void swrViewport_Init(int viewportIndex)
 {
-    HANG("TODO");
+    swrViewport* vp = &swrViewport_array[viewportIndex];
+    int* scaledRect = (int*)&vp->viewport_scaled_x1;
+
+    vp->flag &= ~1u;
+    vp->unkCameraIndex = -1;
+    vp->unk8 = -1;
+    vp->unkc = -1;
+    scaledRect[0] = swrViewport_defaultScaledRect[0];
+    scaledRect[1] = swrViewport_defaultScaledRect[1];
+    scaledRect[2] = swrViewport_defaultScaledRect[2];
+    scaledRect[3] = swrViewport_defaultScaledRect[3];
+    vp->viewport_x1 = 0;
+    vp->viewport_y1 = 0;
+    vp->viewport_x2 = 0x140;
+    vp->viewport_y2 = 0xf0;
+    rdMatrix_SetIdentity44(&vp->unk_mat1);
+    rdMatrix_SetIdentity44(&vp->model_matrix);
+    rdMatrix_SetIdentity44(&vp->unk_mat3);
+    rdMatrix_SetIdentity44(&vp->clipMat);
+    vp->unk130 = 0x10;
+    vp->fov_y_degrees = 90.0;
+    vp->aspect_ratio = 1.0;
+    vp->unk13c = -1.0;
+    vp->near_clipping = 5.0;
+    vp->far_clipping = 5000.0;
+    vp->unk148 = 1.0;
+    vp->unk14c = 0;
+    vp->unk150 = 1.0;
+    vp->unk154 = 1.0;
+    vp->node_flags1_exact_match_for_rendering = 6;
+    vp->node_flags1_any_match_for_rendering = -1;
+    vp->unk160 = 0;
+    vp->unk164 = -1;
+    vp->model_root_node = NULL;
+    swrViewport_ComputeScreenRect(vp);
+    swrViewport_ComputeClipMatrix(vp);
 }
 
 // 0x00483590
@@ -190,11 +268,33 @@ void swrViewport_SetNodeFlagsForAllViewports(int flag, int value)
 }
 
 // 0x00483750
-void swrViewport_Setup(int)
+void swrViewport_Setup(int viewportIndex)
 {
-    HANG("TODO");
+    swrViewport* vp = &swrViewport_array[viewportIndex];
+    rdMatrix44 worldMatrix;
+    rdMatrix44 viewMatrix;
+    rdMatrix44 mvpMatrix;
+    rdVector3 translation;
+
+    swrViewport_ComputeScreenRect(vp);
+    swrViewport_ComputeClipMatrix(vp);
+    rdMatrix_Copy44(&worldMatrix, &vp->model_matrix);
+    translation.x = worldMatrix.vD.x;
+    translation.y = worldMatrix.vD.y;
+    translation.z = worldMatrix.vD.z;
+    worldMatrix.vD.x = 0.0;
+    worldMatrix.vD.y = 0.0;
+    worldMatrix.vD.z = 0.0;
+    rdMatrix_BuildViewMatrix(&viewMatrix, &worldMatrix);
+    rdMatrix_Multiply44(&mvpMatrix, &viewMatrix, &vp->clipMat);
+    SetModelMVPAndTranslation(&mvpMatrix, &translation);
+    if (vp->unk13c > 0.0)
+        vp->unk130 = (short)(65536.0 / vp->unk13c);
 }
 
+// Deferred: decoded, but the scene path it calls (rdModel_BuildAndDrawScene /
+// rdModel_SetupSceneFogAndLights_Maybe) is not reimplemented yet, so a real body
+// would not link into dinput_hook (the reimpl set must stay call-closed).
 // 0x00483A90
 void swrViewport_Render(int x)
 {
@@ -202,7 +302,9 @@ void swrViewport_Render(int x)
 }
 
 // 0x00483BB0
-void swrViewport_Activate(int)
+void swrViewport_Activate(int viewportIndex)
 {
-    HANG("TODO");
+    swrViewport_active = &swrViewport_array[viewportIndex];
+    swrViewport_Setup(viewportIndex);
+    swr_noop3();
 }

--- a/src/Swr/swrViewport.h
+++ b/src/Swr/swrViewport.h
@@ -15,6 +15,7 @@
 #define swrViewport_SetMat3_ADDR (0x00431950)
 #define swrViewport_SetRootNode_ADDR (0x00431a00)
 #define swrViewport_SetNodeFlags_ADDR (0x00431a10)
+#define swrViewport_SetRootNode_Maybe_ADDR (0x00431b90)
 
 #define swrViewport_UpdateUnknown_ADDR (0x00482EE0)
 #define swrViewport_ComputeClipMatrix_ADDR (0x00482f10)
@@ -51,20 +52,23 @@ void swrViewport_SetMat3(swrViewport* a1, const rdMatrix44* a2);
 void swrViewport_SetRootNode(swrViewport* a1, swrModel_Node* a2);
 void swrViewport_SetNodeFlags(swrViewport* a1, int flag, int value);
 
+// Stores the camera-slot index into the viewport's unkCameraIndex field (+4).
+void swrViewport_SetRootNode_Maybe(swrViewport* viewport, int cameraIndex);
+
 void swrViewport_UpdateUnknown(swrViewport*);
 void swrViewport_ComputeClipMatrix(swrViewport* unk);
 void swrViewport_ComputeScreenRect(swrViewport* a1);
 void swrViewport_SetViewport(int viewportIndex, int x1, int y1, int x2, int y2);
 void swrViewport_Enable(int viewportIndex, int cameraIndex);
-void swrViewport_Init(int);
+void swrViewport_Init(int viewportIndex);
 
 void swrViewport_SetCameraParameters(int viewportIndex, float fovY, float aspect, float nearClip, float farClip, float param6);
 
-void swrViewport_Setup(int);
+void swrViewport_Setup(int viewportIndex);
 
 void swrViewport_Render(int x);
 
-void swrViewport_Activate(int);
+void swrViewport_Activate(int viewportIndex);
 
 // Prints the pod position and lap progress as a debug text overlay.
 void swrRace_DrawDebugPosition(int param_1);


### PR DESCRIPTION
Reverse-hook reimplementations for the viewport subsystem (`src/Swr/swrViewport.c`).

**Reimplemented (6):**
- `swrViewport_Init` - viewport struct init (identity matrices, default rect, fov/clip defaults)
- `swrViewport_Setup` - world->view->MVP build + view-distance LOD scale
- `swrViewport_ComputeScreenRect` - this one was previously a stub marked *"Ghidra lost the float args, needs runtime verification."* The "uninitialized regs" were just shared x87 multipliers (`screenWidth/320`, `screenHeight/240`) that Ghidra couldn't track across the `__ftol` calls. Recovered from disasm and verified instruction-for-instruction against the original.
- `swrViewport_Activate`
- `swrViewport_SetCameraIndex`
- `swrViewport_SetRootNode_Maybe` (the `unkCameraIndex` setter `SetCameraIndex` calls)

**Globals named** (in `data_symbols.syms`): `swrViewport_active`, `swrViewport_defaultScaledRect`, `swrViewport_cameraApplied`, `swrViewport_force320x240Quadrant`.

**Left as stubs:** `swrViewport_Render` and `swrViewport_UpdateCameras` are fully decoded but call functions that aren't reimplemented yet (`swrCam_CamState_*`, `BuildLookAtTransform`, `rdModel_BuildAndDrawScene`/`SetupSceneFogAndLights_Maybe`). A real body there would break the `dinput_hook` link (call-closure), so they keep their `HANG` stubs with an in-place note. Follow-up once the callees land.

Builds clean (`dinput_hook` links). /pre-pr-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)