### PR TITLE
rdCache: reimplement 6 render-cache management functions

### DIFF
--- a/src/Raster/rdCache.c
+++ b/src/Raster/rdCache.c
@@ -1,5 +1,6 @@
 #include "rdCache.h"
 
+#include "engine_config.h"
 #include "globals.h"
 #include "Platform/std3D.h"
 
@@ -9,8 +10,11 @@
 // 0x0048db40
 void rdCache_Startup(void)
 {
+    // Zero the leading RDCACHE_MAX_VERTICES *bytes* of the HW vertex scratch
+    // buffer (a dword-at-a-time clear in the original; the count is in bytes,
+    // not vertices).
     int* hwVertexData = (int*)rdCache_aHWVertices;
-    for (int i = 0; i < 0x5000; i++)
+    for (unsigned int i = 0; i < RDCACHE_MAX_VERTICES / sizeof(int); i++)
         hwVertexData[i] = 0;
     rdCache_frameNum = 0;
 }
@@ -37,13 +41,13 @@ int rdCache_GetDrawnFacesNum(void)
 // 0x0048dba0
 RdCacheProcEntry* rdCache_GetProcEntry(void)
 {
-    if ((unsigned int)rdCache_numProcFaces >= 0x400)
+    if ((unsigned int)rdCache_numProcFaces >= RDCACHE_MAX_TRIS)
         rdCache_Flush();
-    if (0x14000U - rdCache_numUsedVertices < 0x50)
+    if (RDCACHE_MAX_VERTICES - rdCache_numUsedVertices < RDCACHE_MIN_FREE_VERTICES)
         return NULL;
-    if (0x14000U - rdCache_numUsedTexVertices < 0x50)
+    if (RDCACHE_MAX_VERTICES - rdCache_numUsedTexVertices < RDCACHE_MIN_FREE_VERTICES)
         return NULL;
-    if (0x14000U - rdCache_numUsedIntensities < 0x50)
+    if (RDCACHE_MAX_VERTICES - rdCache_numUsedIntensities < RDCACHE_MIN_FREE_VERTICES)
         return NULL;
     RdCacheProcEntry* entry = rdCache_aProcFaces + rdCache_numProcFaces;
     entry->aVertices = rdCache_aVertices + rdCache_numUsedVertices;
@@ -111,7 +115,7 @@ size_t rdCache_FlushAlpha(void)
 // 0x0048de10
 int rdCache_AddProcFace(unsigned int nbVertices, char flags)
 {
-    if ((unsigned int)rdCache_numProcFaces < 0x400) {
+    if ((unsigned int)rdCache_numProcFaces < RDCACHE_MAX_TRIS) {
         RdCacheProcEntry* entry = rdCache_aProcFaces + rdCache_numProcFaces;
         float minZ = FLT_MAX;
         entry->numVertices = nbVertices;
@@ -126,11 +130,11 @@ int rdCache_AddProcFace(unsigned int nbVertices, char flags)
             } while (remaining != 0);
         }
         entry->distance = minZ;
-        if (flags & 1)
+        if (flags & rdCache_ProcFaceFLAGS_VERTICES)
             rdCache_numUsedVertices += nbVertices;
-        if (flags & 2)
+        if (flags & rdCache_ProcFaceFLAGS_UVS)
             rdCache_numUsedTexVertices += nbVertices;
-        if (flags & 4)
+        if (flags & rdCache_ProcFaceFLAGS_INTENSITIES)
             rdCache_numUsedIntensities += nbVertices;
         rdCache_numProcFaces++;
         return 1;

--- a/src/Raster/rdCache.c
+++ b/src/Raster/rdCache.c
@@ -3,36 +3,53 @@
 #include "globals.h"
 #include "Platform/std3D.h"
 
+#include <float.h>
 #include <macros.h>
 
 // 0x0048db40
 void rdCache_Startup(void)
 {
-    HANG("TODO");
+    int* hwVertexData = (int*)rdCache_aHWVertices;
+    for (int i = 0; i < 0x5000; i++)
+        hwVertexData[i] = 0;
+    rdCache_frameNum = 0;
 }
 
 // 0x0048db60
 void rdCache_AdvanceFrame(void)
 {
-    HANG("TODO");
+    rdCache_drawnFaces = 0;
+    rdCache_frameNum = rdCache_frameNum + 1;
 }
 
 // 0x0048db80
 int rdCache_GetFrameNum(void)
 {
-    HANG("TODO");
+    return rdCache_frameNum;
 }
 
 // 0x0048db90
 int rdCache_GetDrawnFacesNum(void)
 {
-    HANG("TODO");
+    return rdCache_drawnFaces;
 }
 
 // 0x0048dba0
 RdCacheProcEntry* rdCache_GetProcEntry(void)
 {
-    HANG("TODO");
+    if ((unsigned int)rdCache_numProcFaces >= 0x400)
+        rdCache_Flush();
+    if (0x14000U - rdCache_numUsedVertices < 0x50)
+        return NULL;
+    if (0x14000U - rdCache_numUsedTexVertices < 0x50)
+        return NULL;
+    if (0x14000U - rdCache_numUsedIntensities < 0x50)
+        return NULL;
+    RdCacheProcEntry* entry = rdCache_aProcFaces + rdCache_numProcFaces;
+    entry->aVertices = rdCache_aVertices + rdCache_numUsedVertices;
+    entry->aUVCoords = rdCache_aTexVertices + rdCache_numUsedTexVertices;
+    entry->aVertColors = rdCache_aVertIntensities + rdCache_numUsedIntensities;
+    return entry;
 }
 
 // 0x0048dc40
@@ -94,7 +111,31 @@ size_t rdCache_FlushAlpha(void)
 // 0x0048de10
 int rdCache_AddProcFace(unsigned int nbVertices, char flags)
 {
-    HANG("TODO");
+    if ((unsigned int)rdCache_numProcFaces < 0x400) {
+        RdCacheProcEntry* entry = rdCache_aProcFaces + rdCache_numProcFaces;
+        float minZ = FLT_MAX;
+        entry->numVertices = nbVertices;
+        if (nbVertices != 0) {
+            rdVector3* vertex = entry->aVertices;
+            unsigned int remaining = nbVertices;
+            do {
+                if (vertex->z < minZ)
+                    minZ = vertex->z;
+                vertex++;
+                remaining--;
+            } while (remaining != 0);
+        }
+        entry->distance = minZ;
+        if (flags & 1)
+            rdCache_numUsedVertices += nbVertices;
+        if (flags & 2)
+            rdCache_numUsedTexVertices += nbVertices;
+        if (flags & 4)
+            rdCache_numUsedIntensities += nbVertices;
+        rdCache_numProcFaces++;
+        return 1;
+    }
+    return 0;
 }
 
 // 0x0048dea0

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -3,5 +3,8 @@
 
 #define RDCACHE_MAX_VERTICES (0x14000U) // something wrong with references
 #define RDCACHE_MAX_TRIS (0x400)
+// Free vertex-pool headroom rdCache_GetProcEntry keeps in reserve so the
+// worst-case single face returned by it always fits before the next flush.
+#define RDCACHE_MIN_FREE_VERTICES (0x50)
 
 #endif // ENGINE_CONFIG_H

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -23,6 +23,16 @@ typedef enum StdColorFormatType
     STDCOLOR_FORMAT_RGBA = 0x2,
 } StdColorFormatType;
 
+// rdCache_AddProcFace flags: which shared vertex-attribute pools the face
+// consumes (advances the used-count for). Set per face from the geometry
+// and lighting mode; the intensity bit is only set for lit faces.
+typedef enum rdCache_ProcFaceFLAGS
+{
+    rdCache_ProcFaceFLAGS_VERTICES = 0x1, // vertex positions (rdCache_aVertices)
+    rdCache_ProcFaceFLAGS_UVS = 0x2, // texture coordinates (rdCache_aTexVertices)
+    rdCache_ProcFaceFLAGS_INTENSITIES = 0x4, // vertex colors/lighting (rdCache_aVertIntensities)
+} rdCache_ProcFaceFLAGS;
+
 typedef enum swrVehicleReaction
 {
     swrVehicleReaction_ZOn = 0x1,


### PR DESCRIPTION
Reimplements six render-cache (`rdCache.c`) management functions:

- `rdCache_Startup` — zero the hardware vertex buffer + reset the frame counter
- `rdCache_AdvanceFrame` / `rdCache_GetFrameNum` / `rdCache_GetDrawnFacesNum`
- `rdCache_GetProcEntry` — allocate a capacity-checked proc-face slot, pointing its vertex/uv/color spans into the shared pools
- `rdCache_AddProcFace` — record a face and compute its min-Z sort distance

No new globals — all sibling calls resolve to already-reimplemented functions (`rdCache_Flush` etc.). Builds + links clean. /pre-pr-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)