### PR TITLE
sithMessage: reimplement sithMulti_GetPlayerNum

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -453,7 +453,7 @@ swrMulti_Initialized 0x004eb398 int
 DAT_004eb39c 0x004eb39c  int
 
 playerNumber 0x004eb3b4 int
-# sithPlayer_g_numPlayers 0x004eb38 int # TODO: what is happening with playerNumber then ?
+sithPlayer_g_numPlayers 0x004eb3b8 int # count of entries in sithPlayer_g_aPlayers (loop bound in sithMulti_GetPlayerNum)
 
 swrText_racerTab_array 0x004eb3c4 char**
 swrText_racerTab_buffer 0x004eb3c8 char*

--- a/src/Dss/sithMessage.c
+++ b/src/Dss/sithMessage.c
@@ -44,7 +44,17 @@ void sithMulti_RemovePlayer(unsigned int playerNum)
 // 0x0041d350
 int sithMulti_GetPlayerNum(DPID idPlayer)
 {
-    HANG("TODO");
+    unsigned int i = 0;
+    if (sithPlayer_g_numPlayers != 0) {
+        SithPlayer* player = sithPlayer_g_aPlayers;
+        do {
+            if (idPlayer == *(DPID*)player->awName)
+                return i;
+            i++;
+            player++;
+        } while (i < sithPlayer_g_numPlayers);
+    }
+    return -1;
 }
 
 // 0x00420ff0


### PR DESCRIPTION
Reimplements `sithMulti_GetPlayerNum` (`sithMessage.c`): linear-searches `sithPlayer_g_aPlayers` for the entry whose id (first dword of `awName`) equals `idPlayer`, returning its index or `-1`.

Also enables the previously commented-out `sithPlayer_g_numPlayers` global (`0x004eb3b8`) — it's the loop bound (count of players). Self-contained leaf, builds + links clean, /pre-pr-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)