### PR TITLE
rdMatrixStack: reimplement the rdMatrixStack34 stack + MVP precompute (7 functions)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -307,6 +307,7 @@ swrObjcMan_SpectatorCamModes 0x004c3ef0 int16_t[7] # auto-cycle spectator cam: m
 
 numEnabledLights 0x00004C3BA0 int[12]
 
+rdModel_useModelTranslation 0x004c3c08 int # nonzero -> factor rdVector_model_translation out of the stack-top translation around the MVP concat (model-origin-relative precision)
 rdMatrixStack34_modified 0x004c3c0c int
 rdModel_CurrentLightNum 0x004C3C10 int
 
@@ -631,6 +632,7 @@ swrTextEntries2Count 0x0050c758 int # < 0x20
 numMiniMapPositions 0x0050C764 int
 
 rdMatrixStack34_size 0x0050c6f4 int
+rdMatrixStack34_mvpComputed 0x0050c6f8 int # nonzero once PrecomputeMVPMatrices has run for the current stack top; cleared by rdMatrixStack34_Init
 
 rdModel_LightSelected 0x0050C704 BOOL
 rdModel_CurrentLightIndex 0x0050C708 int

--- a/src/Unknown/rdMatrixStack.c
+++ b/src/Unknown/rdMatrixStack.c
@@ -1,4 +1,5 @@
 #include "rdMatrixStack.h"
+#include "Swr/swrModel.h"
 #include "globals.h"
 
 #include <macros.h>
@@ -105,7 +106,25 @@ rdMatrix44* rdMatrix44_ringBuffer_Get(void)
 // 0x0044b690
 void SetModelMVPAndTranslation(const rdMatrix44* mvp, const rdVector3* translation)
 {
-    HANG("TODO");
+    rdVector_model_translation.x = translation->x;
+    rdVector_model_translation.y = translation->y;
+    rdVector_model_translation.z = translation->z;
+    rdMatrix44_model_MVP.vA.x = mvp->vA.x;
+    rdMatrix44_model_MVP.vA.y = mvp->vA.y;
+    rdMatrix44_model_MVP.vA.z = mvp->vA.z;
+    rdMatrix44_model_MVP.vA.w = mvp->vA.w;
+    rdMatrix44_model_MVP.vB.x = mvp->vB.x;
+    rdMatrix44_model_MVP.vB.y = mvp->vB.y;
+    rdMatrix44_model_MVP.vB.z = mvp->vB.z;
+    rdMatrix44_model_MVP.vB.w = mvp->vB.w;
+    rdMatrix44_model_MVP.vC.x = mvp->vC.x;
+    rdMatrix44_model_MVP.vC.y = mvp->vC.y;
+    rdMatrix44_model_MVP.vC.z = mvp->vC.z;
+    rdMatrix44_model_MVP.vC.w = mvp->vC.w;
+    rdMatrix44_model_MVP.vD.x = mvp->vD.x;
+    rdMatrix44_model_MVP.vD.y = mvp->vD.y;
+    rdMatrix44_model_MVP.vD.z = mvp->vD.z;
+    rdMatrix44_model_MVP.vD.w = mvp->vD.w;
 }
 
 // 0x0044b750
@@ -137,29 +156,107 @@ void __cdecl rdMatrixStack34_Push(const rdMatrix34* mat)
 // 0x0044b7e0
 void rdMatrixStack34_PushMultiply(const rdMatrix34* a1)
 {
-    HANG("TODO");
+    int top = rdMatrixStack34_size;
+    rdMatrixStack34_modified = true;
+    if (rdMatrixStack34_size < 0x20) {
+        int dst = top + 1;
+        rdMatrixStack34_size = dst;
+        rdMatrixStack34[dst].rvec.x = rdMatrixStack34[top].uvec.x * a1->rvec.z + rdMatrixStack34[top].lvec.x * a1->rvec.y + rdMatrixStack34[top].rvec.x * a1->rvec.x;
+        rdMatrixStack34[dst].rvec.y = rdMatrixStack34[top].lvec.y * a1->rvec.y + rdMatrixStack34[top].uvec.y * a1->rvec.z + a1->rvec.x * rdMatrixStack34[top].rvec.y;
+        rdMatrixStack34[dst].rvec.z = a1->rvec.y * rdMatrixStack34[top].lvec.z + a1->rvec.z * rdMatrixStack34[top].uvec.z + a1->rvec.x * rdMatrixStack34[top].rvec.z;
+        rdMatrixStack34[dst].lvec.x = rdMatrixStack34[top].lvec.x * a1->lvec.y + rdMatrixStack34[top].uvec.x * a1->lvec.z + rdMatrixStack34[top].rvec.x * a1->lvec.x;
+        rdMatrixStack34[dst].lvec.y = rdMatrixStack34[top].lvec.y * a1->lvec.y + rdMatrixStack34[top].uvec.y * a1->lvec.z + a1->lvec.x * rdMatrixStack34[top].rvec.y;
+        rdMatrixStack34[dst].lvec.z = a1->lvec.y * rdMatrixStack34[top].lvec.z + a1->lvec.z * rdMatrixStack34[top].uvec.z + a1->lvec.x * rdMatrixStack34[top].rvec.z;
+        rdMatrixStack34[dst].uvec.x = a1->uvec.y * rdMatrixStack34[top].lvec.x + a1->uvec.z * rdMatrixStack34[top].uvec.x + rdMatrixStack34[top].rvec.x * a1->uvec.x;
+        rdMatrixStack34[dst].uvec.y = a1->uvec.y * rdMatrixStack34[top].lvec.y + a1->uvec.x * rdMatrixStack34[top].rvec.y + a1->uvec.z * rdMatrixStack34[top].uvec.y;
+        rdMatrixStack34[dst].uvec.z = a1->uvec.x * rdMatrixStack34[top].rvec.z + a1->uvec.z * rdMatrixStack34[top].uvec.z + a1->uvec.y * rdMatrixStack34[top].lvec.z;
+        rdMatrixStack34[dst].scale.x = a1->scale.z * rdMatrixStack34[top].uvec.x + a1->scale.y * rdMatrixStack34[top].lvec.x + rdMatrixStack34[top].rvec.x * a1->scale.x + rdMatrixStack34[top].scale.x;
+        rdMatrixStack34[dst].scale.y = a1->scale.y * rdMatrixStack34[top].lvec.y + a1->scale.z * rdMatrixStack34[top].uvec.y + a1->scale.x * rdMatrixStack34[top].rvec.y + rdMatrixStack34[top].scale.y;
+        rdMatrixStack34[dst].scale.z = a1->scale.y * rdMatrixStack34[top].lvec.z + a1->scale.z * rdMatrixStack34[top].uvec.z + a1->scale.x * rdMatrixStack34[top].rvec.z + rdMatrixStack34[top].scale.z;
+    }
 }
 
 // 0x0044b9b0
 void rdMatrixStack34_Peek(rdMatrix34* a1)
 {
-    HANG("TODO");
+    a1->rvec.x = rdMatrixStack34[rdMatrixStack34_size].rvec.x;
+    a1->rvec.y = rdMatrixStack34[rdMatrixStack34_size].rvec.y;
+    a1->rvec.z = rdMatrixStack34[rdMatrixStack34_size].rvec.z;
+    a1->lvec.x = rdMatrixStack34[rdMatrixStack34_size].lvec.x;
+    a1->lvec.y = rdMatrixStack34[rdMatrixStack34_size].lvec.y;
+    a1->lvec.z = rdMatrixStack34[rdMatrixStack34_size].lvec.z;
+    a1->uvec.x = rdMatrixStack34[rdMatrixStack34_size].uvec.x;
+    a1->uvec.y = rdMatrixStack34[rdMatrixStack34_size].uvec.y;
+    a1->uvec.z = rdMatrixStack34[rdMatrixStack34_size].uvec.z;
+    a1->scale.x = rdMatrixStack34[rdMatrixStack34_size].scale.x;
+    a1->scale.y = rdMatrixStack34[rdMatrixStack34_size].scale.y;
+    a1->scale.z = rdMatrixStack34[rdMatrixStack34_size].scale.z;
 }
 
 // 0x0044bab0
 void rdMatrixStack34_Pop()
 {
-    HANG("TODO");
+    rdMatrixStack34_modified = true;
+    if (0 < rdMatrixStack34_size) {
+        rdMatrixStack34_size = rdMatrixStack34_size - 1;
+    }
 }
 
 // 0x0044bb40
 void rdMatrixStack34_Init()
 {
-    HANG("TODO");
+    rdMatrixStack34_size = 0;
+    rdMatrixStack34_modified = true;
+    rdMatrixStack34_mvpComputed = 0;
+    rdVector_Set3(&rdMatrixStack34[0].rvec, 1.0, 0.0, 0.0);
+    rdVector_Set3(&rdMatrixStack34[rdMatrixStack34_size].lvec, 0.0, 1.0, 0.0);
+    rdVector_Set3(&rdMatrixStack34[rdMatrixStack34_size].uvec, 0.0, 0.0, 1.0);
+    rdVector_Set3(&rdMatrixStack34[rdMatrixStack34_size].scale, 0.0, 0.0, 0.0);
+}
+
+// 0x0044bbe0
+void swrModel_CachePrecomputedMatrices(void)
+{
+    rdMatrix34* src = rdMatrixStack34 + rdMatrixStack34_size;
+    PrecomputedModelMatrixPtr = rdMatrix44_ringBuffer_Get();
+    rdMatrix_Copy44_34(PrecomputedModelMatrixPtr, src);
+    PrecomputedMVPMatrixPtr = rdMatrix44_ringBuffer_Get();
+    rdMatrix_Copy44(PrecomputedMVPMatrixPtr, &PrecomputedMVPMatrix);
 }
 
 // 0x0044bc20
 void rdMatrixStack34_PrecomputeMVPMatrices()
 {
-    HANG("TODO");
+    int top = rdMatrixStack34_size;
+    rdMatrixStack34_modified = false;
+    rdMatrixStack34_mvpComputed = 1;
+    // High-precision option: factor the model origin out of the stack-top translation so the
+    // concat below runs near the origin, then restore it afterwards.
+    if (rdModel_useModelTranslation != 0) {
+        rdMatrixStack34[top].scale.x = rdMatrixStack34[top].scale.x - rdVector_model_translation.x;
+        rdMatrixStack34[top].scale.y = rdMatrixStack34[top].scale.y - rdVector_model_translation.y;
+        rdMatrixStack34[top].scale.z = rdMatrixStack34[top].scale.z - rdVector_model_translation.z;
+    }
+    PrecomputedMVPMatrix.vA.x = rdMatrixStack34[top].rvec.x * rdMatrix44_model_MVP.vA.x + rdMatrixStack34[top].rvec.z * rdMatrix44_model_MVP.vC.x + rdMatrixStack34[top].rvec.y * rdMatrix44_model_MVP.vB.x;
+    PrecomputedMVPMatrix.vA.y = rdMatrixStack34[top].rvec.x * rdMatrix44_model_MVP.vA.y + rdMatrixStack34[top].rvec.z * rdMatrix44_model_MVP.vC.y + rdMatrixStack34[top].rvec.y * rdMatrix44_model_MVP.vB.y;
+    PrecomputedMVPMatrix.vA.z = rdMatrixStack34[top].rvec.x * rdMatrix44_model_MVP.vA.z + rdMatrixStack34[top].rvec.z * rdMatrix44_model_MVP.vC.z + rdMatrixStack34[top].rvec.y * rdMatrix44_model_MVP.vB.z;
+    PrecomputedMVPMatrix.vA.w = rdMatrixStack34[top].rvec.x * rdMatrix44_model_MVP.vA.w + rdMatrixStack34[top].rvec.z * rdMatrix44_model_MVP.vC.w + rdMatrixStack34[top].rvec.y * rdMatrix44_model_MVP.vB.w;
+    PrecomputedMVPMatrix.vB.x = rdMatrixStack34[top].lvec.z * rdMatrix44_model_MVP.vC.x + rdMatrixStack34[top].lvec.x * rdMatrix44_model_MVP.vA.x + rdMatrixStack34[top].lvec.y * rdMatrix44_model_MVP.vB.x;
+    PrecomputedMVPMatrix.vB.y = rdMatrixStack34[top].lvec.z * rdMatrix44_model_MVP.vC.y + rdMatrixStack34[top].lvec.x * rdMatrix44_model_MVP.vA.y + rdMatrixStack34[top].lvec.y * rdMatrix44_model_MVP.vB.y;
+    PrecomputedMVPMatrix.vB.z = rdMatrixStack34[top].lvec.z * rdMatrix44_model_MVP.vC.z + rdMatrixStack34[top].lvec.x * rdMatrix44_model_MVP.vA.z + rdMatrixStack34[top].lvec.y * rdMatrix44_model_MVP.vB.z;
+    PrecomputedMVPMatrix.vB.w = rdMatrixStack34[top].lvec.z * rdMatrix44_model_MVP.vC.w + rdMatrixStack34[top].lvec.x * rdMatrix44_model_MVP.vA.w + rdMatrixStack34[top].lvec.y * rdMatrix44_model_MVP.vB.w;
+    PrecomputedMVPMatrix.vC.x = rdMatrixStack34[top].uvec.y * rdMatrix44_model_MVP.vB.x + rdMatrixStack34[top].uvec.z * rdMatrix44_model_MVP.vC.x + rdMatrixStack34[top].uvec.x * rdMatrix44_model_MVP.vA.x;
+    PrecomputedMVPMatrix.vC.y = rdMatrixStack34[top].uvec.y * rdMatrix44_model_MVP.vB.y + rdMatrixStack34[top].uvec.z * rdMatrix44_model_MVP.vC.y + rdMatrixStack34[top].uvec.x * rdMatrix44_model_MVP.vA.y;
+    PrecomputedMVPMatrix.vC.z = rdMatrixStack34[top].uvec.y * rdMatrix44_model_MVP.vB.z + rdMatrixStack34[top].uvec.z * rdMatrix44_model_MVP.vC.z + rdMatrixStack34[top].uvec.x * rdMatrix44_model_MVP.vA.z;
+    PrecomputedMVPMatrix.vC.w = rdMatrixStack34[top].uvec.y * rdMatrix44_model_MVP.vB.w + rdMatrixStack34[top].uvec.z * rdMatrix44_model_MVP.vC.w + rdMatrixStack34[top].uvec.x * rdMatrix44_model_MVP.vA.w;
+    PrecomputedMVPMatrix.vD.x = rdMatrixStack34[top].scale.z * rdMatrix44_model_MVP.vC.x + rdMatrixStack34[top].scale.y * rdMatrix44_model_MVP.vB.x + rdMatrixStack34[top].scale.x * rdMatrix44_model_MVP.vA.x + rdMatrix44_model_MVP.vD.x;
+    PrecomputedMVPMatrix.vD.y = rdMatrixStack34[top].scale.z * rdMatrix44_model_MVP.vC.y + rdMatrixStack34[top].scale.y * rdMatrix44_model_MVP.vB.y + rdMatrixStack34[top].scale.x * rdMatrix44_model_MVP.vA.y + rdMatrix44_model_MVP.vD.y;
+    PrecomputedMVPMatrix.vD.z = rdMatrixStack34[top].scale.z * rdMatrix44_model_MVP.vC.z + rdMatrixStack34[top].scale.y * rdMatrix44_model_MVP.vB.z + rdMatrixStack34[top].scale.x * rdMatrix44_model_MVP.vA.z + rdMatrix44_model_MVP.vD.z;
+    PrecomputedMVPMatrix.vD.w = rdMatrixStack34[top].scale.z * rdMatrix44_model_MVP.vC.w + rdMatrixStack34[top].scale.y * rdMatrix44_model_MVP.vB.w + rdMatrixStack34[top].scale.x * rdMatrix44_model_MVP.vA.w + rdMatrix44_model_MVP.vD.w;
+    if (rdModel_useModelTranslation != 0) {
+        rdMatrixStack34[top].scale.x = rdVector_model_translation.x + rdMatrixStack34[top].scale.x;
+        rdMatrixStack34[top].scale.y = rdVector_model_translation.y + rdMatrixStack34[top].scale.y;
+        rdMatrixStack34[top].scale.z = rdVector_model_translation.z + rdMatrixStack34[top].scale.z;
+    }
+    swrModel_CachePrecomputedMatrices();
 }


### PR DESCRIPTION
Fills the last HANG stubs in `rdMatrixStack.c` -- the 3x4 (`rdMatrixStack34`) transform-stack family, mirroring the existing 4x4 ops:

- `SetModelMVPAndTranslation`
- `rdMatrixStack34_PushMultiply` / `_Peek` / `_Pop` / `_Init`
- `rdMatrixStack34_PrecomputeMVPMatrices`
- `swrModel_CachePrecomputedMatrices` -- its only caller is `PrecomputeMVPMatrices`, so I put it next to it in this file rather than `swrModel.c`; easy to move if you'd rather.

Names two globals these touch (added to `data_symbols.syms`):
- `rdMatrixStack34_mvpComputed` (0x0050c6f8)
- `rdModel_useModelTranslation` (0x004c3c08) -- the model-origin-relative translation gate. It's read-only in the binary so the name is a best guess; rename if you have a canonical one.

Builds + links clean.