### PR TITLE
fix(audio): persist master volume, tame cutscene loudness, warn on read-only install (#221)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -518,6 +518,7 @@ Main_drawDevices 0x0050b5ac swrDrawDevices*
 Main_settings_menu_only 0x0050b5b0 int
 swrDisplay_directlyBlitVideoToScreen 0x0050b5bc int
 Main_settings_debug_hud 0x0050b5c0 int
+swrMain_introMoviesPending 0x0050b5c4 int # set to play the 3 startup Smush movies (Goldie/TextCrawl/IntroScene) in swrMain2_GuiAdvance; read by Window_PlayCinematic to pick full cinematic volume
 
 swrMainDisplay_windowed 0x0050b5c8 int
 swrDisplay_SkipNextFrameUpdate 0x0050b5cc int

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -93,6 +93,36 @@ static std::wstring ini_path = [] {
     return (std::filesystem::path(buff).parent_path() / "SW_RACER_RE.ini").wstring();
 }();
 
+// Whether the game's config/save directories are writable. The engine writes audio.cfg and the
+// profile (tgfd.dat) relative to the working directory (.\data\config, .\data\player), so an install
+// under Program Files / OneDrive without write access silently fails to persist any settings or
+// progress -- the long-standing "run as admin" workaround. Checked once at startup (read_settings_ini)
+// and surfaced as a warning in panel_audio.
+static bool g_game_dir_writable = true;
+
+static bool dir_is_writable(const char *dir) {
+    char probe[512];
+    snprintf(probe, sizeof(probe), "%s\\.swrre_writetest", dir);
+    FILE *f = fopen(probe, "wb");
+    if (!f)
+        return false;
+    fclose(f);
+    remove(probe);
+    return true;
+}
+
+static void check_game_dir_writable() {
+    // Both the audio config and the save profile must be writable for settings to persist.
+    g_game_dir_writable = dir_is_writable(".\\data\\config") && dir_is_writable(".\\data\\player");
+    if (!g_game_dir_writable) {
+        fprintf(hook_log,
+                "[audio] WARNING: .\\data\\config or .\\data\\player is not writable -- audio and "
+                "other settings will NOT be saved. Move the game out of Program Files (or a synced "
+                "OneDrive folder), or run it as administrator.\n");
+        fflush(hook_log);
+    }
+}
+
 bool read_hd_font_setting() {
     imgui_state.hd_font = GetPrivateProfileIntW(L"settings", L"hd_font", 1, ini_path.c_str());
     return imgui_state.hd_font;
@@ -160,6 +190,15 @@ void read_settings_ini() {
     float fov_scale = (float) wcstod(fov_scale_buf, nullptr);
     imgui_state.fov_scale = (fov_scale >= 0.5f && fov_scale <= 2.0f) ? fov_scale : 1.0f;
 
+    wchar_t vol_buf[32] = {0};
+    GetPrivateProfileStringW(L"settings", L"master_volume", L"1.0", vol_buf, 32, ini_path.c_str());
+    float master_volume = (float) wcstod(vol_buf, nullptr);
+    imgui_state.master_volume = (master_volume >= 0.0f && master_volume <= 1.0f) ? master_volume : 1.0f;
+    GetPrivateProfileStringW(L"settings", L"cutscene_volume", L"0.7", vol_buf, 32, ini_path.c_str());
+    float cutscene_volume = (float) wcstod(vol_buf, nullptr);
+    imgui_state.cutscene_volume =
+        (cutscene_volume >= 0.0f && cutscene_volume <= 1.0f) ? cutscene_volume : 0.7f;
+
     imgui_state.show_pod_names =
         GetPrivateProfileIntW(L"settings", L"show_pod_names", 1, ini_path.c_str());
 
@@ -170,6 +209,8 @@ void read_settings_ini() {
     // The window starts as a maximized windowed window, so only apply non-windowed modes here.
     if (g_window_mode != WINDOW_MODE_WINDOWED)
         set_window_mode(g_window_mode);
+
+    check_game_dir_writable();
 }
 
 void save_settings_ini() {
@@ -210,6 +251,11 @@ void save_settings_ini() {
                                ini_path.c_str());
     WritePrivateProfileStringW(L"settings", L"fov_scale",
                                std::to_wstring(imgui_state.fov_scale).c_str(), ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"master_volume",
+                               std::to_wstring(imgui_state.master_volume).c_str(), ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"cutscene_volume",
+                               std::to_wstring(imgui_state.cutscene_volume).c_str(), ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"hd_replacement",
                                imgui_state.HD_replacement ? L"1" : L"0", ini_path.c_str());
@@ -1308,17 +1354,38 @@ static void panel_race() {
 // one knob that scales every channel); music uses the fade state machine so the
 // toggle stops/starts playback live, not just on the next track change.
 static void panel_audio() {
-    static float master = -1.0f;
-    if (master < 0.0f)
-        master = a3dOutputGain > 0.0f ? a3dOutputGain : Main_sound_gain_const;
-    if (ImGui::SliderFloat("Master volume", &master, 0.0f, 1.0f, "%.2f"))
-        swrSound_SetOutputGain(master);
+    if (!g_game_dir_writable) {
+        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 96, 96, 255));
+        ImGui::TextWrapped(
+            "Warning: the game folder isn't writable, so audio and other settings won't be saved. "
+            "Move the game out of Program Files (or a synced OneDrive folder), or run as admin.");
+        ImGui::PopStyleColor();
+        ImGui::Separator();
+    }
 
-    ImGui::SliderFloat("Sound effects volume", &Main_sound_gain, 0.0f, 2.0f, "%.2f");
+    // Master volume drives the A3D device output gain (scales every channel). Persisted mod-side and
+    // re-applied after swrSound_Startup (which otherwise forces the gain back to 1.0 every boot).
+    if (ImGui::SliderFloat("Master volume", &imgui_state.master_volume, 0.0f, 1.0f, "%.2f")) {
+        swrSound_SetOutputGain(imgui_state.master_volume);
+        save_settings_ini();
+    }
 
-    int music_vol = sound_music_volume;
-    if (ImGui::SliderInt("Music volume", &music_vol, 0, 100))
-        sound_music_volume = (short) music_vol;
+    // Cutscene (Smush) audio runs on its own DirectSound path that ignores every other audio setting
+    // -- the startup movies at hardcoded full volume -- so this master-scaled knob is the only way to
+    // tame them. Applied in Window_PlayCinematic_delta (renderer_hook.cpp).
+    if (ImGui::SliderFloat("Cutscene volume", &imgui_state.cutscene_volume, 0.0f, 1.0f, "%.2f"))
+        save_settings_ini();
+
+    // SFX and music volume are 0..255 bytes in the save image -- the same values the in-game Audio
+    // menu sliders write, consumed by playASoundImpl and persisted with the profile in tgfd.dat.
+    // Present them as 0..100%.
+    int sfx_pct = (sound_sfx_volume * 100 + 127) / 255;
+    if (ImGui::SliderInt("Sound effects volume", &sfx_pct, 0, 100))
+        sound_sfx_volume = (uint8_t) ((sfx_pct * 255 + 50) / 100);
+
+    int music_pct = ((int) (uint8_t) sound_music_volume * 100 + 127) / 255;
+    if (ImGui::SliderInt("Music volume", &music_pct, 0, 100))
+        sound_music_volume = (short) ((music_pct * 255 + 50) / 100);
 
     bool sound_3d = Sound_enabled_3d != 0;
     if (ImGui::Checkbox("3D sound", &sound_3d))

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -53,6 +53,14 @@ typedef struct ImGuiState {
     // Camera FOV multiplier (1.0 == game default; >1 widens the view / zooms out). Aspect ratio is
     // handled in the projection (Hor+: the 4:3 vertical fov is held constant across ratios). Persisted.
     float fov_scale = 1.0f;
+
+    // Audio volumes the vanilla engine never persisted, kept mod-side (SW_RACER_RE.ini [settings]).
+    // master_volume drives the A3D device output gain (scales every swrSound channel); the engine
+    // forces that gain to 1.0 at the tail of swrSound_Startup on every boot, so we re-apply this.
+    // cutscene_volume scales the Smush cinematic audio, which runs on its own DirectSound path and
+    // otherwise ignores every audio setting (the startup movies play at hardcoded full volume).
+    float master_volume = 1.0f;  // 0..1, applied via swrSound_SetOutputGain
+    float cutscene_volume = 0.7f;// 0..1, multiplied by master_volume for Smush cinematics
 } ImGuiState;
 
 extern "C" {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -72,6 +72,7 @@ extern "C" {
 #include <Swr/swrObj.h>
 #include <Swr/swrRace.h>
 #include <Swr/swrRender.h>
+#include <Swr/swrSound.h>
 #include <Swr/swrSpline.h>
 #include <Swr/swrSprite.h>
 #include <Swr/swrText.h>
@@ -1284,11 +1285,52 @@ extern "C" void swrModel_ClearLoadedModels_delta(void) {
     hook_call_original(swrModel_ClearLoadedModels);
 }
 
+// Cutscene (Smush) audio runs on its own DirectSound path: vanilla Window_PlayCinematic sets the Smush
+// volume to a hardcoded full 0x7f for the startup movies (swrMain_introMoviesPending set) and to
+// sound_music_volume-scaled otherwise -- so cinematics ignore the master gain and the startup movies
+// blast at full. Drive it off the mod's master*cutscene knob instead: clear the intro flag (so the
+// original takes the music-scaled branch, not the hardcoded max) and load sound_music_volume with the
+// 0..255 level the original scales down to 0..127, then restore both. swrMain2_GuiAdvance clears the
+// intro flag itself and the real music volume must stand. (Main_sound == 0 still silences it inside
+// the original, so sound-off is respected.)
+extern "C" int Window_PlayCinematic_delta(char **znmFile) {
+    const int saved_intro = swrMain_introMoviesPending;
+    const short saved_music_vol = sound_music_volume;
+    float effective = imgui_state.master_volume * imgui_state.cutscene_volume;
+    effective = effective < 0.0f ? 0.0f : (effective > 1.0f ? 1.0f : effective);
+    swrMain_introMoviesPending = 0;
+    sound_music_volume = (short) (effective * 255.0f);
+
+    int result = hook_call_original(Window_PlayCinematic, znmFile);
+
+    swrMain_introMoviesPending = saved_intro;
+    sound_music_volume = saved_music_vol;
+    return result;
+}
+
+// swrSound_Startup ends with an unconditional swrSound_SetOutputGain(1.0), so the A3D device output
+// gain (the one knob scaling every channel) is reset to full on every boot -- and on every sound /
+// hi-res toggle, which re-runs Startup. The engine never persisted a master volume, so re-apply the
+// mod-side master_volume here, after the original has finished bringing sound up.
+extern "C" int swrSound_Startup_delta(void) {
+    int result = hook_call_original(swrSound_Startup);
+    if (Main_sound != 0)
+        swrSound_SetOutputGain(imgui_state.master_volume);
+    return result;
+}
+
 extern "C" void init_renderer_hooks() {
 
     // ========================================
     // Hooks required for renderer replacement
     // ========================================
+
+    // Audio fixes (issue #221): re-apply the persisted master volume after swrSound_Startup (it forces
+    // the A3D output gain to 1.0), and scale the Smush cinematic volume by master*cutscene (vanilla
+    // plays the startup movies at hardcoded full and ignores the audio settings). Both are reverse-
+    // hooked (registered in hook_generated) -> replace only.
+    hook_replace(swrSound_Startup, swrSound_Startup_delta);
+    hook_replace(Window_PlayCinematic, Window_PlayCinematic_delta);
 
 #if ENABLE_GAMEPAD_NAV
     // Feed the gamepad's D-pad / START / BACK into the game's menu + in-race input.


### PR DESCRIPTION
Addresses the audio complaints in #221.

- **Master volume resets to 100% every launch** — `swrSound_Startup` re-forces the A3D output gain to 1.0 on every boot. Now persisted (`SW_RACER_RE.ini`) and re-applied via a `swrSound_Startup` delta.
- **Cutscene audio ignores the settings / is way too loud** — the Smush player runs on its own DirectSound path and plays the startup movies at a hardcoded full `0x7f`. Now scaled by a master×cutscene knob in `Window_PlayCinematic_delta`.
- **The debug Audio panel didn't touch the real volumes** — the SFX/Music sliders now drive the actual engine bytes (`sound_sfx_volume` / `sound_music_volume`) instead of a stray 2D-gain multiplier and a mis-scaled 0..100 write; these persist with the profile (`tgfd.dat`).
- **"Requires admin / settings don't save"** — the engine writes `audio.cfg`/`tgfd.dat` relative to the game dir, so a read-only install (Program Files / OneDrive) silently drops all settings. Now detected at startup and warned in `hook.log` + the Audio panel.

Adds `master_volume`/`cutscene_volume` to the ini and one named global (`swrMain_introMoviesPending` @ 0x0050b5c4). Neutral values reproduce vanilla except the intro no longer blasts at full. Playtested (master persistence, cutscene volume, and the SFX/Music sliders).

Follow-up (not here): redirect config/save writes to `%LOCALAPPDATA%` to fully fix the read-only case.