### PR TITLE
swrUI: reimplement swrUI_UpdateProgressBar

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -393,8 +393,14 @@ swrControl_acceptReleasedEdge 0x004d6b4c int
 
 enableWindowInput 0x004D6B54 int
 
+swrUI_progressBarY 0x004d6b70 int # progress-bar rect top (swrUI_UpdateProgressBar)
+swrUI_progressBarX 0x004d6b74 int # progress-bar rect left
+
 rdLight_1 0x004d6b78 rdLight
 rdLight_2 0x004d6ba8 rdLight
+
+swrUI_progressBarHeight 0x004d6bd8 int # progress-bar rect height
+swrUI_progressBarWidth 0x004d6bdc int # progress-bar rect width
 
 ddSurfaceForProgressBar 0x004d6be0 LPDIRECTDRAWSURFACE4
 ddSurfaceDescForProgressBar 0x004d6be4 DDSURFACEDESC

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -10,7 +10,52 @@
 // 0x00408640
 void swrUI_UpdateProgressBar(int progressPercent)
 {
-    HANG("TODO");
+    struct tagRECT rect;
+    LPDIRECTDRAWSURFACE4 surf;
+
+    if (iDirectDraw4_error != 0)
+        return;
+
+    surf = stdDisplay_g_frontBuffer.pVSurface.pDDSurf;
+
+    // top edge
+    rect.left = swrUI_progressBarX;
+    rect.top = swrUI_progressBarY;
+    rect.right = swrUI_progressBarX + swrUI_progressBarWidth;
+    rect.bottom = swrUI_progressBarY + 1;
+    surf->lpVtbl->Blt(surf, (LPRECT)&rect, ddSurfaceForProgressBar, (LPRECT)&tagRect, 0x1000000 /* DDBLT_WAIT */, NULL);
+
+    // bottom edge
+    rect.left = swrUI_progressBarX;
+    rect.right = swrUI_progressBarX + swrUI_progressBarWidth;
+    rect.bottom = swrUI_progressBarY + swrUI_progressBarHeight;
+    rect.top = rect.bottom - 1;
+    surf->lpVtbl->Blt(surf, (LPRECT)&rect, ddSurfaceForProgressBar, (LPRECT)&tagRect, 0x1000000 /* DDBLT_WAIT */, NULL);
+
+    // left edge
+    rect.left = swrUI_progressBarX;
+    rect.right = swrUI_progressBarX + 1;
+    rect.top = swrUI_progressBarY;
+    rect.bottom = swrUI_progressBarY + swrUI_progressBarHeight;
+    surf->lpVtbl->Blt(surf, (LPRECT)&rect, ddSurfaceForProgressBar, (LPRECT)&tagRect, 0x1000000 /* DDBLT_WAIT */, NULL);
+
+    // right edge
+    rect.left = swrUI_progressBarX + swrUI_progressBarWidth - 1;
+    rect.right = swrUI_progressBarX + swrUI_progressBarWidth;
+    rect.top = swrUI_progressBarY;
+    rect.bottom = swrUI_progressBarY + swrUI_progressBarHeight;
+    surf->lpVtbl->Blt(surf, (LPRECT)&rect, ddSurfaceForProgressBar, (LPRECT)&tagRect, 0x1000000 /* DDBLT_WAIT */, NULL);
+
+    // fill proportional to progress
+    if (progressPercent > 100)
+        progressPercent = 100;
+    if (progressPercent < 0)
+        progressPercent = 0;
+    rect.left = swrUI_progressBarX;
+    rect.right = swrUI_progressBarX + (progressPercent * swrUI_progressBarWidth) / 100;
+    rect.top = swrUI_progressBarY;
+    rect.bottom = swrUI_progressBarY + swrUI_progressBarHeight;
+    surf->lpVtbl->Blt(surf, (LPRECT)&rect, ddSurfaceForProgressBar, (LPRECT)&tagRect, 0x1000000 /* DDBLT_WAIT */, NULL);
 }
 
 // 0x00408800 TODO: Crashes on release, works fine on debug


### PR DESCRIPTION
Reimplements the DirectDraw loader progress bar (`swrUI.c`).

It blits the bar's 4 border edges plus a fill rect proportional to `progressPercent` (clamped 0-100) from `ddSurfaceForProgressBar` into the front buffer.

Names the 4 rect globals it uses: `swrUI_progressBarX`, `swrUI_progressBarY`, `swrUI_progressBarWidth`, `swrUI_progressBarHeight`.

Self-contained leaf (9 callers, no game-function callees). Builds + links clean. /pre-pr-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)