### PR TITLE
rd*: reimplement rdFont, rdModel3 new/free-entry + fog flags, rdThing free-entry

### DIFF
--- a/src/Engine/rdFont.c
+++ b/src/Engine/rdFont.c
@@ -1,27 +1,43 @@
 #include "rdFont.h"
 
+#include "globals.h"
+
 #include <macros.h>
 
 // 0x00493df0
 void rdFont_Startup(void)
 {
-    HANG("TODO");
+    if (rdFont_bStartup != 0) {
+        return;
+    }
+    rdFont_bStartup = 1;
 }
 
 // 0x00493e10
 void rdFont_Shutdown(void)
 {
-    HANG("TODO");
+    if (rdFont_bOpen != 0) {
+        rdFont_Close();
+    }
+    if (rdFont_bStartup != 0) {
+        rdFont_bStartup = 0;
+    }
 }
 
 // 0x00493e40
 int rdFont_Open(void)
 {
-    HANG("TODO");
+    if (rdFont_bOpen != 0) {
+        return -2;
+    }
+    rdFont_bOpen = 1;
+    return 0;
 }
 
 // 0x00493e60
 void rdFont_Close(void)
 {
-    HANG("TODO");
+    if (rdFont_bOpen != 0) {
+        rdFont_bOpen = 0;
+    }
 }

--- a/src/Engine/rdThing.c
+++ b/src/Engine/rdThing.c
@@ -1,5 +1,8 @@
 #include "rdThing.h"
 
+#include "globals.h"
+#include "rdCanvas.h"
+
 #include <macros.h>
 
 // 0x00490b70
@@ -23,7 +26,24 @@ void rdThing_Free(RdThing* pThing)
 // 0x00490c10
 void rdThing_FreeEntry(RdThing* pThing)
 {
-    HANG("TODO");
+    if (pThing->type == RD_THING_MODEL3) {
+        if (pThing->paJointMatrices != NULL) {
+            (*rdroid_hostServices_ptr->free)(pThing->paJointMatrices);
+            pThing->paJointMatrices = NULL;
+        }
+        if (pThing->apTweakedAngles != NULL) {
+            (*rdroid_hostServices_ptr->free)(pThing->apTweakedAngles);
+            pThing->apTweakedAngles = NULL;
+        }
+        if (pThing->paJointAmputationFlags != NULL) {
+            (*rdroid_hostServices_ptr->free)(pThing->paJointAmputationFlags);
+            pThing->paJointAmputationFlags = NULL;
+        }
+    }
+    if (pThing->pPuppet != NULL) {
+        rdCanvas_Free((rdCanvas*)pThing->pPuppet);
+        pThing->pPuppet = NULL;
+    }
 }
 
 // int __cdecl rdThing_Draw(RdThing* prdThing, const RdMatrix* pOrient)

--- a/src/Primitives/rdModel.c
+++ b/src/Primitives/rdModel.c
@@ -4,6 +4,8 @@
 
 #include <macros.h>
 
+#include <string.h>
+
 // 0x00408f70
 void rdModel3_SetRootMaterials(RdModel3* rootModel)
 {
@@ -20,7 +22,10 @@ RdMaterial* rdMaterial_GetOrCreateDefaultMaterial(void* curr_asset_buffer_offset
 // 0x0048ee10
 void rdModel3_NewEntry(RdModel3* pModel)
 {
-    HANG("TODO");
+    memset(pModel, 0, sizeof(RdModel3));
+    strncpy(pModel->aName, "UNKNOWN", 0x3f);
+    pModel->aName[0x3f] = '\0';
+    pModel->curGeoNum = 0;
 }
 
 // 0x0048ee40
@@ -63,5 +68,9 @@ void rdModel3_DrawFace(RdFace* pFace, rdVector3* aTransformedVertices, int bIsBa
 // 0x0048FAB0
 void rdModel3_SetFogFlags(int flags)
 {
-    HANG("TODO");
+    if (flags == 0) {
+        rdFace_FogFlags = 0;
+        return;
+    }
+    rdFace_FogFlags = (flags == 1) ? RD_FF_3DO_WHIP_AIM : RD_FF_FOG_ENABLED;
 }

--- a/src/Primitives/rdModel.c
+++ b/src/Primitives/rdModel.c
@@ -2,6 +2,9 @@
 
 #include "globals.h"
 
+#include <Engine/rdMaterial.h>
+#include <Raster/rdFace.h>
+
 #include <macros.h>
 
 #include <string.h>
@@ -37,7 +40,59 @@ void rdModel3_Free(RdModel3* model)
 // 0x0048ee70
 void rdModel3_FreeEntry(RdModel3* pModel3)
 {
-    HANG("TODO");
+    rdModel3GeoSet* geoSet;
+    rdModel3Mesh* mesh;
+    RdFace* face;
+    int geoIdx;
+    int meshIdx;
+    int faceIdx;
+    int matIdx;
+
+    if (pModel3 == NULL) {
+        return;
+    }
+    geoSet = pModel3->aGeos;
+    for (geoIdx = 0; geoIdx < pModel3->numGeos; geoIdx++) {
+        for (meshIdx = 0; meshIdx < geoSet->numMeshes; meshIdx++) {
+            mesh = geoSet->aMeshes + meshIdx;
+            if (mesh->apVertices != NULL) {
+                (*rdroid_hostServices_ptr->free)(mesh->apVertices);
+            }
+            if (mesh->apTexVertices != NULL) {
+                (*rdroid_hostServices_ptr->free)(mesh->apTexVertices);
+            }
+            face = mesh->aFaces;
+            if (face != NULL) {
+                for (faceIdx = 0; faceIdx < mesh->numFaces; faceIdx++) {
+                    rdFace_FreeEntry(face);
+                    face = face + 1;
+                }
+                (*rdroid_hostServices_ptr->free)(mesh->aFaces);
+            }
+            if (mesh->aVertColors != NULL) {
+                (*rdroid_hostServices_ptr->free)(mesh->aVertColors);
+            }
+            if (mesh->aLightIntensities != NULL) {
+                (*rdroid_hostServices_ptr->free)(mesh->aLightIntensities);
+            }
+            if (mesh->aVertNormals != NULL) {
+                (*rdroid_hostServices_ptr->free)(mesh->aVertNormals);
+            }
+        }
+        if (geoSet->aMeshes != NULL) {
+            (*rdroid_hostServices_ptr->free)(geoSet->aMeshes);
+        }
+        geoSet = geoSet + 1;
+    }
+    if (pModel3->aHierarchyNodes != NULL) {
+        (*rdroid_hostServices_ptr->free)(pModel3->aHierarchyNodes);
+    }
+    for (matIdx = 0; matIdx < pModel3->numMaterials; matIdx++) {
+        rdMaterial_Free(pModel3->apMaterials[matIdx]);
+    }
+    if (pModel3->apMaterials != NULL) {
+        (*rdroid_hostServices_ptr->free)(pModel3->apMaterials);
+    }
 }
 
 // 0x0048efe0

--- a/src/types.h
+++ b/src/types.h
@@ -2757,6 +2757,11 @@ extern "C"
         int numFaces;
         float radius;
         int someFaceFlags;
+        uint8_t colorFlags; // 0x88 vertex-color apply bits (0x1 rgb, 0x2 alpha, 0x4 per-vertex); rdModel_ConvertSwrModelMesh / rdModel3Mesh_ApplySwrModelColors
+        uint8_t unk89; // 0x89 light-set selector read by rdModel3_DrawMesh
+        uint16_t unk8a;
+        void* unk8c; // read by rdModel3_DrawMesh, passed to rdModel3_DrawFace
+        void* unk90; // read by rdModel3_DrawMesh, passed to rdModel3_DrawFace
     } rdModel3Mesh;
 
     // Indy


### PR DESCRIPTION
Small `rd*` renderer reimpls:

- `rdFont.c` - completes the file: `Startup`/`Shutdown`/`Open`/`Close` (the `bStartup`/`bOpen` toggles)
- `rdModel3_NewEntry` - zero the model, name it "UNKNOWN"
- `rdModel3_SetFogFlags` - maps `flags` to `rdFace_FogFlags` using `RdFaceFlag` values (0 / `RD_FF_3DO_WHIP_AIM` / `RD_FF_FOG_ENABLED`). The `0x200` case reuses the existing enum name by value - flag if you'd rather rename that bit for SWE1R.
- `rdModel3_FreeEntry` - frees the per-mesh vertex/face/normal buffers, hierarchy nodes and materials
- `rdThing_FreeEntry` - frees the MODEL3 joint arrays + puppet canvas

Also fixes a `types.h` bug that `FreeEntry` needs: `rdModel3Mesh` was `0x88` but the binary strides the mesh array by `0x94` (`rdModel_ConvertSwrModelMesh` writes a flags byte at `+0x88`; `rdModel3_DrawMesh` reads `+0x88/+0x8c/+0x90`). Added the 3 trailing fields (only `colorFlags` named confidently; the two draw pointers left `unk` with access notes). Verified 148 via a scratch `_Static_assert`.

Built + linked clean (WinLibs GCC 13.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)