### PR TITLE
Fix full-LOD AI pod visibility + dust/splash issues

### DIFF
--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -5,15 +5,20 @@
 #include <utility>
 
 extern "C" {
-#include <Swr/swrObj.h>
+#include <Swr/swrObj.h> // swrObjTest_F0_ADDR
 #include <Swr/swrRace.h>
-#include <globals.h>
+#include <Swr/swrEvent.h> // swrEvent_GetItem/AllocateAndLoadObjs/FreeObjs (Toss pool)
+#include <Swr/swrModel.h> // swrModel_NodeInit / swrModel_NodeModifyFlags (dust-kick nodes)
+#include <swr.h>          // playASound
+#include <globals.h>      // someRootNodeChildNodes
+#include <types_enums.h>  // swrObjTest_FLAG0_LOCAL, MODELID_dustkick1_vlec
 
 extern FILE* hook_log;
 }
 
 #include "../hook_helper.h"
-#include "../imgui_utils.h" // imgui_state.mp_disable_collision (the debug-menu toggle)
+#include "../imgui_utils.h"  // imgui_state.mp_disable_collision (the debug-menu toggle)
+#include "swrModel_delta.h"  // swrModel_LoadFromId_delta (loads dust models through the GL path)
 
 // The pod's cockpit->engine cables (unk344_nodeArray[10] and [11]) are bent into a curve each
 // frame by swrRace's connection-mesh deformer (FUN_00481c30 @ 0x481c30). That deformation is
@@ -117,6 +122,143 @@ void __cdecl swrRace_ResolvePodCollision_delta(swrRace* player) {
         return;
     }
     hook_call_original((swrRace_ResolvePodCollision_t) swrRace_ResolvePodCollision_ADDR, player);
+}
+
+// --- Ground dust/splash effect: fix the AI-full-LOD contention -------------------------------------
+// swrRace_PoddAnimateVariousThings -> swrRace_SpawnGroundDustKick_Maybe spawns the ground dust/splash
+// trail. Each spawn takes a Toss entity from a FIXED 16-slot pool (swrEvent_AllocObj) and, on
+// swamp/soft terrain, plays the splash sound (playASound id 0x45). That path only runs for full-model
+// pods, so in vanilla only the local player triggers it. With ai_full_lod every AI pod is a full
+// model and runs it too, which (a) drains the shared Toss pool so the player's (and everyone's) trail
+// keeps gapping/restarting, and (b) hammers the single shared splash voice at full, non-spatial
+// volume so the player's continuous splash loop restarts over and over.
+//
+// Keep the AI dust VISUAL but stop it breaking the player's: enlarge the Toss pool (below) so AI dust
+// no longer starves it, suppress the splash SOUND for non-local pods, and keep a small reserve as
+// insurance for the local player on a fully-saturated grid.
+static const int DUST_SPLASH_SOUND_ID = 0x45; // ground dust/splash loop sound id (see the function above)
+static const int TOSS_EVENT = 0x546f7373;     // 'Toss' - the dust-kick entity pool
+static const int SWR_OBJ_FLAG_FREE = 0x100;   // swrObj.flags: slot is free/unused (see swrEvent_AllocObj)
+static const int DUST_LOCAL_RESERVE_SLOTS = 4; // Toss slots kept free for local player(s)
+
+static bool g_suppress_dust_splash_sound = false;
+
+// Free slots left in the fixed Toss pool. Walks the pool through the public event API (cheap: <=16).
+static int count_free_toss_slots() {
+    int free_slots = 0;
+    for (int i = 0;; i++) {
+        void* obj = swrEvent_GetItem(TOSS_EVENT, i);
+        if (obj == nullptr)
+            break;// past the end of the pool
+        if ((((swrObj*) obj)->flags & SWR_OBJ_FLAG_FREE) != 0)
+            free_slots++;
+    }
+    return free_slots;
+}
+
+// playASound is dormant (reverse-hooked); the original .text runs and is reached via its address.
+typedef void(__cdecl* playASound_t)(int, short, float, float, int);
+
+void __cdecl playASound_delta(int sound_id, short priority, float volume, float pitch, int flags) {
+    // Drop the ground-dust splash sound while a non-local pod is spawning its dust kick (flag set by
+    // swrRace_SpawnGroundDustKick_Maybe_delta below). Only the local player's splash should be heard;
+    // AI/remote splashes play non-spatially and restart the player's looping voice.
+    if (g_suppress_dust_splash_sound && sound_id == DUST_SPLASH_SOUND_ID)
+        return;
+    hook_call_original((playASound_t) playASound_ADDR, sound_id, priority, volume, pitch, flags);
+}
+
+typedef void(__cdecl* swrRace_SpawnGroundDustKick_Maybe_t)(swrRace*, float*, float, float, float,
+                                                           float, int);
+
+void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* transform, float sx,
+                                                     float sy, float sz, float param_6,
+                                                     int param_7) {
+    const bool is_local = player != nullptr && (player->flags0 & swrObjTest_FLAG0_LOCAL) != 0;
+
+    if (!is_local) {
+        // Reserve headroom so a full grid of AI dust never starves the local player's trail.
+        if (count_free_toss_slots() <= DUST_LOCAL_RESERVE_SLOTS)
+            return;
+        // Keep the AI dust visual, but silence its splash sound for the duration of this call.
+        g_suppress_dust_splash_sound = true;
+        hook_call_original(
+            (swrRace_SpawnGroundDustKick_Maybe_t) swrRace_SpawnGroundDustKick_Maybe_ADDR, player,
+            transform, sx, sy, sz, param_6, param_7);
+        g_suppress_dust_splash_sound = false;
+        return;
+    }
+
+    hook_call_original((swrRace_SpawnGroundDustKick_Maybe_t) swrRace_SpawnGroundDustKick_Maybe_ADDR,
+                       player, transform, sx, sy, sz, param_6, param_7);
+}
+
+// Enlarged dust-kick pool. The stock swrObjToss_AddDustKickModelsToScene builds a 16-slot Toss pool
+// backed by a fixed 16-entry node array (each Toss draws its node from dustWhirlChildNodesPtr[id], so
+// the pool count and the node array must match). 16 is fine when only the player kicks up dust, but
+// with ai_full_lod every pod does, so the pool needs to be bigger. This delta rebuilds the setup with
+// DUST_POOL_SIZE slots and delta-owned node buffers. Each Toss still needs its OWN dust-model copy
+// (swrObjToss_F3 tints the per-particle material), so the model is loaded once per slot -- the stock
+// function does the same. A NODE_TRANSFORMED_WITH_PIVOT node writes slots [0..3] in
+// swrModel_NodeInit, so each wrapper reserves 4 contiguous swrModel_Node slots.
+// Sized so the shared pool isn't exhausted once far AI also spawn dust (see the reserve in
+// swrRace_SpawnGroundDustKick_Maybe_delta): when free slots hit the reserve, ALL AI skip that frame
+// and their trails gap while the (unchecked) player stays smooth. More headroom keeps AI continuous.
+static const int DUST_POOL_SIZE = 128;
+static swrModel_Node g_dustWrappers[DUST_POOL_SIZE * 4];
+static swrModel_Node* g_dustChildNodes[DUST_POOL_SIZE];
+static swrModel_Node* g_dustChildArray2[DUST_POOL_SIZE];
+static swrModel_Node g_dustRootNode;
+
+void swrObjToss_AddDustKickModelsToScene_delta() {
+    swrEvent_AllocateAndLoadObjs(TOSS_EVENT, DUST_POOL_SIZE);
+    swrEvent_FreeObjs(TOSS_EVENT);
+
+    for (int i = 0; i < DUST_POOL_SIZE; i++) {
+        // Load through the delta so the model registers its asset range like every other GL-path
+        // model (the stock function calls swrModel_LoadFromId, which is detoured to this).
+        swrModel_Header* header = swrModel_LoadFromId_delta(MODELID_dustkick1_vlec);
+        if (header == nullptr) {
+            g_dustChildNodes[i] = nullptr;
+            continue;
+        }
+        swrModel_Node* wrapper = &g_dustWrappers[i * 4];
+        swrModel_NodeInit(wrapper, NODE_TRANSFORMED_WITH_PIVOT);
+        wrapper->num_children = 1;
+        wrapper->children.nodes = &g_dustChildArray2[i];
+        g_dustChildArray2[i] = header->entries[0].node;
+        g_dustChildNodes[i] = wrapper;
+        swrModel_NodeModifyFlags(wrapper, 2, -4, 0x10, 3);// start hidden (shown on spawn)
+    }
+
+    swrModel_NodeInit(&g_dustRootNode, NODE_BASIC);
+    g_dustRootNode.num_children = DUST_POOL_SIZE;
+    g_dustRootNode.children.nodes = g_dustChildNodes;
+    someRootNodeChildNodes[6] = &g_dustRootNode;
+    swrObjToss_SetDustKickChildNodesPtr(g_dustChildNodes);
+}
+
+// Widen far-AI ground contact so distant AI kick up dust. Distant non-local pods run simplified
+// on-rails physics, so their ground-contact / shadow pipeline (which the dust spawns from) is not
+// refreshed and no dust appears beyond a short range. Every gate in that pipeline keys on unk1998
+// (linear camera distance, set each frame by swrObjTest_F0). After F0 sets it, clamp it down for
+// visible non-local pods so their ground contact + shadow (and thus dust) run like a nearby pod.
+// Only within FAR_AI_GROUND_RADIUS, so off-screen pods keep their cheap LOD. This runs more physics
+// on those pods (the AI-LOD "gate 2"): the same full ground handling they already use up close, just
+// applied farther out -- so behavior stays consistent, at a per-frame cost that scales with how many
+// AI are on screen. Tunables: raise CLAMP (>=100 skips the hover-pad detail) or lower RADIUS to trade
+// dust range for performance.
+static const int FAR_AI_GROUND_CLAMP = 90;     // treat a widened pod as this camera distance
+static const int FAR_AI_GROUND_RADIUS = 20000; // only widen non-local pods within this real distance
+
+typedef void(__cdecl* swrObjTest_F0_t)(swrRace*);
+
+void __cdecl swrObjTest_F0_delta(swrRace* player) {
+    hook_call_original((swrObjTest_F0_t) swrObjTest_F0_ADDR, player);
+    if (player != nullptr && (player->flags0 & swrObjTest_FLAG0_LOCAL) == 0 &&
+        player->unk1998 > FAR_AI_GROUND_CLAMP && player->unk1998 < FAR_AI_GROUND_RADIUS) {
+        player->unk1998 = FAR_AI_GROUND_CLAMP;
+    }
 }
 
 float swrRace_GetCableBendAmplitude(const swrModel_Node* node) {

--- a/dinput_hook/game_deltas/swrRace_delta.h
+++ b/dinput_hook/game_deltas/swrRace_delta.h
@@ -14,6 +14,22 @@ void swrRace_AnimateDisplayPod_delta(swrModel_Node** nodes, void* transform, int
 // local player passes through other racers; track/wall collision is kept. Hooked by address.
 void swrRace_ResolvePodCollision_delta(swrRace* player);
 
+// ai_full_lod dust/splash fix (hooked by address, both dormant/reverse-hooked originals):
+// - swrRace_SpawnGroundDustKick_Maybe_delta: for non-local pods, reserve Toss-pool headroom (so AI
+//   dust never starves the player's trail) and suppress the splash sound.
+// - playASound_delta: drops the dust-splash sound while a non-local dust kick is being spawned.
+void swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* transform, float sx, float sy,
+                                             float sz, float param_6, int param_7);
+void playASound_delta(int sound_id, short priority, float volume, float pitch, int flags);
+
+// Rebuilds the dust-kick Toss pool with more slots (stock is 16) so full-LOD AI dust no longer
+// starves the player's trail. Replaces swrObjToss_AddDustKickModelsToScene (hooked by address).
+void swrObjToss_AddDustKickModelsToScene_delta();
+
+// Widens far-AI ground contact (clamps unk1998 for visible non-local pods) so distant AI run their
+// full ground/shadow pipeline and kick up dust. Hooks swrObjTest_F0 by address.
+void swrObjTest_F0_delta(swrRace* player);
+
 // Cable-curve amplitude for a curently-curved cable node (-1.0 = not a curved cable). Consumed by
 // the renderer to bend the cable mesh in the GL path.
 float swrRace_GetCableBendAmplitude(const swrModel_Node* node);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -314,11 +314,15 @@ void collect_all_visual_textures(const swrViewport &current_vp, bool skip_pod_te
     if (!node)
         return;
 
-    if ((current_vp.node_flags1_exact_match_for_rendering & node->flags_1) !=
-        current_vp.node_flags1_exact_match_for_rendering)
-        return;
-
-    if ((current_vp.node_flags1_any_match_for_rendering & node->flags_1) == 0)
+    // Mirror debug_render_node's visibility gate, including the foreign-hidden-pod override, so a pod
+    // that this renderer force-draws (a remote/AI pod its own camera hid) still has its textures
+    // enumerated for replacement/upload.
+    const bool exact_match_fail =
+        (current_vp.node_flags1_exact_match_for_rendering & node->flags_1) !=
+        current_vp.node_flags1_exact_match_for_rendering;
+    const bool any_match_fail =
+        (current_vp.node_flags1_any_match_for_rendering & node->flags_1) == 0;
+    if ((exact_match_fail || any_match_fail) && !is_foreign_hidden_pod_root(node))
         return;
 
     if (node->type == NODE_MESH_GROUP) {

--- a/dinput_hook/node_utils.cpp
+++ b/dinput_hook/node_utils.cpp
@@ -96,11 +96,13 @@ std::optional<MODELID> find_model_id_for_node(const swrModel_Node *node) {
         asset_pointer_to_model.begin(), asset_pointer_to_model.end(), raw_ptr,
         [](char *raw_ptr, const AssetPointerToModel &elem) { return raw_ptr < elem.asset_pointer_end; });
 
-    if (it == asset_pointer_to_model.end())
-        std::abort();// TODO: this should never happen, maybe error?
-
-    if (raw_ptr < it->asset_pointer_begin)
-        return std::nullopt;// internal static node
+    // Not part of any loaded asset: a static/structural node that lives outside the asset buffer.
+    // Below the highest range (between ranges) OR past all ranges -- the latter covers delta-owned
+    // node pools allocated in the DLL's own (high) address space, e.g. the enlarged dust-kick pool
+    // in swrObjToss_AddDustKickModelsToScene_delta. Treat both as internal nodes (no model id) rather
+    // than aborting; find_asset_range_for_node already handles them the same way.
+    if (it == asset_pointer_to_model.end() || raw_ptr < it->asset_pointer_begin)
+        return std::nullopt;
 
     return it->id;
 }
@@ -177,6 +179,19 @@ swrRace *find_entity_for_node(const swrModel_Node *node) {
         return nullptr;
 
     return it->entity;
+}
+
+bool is_foreign_hidden_pod_root(const swrModel_Node *node) {
+    swrRace *owner = find_entity_for_node(node);
+    if (owner == nullptr)
+        return false;
+    if (owner->flags0 & swrObjTest_FLAG0_LOCAL)
+        return false;// the viewport's own pod: honor the first-person/bumper hide
+    // Match the stock re-show condition (swrRace_PoddAnimateEngines): hidden-but-present, not gone.
+    if ((owner->flags0 & (swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_DEAD)) !=
+        swrObjTest_FLAG0_POD_HIDDEN)
+        return false;
+    return owner->unk344_nodeArray != nullptr && node == owner->unk344_nodeArray[0];
 }
 
 void apply_node_transform(rdMatrix44 &model_mat, const swrModel_Node *node,

--- a/dinput_hook/node_utils.h
+++ b/dinput_hook/node_utils.h
@@ -61,5 +61,13 @@ void rebuild_pod_node_owners();
 // part of any racer's pod (track/env/internal nodes, or not in a race).
 swrRace *find_entity_for_node(const swrModel_Node *node);
 
+// True when `node` is the pod-root node of a racer that is NOT the local player and whose pod its own
+// camera is hiding (POD_HIDDEN set, DEAD clear) -- a pod the stock game re-shows to other viewports
+// in swrViewport_Render, which the OpenGL renderer replaces and skips. Scene traversal uses this to
+// draw such a pod anyway (otherwise a remote player in bumper cam, or an AI on the post-race autopilot
+// cam, is invisible to everyone). Keyed on the exact node the game hides (owner->unk344_nodeArray[0])
+// so the sub-nodes hidden on purpose (cockpit interior, shadows) are not un-hidden with it.
+bool is_foreign_hidden_pod_root(const swrModel_Node *node);
+
 void apply_node_transform(rdMatrix44 &model_mat, const swrModel_Node *node,
                           rdVector3 *viewport_position);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -664,12 +664,25 @@ void debug_render_node(const swrViewport &current_vp, const swrModel_Node *node,
     if (!node)
         return;
 
-    if ((current_vp.node_flags1_exact_match_for_rendering & node->flags_1) !=
-        current_vp.node_flags1_exact_match_for_rendering)
-        return;
-
-    if ((current_vp.node_flags1_any_match_for_rendering & node->flags_1) == 0)
-        return;
+    const bool exact_match_fail =
+        (current_vp.node_flags1_exact_match_for_rendering & node->flags_1) !=
+        current_vp.node_flags1_exact_match_for_rendering;
+    const bool any_match_fail =
+        (current_vp.node_flags1_any_match_for_rendering & node->flags_1) == 0;
+    if (exact_match_fail || any_match_fail) {
+        // The scene's per-node visibility flags hide this node. We honor that, with one exception:
+        // a racer's pod that its OWN camera hides. swrRace_PoddAnimateEngines clears the pod root's
+        // visible bit whenever the pod is in a hide-from-own-view camera mode (first-person / bumper
+        // cam, flagged POD_HIDDEN). The stock game re-shows that pod in the OTHER viewport inside
+        // swrViewport_Render -- but this renderer replaces swrViewport_Render and skips that re-show,
+        // and the stock re-show only ever covered split-screen LOCAL players anyway. So a pod hidden
+        // by its own camera stays invisible in every view: a remote player who switches to bumper
+        // cam vanishes for everyone else, and AI racers on the post-race autopilot cam (which cycles
+        // through a bumper mode) disappear once ai_full_lod gives them a full pod model. If this is
+        // the hidden pod root of a NON-local racer, draw it anyway.
+        if (!is_foreign_hidden_pod_root(node))
+            return;
+    }
 
 #ifndef NDEBUG
     for (NodeMember &member: node_members) {
@@ -1586,6 +1599,21 @@ extern "C" void init_renderer_hooks() {
     // reimplemented); the original is called back through swrRace_ResolvePodCollision_ADDR.
     hook_function("swrRace_ResolvePodCollision", (uint32_t) swrRace_ResolvePodCollision_ADDR,
                   (uint8_t *) swrRace_ResolvePodCollision_delta);
+
+    // ai_full_lod dust/splash contention fix: every full-LOD AI pod now spawns the ground dust
+    // trail + splash sound, draining the fixed 16-slot Toss pool and hammering the shared splash
+    // voice so the player's trail/sound restarts. Reserve pool headroom + silence the sound for
+    // non-local pods. Both originals are dormant (reverse-hooked); hooked by address.
+    hook_function("swrRace_SpawnGroundDustKick_Maybe",
+                  (uint32_t) swrRace_SpawnGroundDustKick_Maybe_ADDR,
+                  (uint8_t *) swrRace_SpawnGroundDustKick_Maybe_delta);
+    hook_function("playASound", (uint32_t) playASound_ADDR, (uint8_t *) playASound_delta);
+    // Enlarge the dust-kick Toss pool so full-LOD AI dust doesn't starve the player's trail.
+    hook_function("swrObjToss_AddDustKickModelsToScene",
+                  (uint32_t) swrObjToss_AddDustKickModelsToScene_ADDR,
+                  (uint8_t *) swrObjToss_AddDustKickModelsToScene_delta);
+    // Widen far-AI ground contact so distant AI kick up dust (clamps unk1998 for visible AI).
+    hook_function("swrObjTest_F0", (uint32_t) swrObjTest_F0_ADDR, (uint8_t *) swrObjTest_F0_delta);
 
     // 100-lap support: de-index swrObjJdge_F2's fixed 5-slot per-lap split-time array so lap
     // counts above 5 no longer corrupt the score struct (the real hardcoded 5-lap limit). The

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -63,6 +63,10 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_AI_RIVAL_AHEAD = 0x8000, // AI pacing to the rival ahead
     swrObjTest_FLAG0_AI_RIVAL_BEHIND = 0x10000, // AI pacing to the rival behind
     swrObjTest_FLAG0_TP_TO_SPLINE = 0x20000, // teleport to spline point requested
+    swrObjTest_FLAG0_POD_HIDDEN = 0x80000, // hide the pod in its OWN camera view (first-person /
+    // bumper cam, and demo mode). swrRace_PoddAnimateEngines clears the pod root node's visible
+    // flag when this is set (and DEAD is clear); vanilla re-shows the pod to the OTHER viewport in
+    // swrViewport_Render. Cleared each frame in swrObjTest_F0.
     swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost
     swrObjTest_FLAG0_BOOSTING = 0x800000, // boost active
     swrObjTest_FLAG0_HIT_BOTTOM = 0x1000000, // hard-landing debounce ('HittBotm' event)


### PR DESCRIPTION
Two related full-LOD-AI pod fixes, both in the dinput_hook delta layer (no reimpl bodies touched; one named flag added to types_enums.h).

**Pods invisible in first-person/bumper cam.** The game hides a pod's node when its own camera is in first-person/bumper, and vanilla re-shows it per viewport in `swrViewport_Render` — which the GL renderer replaces and skips. So a remote MP player in bumper cam, or an AI on the post-race autopilot cam (with a full-LOD model), vanished for everyone else. `debug_render_node` now redraws a non-local racer's hidden pod; your own pod still hides in first-person. Adds `swrObjTest_FLAG0_POD_HIDDEN`.

**AI full-LOD dust/splash.** With full-LOD models every AI runs the ground dust path, which drained the 16-slot dust-kick pool (choppy trails) and retriggered the single shared splash voice at full volume (player's loop restarting). Enlarged the pool, made the splash sound local-player-only, reserved headroom for the local player, and widened far-AI ground contact so distant AI kick up dust too. Also stops `find_model_id_for_node` aborting on the delta-owned dust nodes (which live past all asset ranges).

Playtested SP incl. the post-race autopilot finish, dusty tracks, and bumper cam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)