### PR TITLE
refactor(modding): route swrObjJdge byte-patches through the journal

### DIFF
--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -15,6 +15,7 @@ extern FILE* hook_log;
 }
 
 #include "../hook_helper.h"
+#include "../patch.h"
 
 extern "C" void hook_function(const char *function_name, uint32_t original_address,
                               uint8_t *hook_address);
@@ -135,11 +136,11 @@ void swrObjJdge_PatchLapTimeOverflow() {
             return;
         }
 
-        DWORD old_protect = 0;
-        VirtualProtect(code, 4, PAGE_EXECUTE_READWRITE, &old_protect);
-        std::memcpy(code, site.patched, 4);
-        VirtualProtect(code, 4, old_protect, &old_protect);
-        patched++;
+        // Route the write through the owner-tagged journal (revertible, overlap-checked) instead
+        // of a raw VirtualProtect+memcpy. The verify above guarantees WriteMemory snapshots the
+        // stock bytes, so UndoOwner("lap_time_overflow") restores the original binary exactly.
+        if (WriteMemory("lap_time_overflow", code, site.patched, 4))
+            patched++;
     }
 
     fprintf(hook_log,
@@ -188,11 +189,10 @@ void swrObjJdge_PatchRaceTimeCap() {
             return;
         }
 
-        DWORD old_protect = 0;
-        VirtualProtect(p, 4, PAGE_EXECUTE_READWRITE, &old_protect);
-        std::memcpy(p, cap_bytes, 4);
-        VirtualProtect(p, 4, old_protect, &old_protect);
-        patched++;
+        // Journaled write (see PatchLapTimeOverflow): the verify above pins the snapshot to the
+        // stock 3000.0f, so UndoOwner("race_time_cap") restores the original cap.
+        if (WriteMemory("race_time_cap", p, cap_bytes, 4))
+            patched++;
     }
 
     fprintf(hook_log,


### PR DESCRIPTION
Follow-up to #209 (the `WriteMemory`/`UndoOwner` journal). Routes the two hand-rolled `.text` byte-patches in `swrObjJdge_delta.cpp` through the owner-tagged journal instead of a raw `VirtualProtect` + `memcpy` + restore dance:

- `swrObjJdge_PatchLapTimeOverflow` (100-lap de-index, 10 sites) -> `WriteMemory("lap_time_overflow", ...)`
- `swrObjJdge_PatchRaceTimeCap` (50:00 -> 24h cap, 3 sites) -> `WriteMemory("race_time_cap", ...)`

Each keeps its verify-the-stock-bytes-then-write guard, so the journal snapshots the true originals and `UndoOwner` would restore the stock binary exactly. No behavior change - both are still one-shot startup patches; they just gain revertibility + cross-owner overlap checking and drop the duplicated page-protection code.

**Not migrated (deliberately):** `swrModel_InitializeTextureBuffer_delta` re-points 5 `.text` immediates to a `realloc`'d texture buffer *every track load*, so the target value changes and the write repeats. The snapshot-stack journal would either grow unboundedly (a new entry per load) or need an "update my existing patch in place" primitive - exactly the path we removed in #209 review. It's a runtime data binding, not a one-shot stock->modded patch, so it stays raw for now. Same reasoning for `custom_tracks.cpp::patch_occurrence` (repeated whole-`.text` scan-replace). Happy to revisit if you'd rather add a tracked-binding primitive for those.

Built + linked clean (WinLibs i686 GCC 13.2); the three integrity-check scripts pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)