### PR TITLE
multiplayer: enable "disable pod collision" by default

### DIFF
--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -176,7 +176,7 @@ void read_settings_ini() {
     imgui_state.ui_scale = (ui_scale >= 0.5f && ui_scale <= 2.0f) ? ui_scale : 1.0f;
 
     imgui_state.mp_disable_collision =
-        GetPrivateProfileIntW(L"settings", L"mp_disable_collision", 0, ini_path.c_str());
+        GetPrivateProfileIntW(L"settings", L"mp_disable_collision", 1, ini_path.c_str());
 
     imgui_state.cache_meshes =
         GetPrivateProfileIntW(L"settings", L"cache_meshes", 1, ini_path.c_str());

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -38,7 +38,7 @@ typedef struct ImGuiState {
     bool show_fps_overlay = false;// pinned top-right FPS readout + frame-time graph
     bool show_fps_graph = false;// graph beneath the FPS overlay number (opt-in)
     bool show_pod_names = true;// draw the overhead racer labels (MP player names / SP place numbers)
-    bool mp_disable_collision = false;// in multiplayer, skip pod-to-pod collision for the local
+    bool mp_disable_collision = true;// in multiplayer, skip pod-to-pod collision for the local
                                    // player so they pass through other racers (track collision kept)
     bool mp_allow_upgrades = false;// master gate: in multiplayer, layer the player-chosen upgrades
                                    // below onto the local pod (vanilla MP races everyone on raw base


### PR DESCRIPTION
Per #236 (0.16 roadmap): flip the multiplayer "disable pod collision" toggle to on by default.

Both defaults move together — the `ImGuiState` initializer and the `SW_RACER_RE.ini` read fallback — so a fresh install races with pass-through pods in multiplayer.

- Single-player untouched (the delta gates on `multiplayer_enabled`).
- Users with an existing `SW_RACER_RE.ini` keep whatever they had saved.

Closes the last checklist item tim flagged in #236.