### PR TITLE
reimpl: 17 leaf functions (swrText / swrRender / rd / stdMemory / swrSprite)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -568,6 +568,16 @@ swrLoader_texture_file 0x0050c094 FILE*
 swrLoader_model_file 0x0050c098 FILE*
 
 swrText_halfScale 0x0050c0ac uint8_t # 1 = render text at half scale (the 0.5 at 0x004ac64c); set by the "~F" code in swrText_RenderString, read by rdProcEntry_Add2DQuad2
+swrText_bboxMinY 0x0050c09c int16_t # accumulated on-screen text bounding box (empty when bboxMaxX < bboxMinX), grown by rdProcEntry_Add2DQuad2
+swrText_bboxMinX 0x0050c0a0 int16_t
+swrText_bboxMaxY 0x0050c0a4 int16_t
+swrText_bboxMaxX 0x0050c0a8 int16_t
+swrText_clipEnabled 0x0050c0b0 uint8_t # 1 = scissor glyphs against swrText_clip{Left,Top,Right,Bottom}; set by swrText_RenderEntries1
+swrText_orientation 0x0050c0c8 int # 0xbf = diagonal UV flip in rdProcEntry_Add2DQuad2; set by swrText_DrawString
+swrText_clipLeft 0x00e99750 int # text scissor rect, set by swrText_RenderEntries1
+swrText_clipTop 0x00e99754 int
+swrText_clipRight 0x00e99758 int
+swrText_clipBottom 0x00e9975c int
 currentTextPosX 0x0050C0B8 int16_t
 currentTextPosY 0x0050C0BA int16_t
 previousTextPosX 0x0050C0BC int16_t

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -885,7 +885,7 @@ Window_hinstance 0x0052ee74 HINSTANCE
 stdConsole_hConsoleOutput 0x0052ee78 HANDLE
 stdConsole_wAttributes 0x0052ee7c WORD
 
-daAlloc_struct 0x0052ee98 void*
+daAlloc_struct 0x0052ee98 daArena[1057]
 
 rdCache_aProcFaces 0x005330c0 RdCacheProcEntry[1] # unk size
 

--- a/src/Engine/rdMaterial.c
+++ b/src/Engine/rdMaterial.c
@@ -80,7 +80,8 @@ void rdMaterial_SaturateTextureR4G4B4A4(RdMaterial* mat)
 // 0x00432190
 void rdModel_SetCurrentMaterial(RdMaterial* a1)
 {
-    HANG("TODO");
+    rdModel_CurrentMaterialSet = 1;
+    rdModel_CurrentMaterial = a1;
 }
 
 // 0x00432580

--- a/src/Engine/rdroid.c
+++ b/src/Engine/rdroid.c
@@ -42,17 +42,17 @@ void rdClose(void)
 // 0x00490a20
 void rdSetRenderOptions(RdDroidFlags options)
 {
-    HANG("TODO");
+    rdroid_g_curRenderOptions = options;
 }
 
 // 0x00490a30
 void rdSetGeometryMode(RdGeometryMode mode)
 {
-    HANG("TODO");
+    rdroid_g_curGeometryMode = mode;
 }
 
 // 0x00490a40
 void rdSetLightingMode(RdLightMode mode)
 {
-    HANG("TODO");
+    rdroid_g_curLightingMode = mode;
 }

--- a/src/General/stdMemory.c
+++ b/src/General/stdMemory.c
@@ -1,27 +1,202 @@
 #include "stdMemory.h"
 
 #include "macros.h"
+#include "globals.h"
+#include "engine_config.h"
 
 #include <Platform/cstdlib.h>
+#include <string.h>
 
+// Arena allocator for small blocks (<= DAALLOC_SMALL_ALLOC_MAX). Serves the request from a
+// per-page free list by best fit, splitting the chosen free block and refreshing the arena's
+// cached largest-free-block hint; grows a new page (or falls back to daSmallAlloc) when needed.
 // 0x0048d7e0
 void* daAlloc(uint32_t size)
 {
-    HANG("TODO");
-    return NULL;
+    if (DAALLOC_SMALL_ALLOC_MAX < size) {
+        return daSmallAlloc(size);
+    }
+
+    uint32_t needed = (size + 3) & ~3u;// round the payload up to 4 bytes
+    uint32_t needTotal = needed + 8;// + block header
+
+    // Find an in-use arena whose cached free block is big enough (stop at the first free slot).
+    int slot = 0;
+    while (slot < DAALLOC_ARENA_COUNT) {
+        if (daAlloc_struct[slot].inUse == 0 || needed <= daAlloc_struct[slot].bestFreeSize) {
+            break;
+        }
+        slot++;
+    }
+
+    // None fit: claim a free/empty slot and carve it a fresh page.
+    if (slot == DAALLOC_ARENA_COUNT || daAlloc_struct[slot].inUse == 0) {
+        slot = 0;
+        while (slot < DAALLOC_ARENA_COUNT) {
+            if (daAlloc_struct[slot].inUse == 0 || daAlloc_struct[slot].page == NULL) {
+                break;
+            }
+            slot++;
+        }
+        if (slot == DAALLOC_ARENA_COUNT) {
+            return daSmallAlloc(needed);
+        }
+
+        daBlock* page = (daBlock*) malloc(DAALLOC_PAGE_SIZE);
+        if (page == NULL) {
+            return daSmallAlloc(needed);
+        }
+
+        daArena* arena = &daAlloc_struct[slot];
+        arena->page = page;
+        arena->bestFree = page;
+        arena->bestFreeSize = DAALLOC_PAGE_SIZE - 16;
+        arena->inUse = 1;
+
+        // one free block spanning the page, followed by a zero-size end sentinel
+        page->size = DAALLOC_PAGE_SIZE - 8;
+        page->prevSize = 0;
+        page->owner = arena;
+        daBlock* sentinel = (daBlock*) ((char*) page + (DAALLOC_PAGE_SIZE - 8));
+        sentinel->size = 0;
+        sentinel->prevSize = DAALLOC_PAGE_SIZE - 8;
+        sentinel->owner = arena;
+    }
+
+    daArena* arena = &daAlloc_struct[slot];
+
+    // best fit: the free block that leaves the smallest leftover
+    daBlock* best = NULL;
+    uint16_t bestLeftover = DAALLOC_PAGE_SIZE;
+    for (daBlock* b = (daBlock*) arena->page; b->size != 0;) {
+        uint16_t step = b->size;
+        if ((b->size & DABLOCK_ALLOCATED) == 0) {
+            uint16_t leftover = (uint16_t) (b->size - needTotal);
+            if (leftover < bestLeftover) {
+                best = b;
+                bestLeftover = leftover;
+            }
+        } else {
+            step &= DABLOCK_SIZE_MASK;
+        }
+        b = (daBlock*) ((char*) b + step);
+    }
+
+    // allocate, splitting the remainder into a new free block
+    uint16_t origSize = best->size;
+    best->size = (uint16_t) needTotal | DABLOCK_ALLOCATED;
+    if (origSize != needTotal) {
+        daBlock* split = (daBlock*) ((char*) best + needTotal);
+        split->size = (uint16_t) (origSize - needTotal);
+        split->prevSize = (uint16_t) needTotal;
+        ((daBlock*) ((char*) best + origSize))->prevSize = (uint16_t) (origSize - needTotal);
+    }
+    best->owner = arena;
+
+    // if we consumed the cached largest-free block, rescan for the new largest
+    if (best == arena->bestFree) {
+        daBlock* largest = NULL;
+        uint16_t largestSize = 8;
+        for (daBlock* b = (daBlock*) arena->page; b->size != 0;) {
+            uint16_t step = b->size;
+            if ((b->size & DABLOCK_ALLOCATED) == 0) {
+                if (largestSize < b->size) {
+                    largestSize = b->size;
+                    largest = b;
+                }
+            } else {
+                step &= DABLOCK_SIZE_MASK;
+            }
+            b = (daBlock*) ((char*) b + step);
+        }
+        arena->bestFree = largest;
+        arena->bestFreeSize = (largestSize > 8) ? (uint16_t) (largestSize - 8) : 0;
+    }
+
+    return best + 1;
 }
 
+// Free a daAlloc / daSmallAlloc block. Standalone blocks (owner == NULL) go straight to free();
+// arena blocks are coalesced with any free neighbours and the arena's largest-free hint refreshed,
+// releasing the whole page back to free() once it is entirely free again.
 // 0x0048d9a0
 void daFree(void* alloc)
 {
-    HANG("TODO");
+    daBlock* block = (daBlock*) ((char*) alloc - 8);
+    daArena* owner = block->owner;
+    if (owner == NULL) {
+        free(block);
+        return;
+    }
+
+    if ((block->size & DABLOCK_ALLOCATED) == 0 ||
+        (uint16_t) (owner - &daAlloc_struct[0]) > DAALLOC_ARENA_COUNT - 1) {
+        (*stdPlatform_hostServices_ptr->warningPrint)(
+            "Attempting to dispose a bogus or already-disposed-of block!");
+        return;
+    }
+
+    uint32_t merged = block->size & DABLOCK_SIZE_MASK;
+    // coalesce with the following block if it is free
+    daBlock* next = (daBlock*) ((char*) block + merged);
+    if ((next->size & DABLOCK_ALLOCATED) == 0) {
+        merged += next->size;
+    }
+    // coalesce with the preceding block if it is free
+    daBlock* prev = (daBlock*) ((char*) block - block->prevSize);
+    if ((prev->size & DABLOCK_ALLOCATED) == 0) {
+        merged += prev->size;
+        block = prev;
+    }
+
+    uint16_t mergedSize = (uint16_t) merged;
+    block->size = mergedSize;
+    ((daBlock*) ((char*) block + mergedSize))->prevSize = mergedSize;
+
+    uint32_t usable = mergedSize - 8;
+    if (owner->bestFreeSize < usable) {
+        if (mergedSize == DAALLOC_PAGE_SIZE - 8) {// the block now spans the whole page
+            free(owner->page);
+            owner->page = NULL;
+            owner->bestFreeSize = 0;
+            owner->bestFree = NULL;
+            return;
+        }
+        owner->bestFreeSize = usable;
+        owner->bestFree = block;
+    }
 }
 
+// Resize a daAlloc / daSmallAlloc block: allocate the new size, copy across the smaller of the
+// request and the old payload, then free the old block. NULL old behaves as daAlloc; size 0 as daFree.
 // 0x0048da80
 void* daRealloc(void* old, uint32_t size)
 {
-    HANG("TODO");
-    return NULL;
+    if (old == NULL) {
+        return daAlloc(size);
+    }
+    if (size == 0) {
+        daFree(old);
+        return NULL;
+    }
+
+    void* neu = daAlloc(size);
+
+    uint32_t oldSize;
+    if (((daBlock*) ((char*) old - 8))->owner == NULL) {
+        oldSize = *(uint32_t*) ((char*) old - 8);// daSmallAlloc: full size_t size header
+    } else {
+        oldSize = *(uint16_t*) ((char*) old - 8) & ~DABLOCK_ALLOCATED;// arena block size (mask alloc bit)
+    }
+
+    if (neu == NULL) {
+        return NULL;
+    }
+
+    uint32_t copy = (oldSize - 8 <= size) ? (oldSize - 8) : size;
+    memcpy(neu, old, copy);
+    daFree(old);
+    return neu;
 }
 
 // Fallback allocator for requests the daAlloc arena can't serve (oversized, or all arena

--- a/src/General/stdMemory.c
+++ b/src/General/stdMemory.c
@@ -2,6 +2,8 @@
 
 #include "macros.h"
 
+#include <Platform/cstdlib.h>
+
 // 0x0048d7e0
 void* daAlloc(uint32_t size)
 {
@@ -22,9 +24,17 @@ void* daRealloc(void* old, uint32_t size)
     return NULL;
 }
 
+// Fallback allocator for requests the daAlloc arena can't serve (oversized, or all arena
+// slots full): a plain malloc of size + an 8-byte header. The header's second word is 0,
+// which is the owner-arena pointer daFree checks to tell a standalone block (free()) from
+// an arena block. Returns the user pointer 8 bytes past the header.
 // 0x0048db10
 void* daSmallAlloc(int size)
 {
-    HANG("TODO");
-    return NULL;
+    size_t* alloc = (size_t*)malloc(size + 8);
+    if (alloc == NULL)
+        return NULL;
+    alloc[0] = size + 8;
+    alloc[1] = 0;
+    return alloc + 2;
 }

--- a/src/Swr/swrRender.c
+++ b/src/Swr/swrRender.c
@@ -2,6 +2,8 @@
 
 #include "globals.h"
 
+#include <Primitives/rdModel.h>
+#include <Win95/DirectX.h>
 #include <macros.h>
 
 // 0x00409290
@@ -16,16 +18,31 @@ void rdFace_ConfigureFogStartEnd(int16_t start, int16_t end)
     HANG("TODO");
 }
 
+// Set the fog color from 0-255 component values, then push it (with the current
+// fogStart/fogEnd range) to the D3D fog state. Alpha is stored in fogColor.w but not
+// forwarded to Direct3d_ConfigFog.
 // 0x00409450
 void Direct3d_ConfigFog2(short r, short g, short b, short a)
 {
-    HANG("TODO");
+    fogColor.x = (float)(int)r * oneOver255f;
+    fogColor.y = (float)(int)g * oneOver255f;
+    fogColor.z = (float)(int)b * oneOver255f;
+    fogColor.w = (float)(int)a * oneOver255f;
+    Direct3d_ConfigFog(fogColor.x, fogColor.y, fogColor.z, fogStart, fogEnd);
 }
 
+// Enable/disable fog. mode==0 clears all fog flags (and returns 0); otherwise the
+// hardware-supported fog flags are applied and returned.
 // 0x004094E0
 int rdFace_SetFogEnabled(int mode)
 {
-    HANG("TODO");
+    if (mode == 0) {
+        rdModel3_SetFogFlags(0);
+        return mode;
+    }
+    uint32_t flags = rdFace_FogFlagsSupportedByHardware;
+    rdModel3_SetFogFlags(rdFace_FogFlagsSupportedByHardware);
+    return flags;
 }
 
 // 0x00409510

--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -2,10 +2,12 @@
 
 #include "macros.h"
 #include "globals.h"
+#include "swr.h"
 #include "swrLoader.h"
 #include "swrUI.h"
 
 #include <Engine/rdMaterial.h>
+#include <Raster/rdCache.h>
 #include <Win95/stdConsole.h>
 
 extern swrSpriteTexture* FUN_00445b40();
@@ -471,13 +473,107 @@ int16_t swrSprite_setCurrentTextPos(int16_t x, int16_t y)
 // 0x0042D930
 short swrSprite_getCurrentTextPos(int16_t* x, int16_t* y)
 {
-    HANG("TODO");
+    *x = currentTextPosX;
+    *y = currentTextPosY;
+    return currentTextPosY;
 }
 
+// The text-glyph quad emitter. Takes a design-space rect (x0,y0 = pos, x1,y1 = size) and a
+// texel-space UV rect, scales the rect from design space to the actual framebuffer, grows the
+// accumulated on-screen text bounding box (swrText_bbox*), optionally half-scales the glyph,
+// scissors against the text clip rect (sliding the UVs to match the clamped edges), applies the
+// 0xbf diagonal-flip orientation, then hands the final screen+UV quad to rdProcEntry_Add2DQuad.
 // 0x0042D990
 void rdProcEntry_Add2DQuad2(short a1, short a2, short a3, short a4, short a5, short a6, short a7, short a8)
 {
-    HANG("TODO");
+    // Design (640x480-ish) -> framebuffer scale; a negative reciprocal falls back to identity.
+    float scaleX = (float)swrDisplay_screenWidth * (float)swrText_designWidthRecip;
+    float scaleY = (float)swrDisplay_screenHeight * (float)swrText_designHeightRecip;
+    if (scaleX < 0.0f)
+        scaleX = 1.0f;
+    if (scaleY < 0.0f)
+        scaleY = 1.0f;
+
+    short dx = a1 - a3;
+    short dy = a2 - a4;
+    float left = (float)(int)dx;
+    float top = (float)(int)dy;
+    float right = (float)(int)(short)(a5 + dx);
+    float bottom = (float)(int)(short)(a6 + dy);
+
+    float minXf = scaleX * left;
+    float minYf = scaleY * top;
+    float maxXf = scaleX * right;
+    float maxYf = scaleY * bottom;
+
+    // Grow the accumulated text bounding box (empty when bboxMaxX < bboxMinX).
+    if (swrText_bboxMaxX < swrText_bboxMinX) {
+        swrText_bboxMinX = (short)(int)minXf;
+        swrText_bboxMinY = (short)(int)minYf;
+        swrText_bboxMaxX = (short)(int)maxXf;
+        swrText_bboxMaxY = (short)(int)maxYf;
+    } else {
+        if (minXf < (float)swrText_bboxMinX)
+            swrText_bboxMinX = (short)(int)minXf;
+        if (minYf < (float)swrText_bboxMinY)
+            swrText_bboxMinY = (short)(int)minYf;
+        if ((float)swrText_bboxMaxX < maxXf)
+            swrText_bboxMaxX = (short)(int)maxXf;
+        if ((float)swrText_bboxMaxY < maxYf)
+            swrText_bboxMaxY = (short)(int)maxYf;
+    }
+
+    // Glyph UVs (the font atlas is 64 texels wide, 128 tall).
+    float tex_u0 = (float)(int)a7 * (1.0f / 64.0f);
+    float tex_u1 = (float)((int)a5 + (int)a7) * (1.0f / 64.0f);
+    float tex_v0 = (float)(int)a8 * (1.0f / 128.0f);
+    float tex_v1 = (float)((int)a6 + (int)a8) * (1.0f / 128.0f);
+
+    // Screen coordinates: the bbox extents, optionally halved for half-scale text.
+    float rsx = swrText_halfScale ? scaleX * 0.5f : scaleX;
+    float rsy = swrText_halfScale ? scaleY * 0.5f : scaleY;
+    short sx0 = (short)(int)(rsx * left);
+    short sy0 = (short)(int)(rsy * top);
+    short sx1 = (short)(int)(rsx * right);
+    short sy1 = (short)(int)(rsy * bottom);
+
+    // Scissor against the text clip rect, sliding the matching UV edge to keep the glyph aligned.
+    if (swrText_clipEnabled != 0) {
+        if (sx0 > swrText_clipRight || sy0 > swrText_clipBottom || sx1 < swrText_clipLeft || sy1 < swrText_clipTop)
+            return;
+        if (sx0 < swrText_clipLeft) {
+            int d = swrText_clipLeft - sx0;
+            sx0 = (short)(sx0 + d);
+            tex_u0 += (float)d;
+        }
+        if (sy0 < swrText_clipTop) {
+            int d = swrText_clipTop - sy0;
+            sy0 = (short)(sy0 + d);
+            tex_v0 += (float)d;
+        }
+        if (sx1 > swrText_clipRight) {
+            int d = sx1 - swrText_clipRight;
+            sx1 = (short)(sx1 - d);
+            tex_u1 -= (float)d;
+        }
+        if (sy1 > swrText_clipBottom) {
+            int d = sy1 - swrText_clipBottom;
+            sy1 = (short)(sy1 - d);
+            tex_v1 -= (float)d;
+        }
+    }
+
+    // orientation 0xbf = diagonal flip: swap the U and V endpoints.
+    if (swrText_orientation == 0xbf) {
+        float tmpU = tex_u0;
+        tex_u0 = tex_u1;
+        tex_u1 = tmpU;
+        float tmpV = tex_v0;
+        tex_v0 = tex_v1;
+        tex_v1 = tmpV;
+    }
+
+    rdProcEntry_Add2DQuad(sx0, sy0, sx1, sy1, tex_u0, tex_v0, tex_u1, tex_v1);
 }
 
 // 0x0042D950
@@ -503,16 +599,96 @@ void rdProcEntry_Add2DQuad3(short x0, short y0, short x1, short y1, float tex_wi
     HANG("TODO");
 }
 
+// Emit an arbitrary 2D quad from four explicit corner points (x0,y0)..(x3,y3), fixed
+// full-texture UVs (0,0)-(1,1). Like rdProcEntry_Add2DQuad but the caller gives all four
+// corners instead of an axis-aligned rect. Uses the current material + current color.
 // 0x004327E0
-void rdProcEntry_Add2DQuad4(short a1, short a2, short a3, short a4, short a5, short a6, short a7, short a8)
+void rdProcEntry_Add2DQuad4(short x0, short y0, short x1, short y1, short x2, short y2, short x3, short y3)
 {
-    HANG("TODO");
+    RdCacheProcEntry* pEntry = rdCache_GetProcEntry();
+    pEntry->flags = RD_FF_ZWRITE_DISABLED | RD_FF_TEX_CLAMP_Y | RD_FF_TEX_CLAMP_X | RD_FF_TEX_TRANSLUCENT;
+    pEntry->lightingMode = RD_LIGHTING_LIT;
+    pEntry->numVertices = 4;
+    pEntry->uv_offset.x = 0.0f;
+    pEntry->uv_offset.y = 0.0f;
+    pEntry->matCelNum = 0;
+    pEntry->pMaterial = rdModel_CurrentMaterial;
+    pEntry->distance = 0.0f;
+
+    const float z = rdCamera_pCurCamera->pClipFrustum->zNear;
+    rdVector3* aVertices = pEntry->aVertices;
+    rdVector2* aUVs = pEntry->aUVCoords;
+    rdVector4* aColors = pEntry->aVertColors;
+
+    aVertices[0].x = (float)(int)x0;
+    aVertices[0].y = (float)(int)y0;
+    aVertices[1].x = (float)(int)x1;
+    aVertices[1].y = (float)(int)y1;
+    aVertices[2].x = (float)(int)x2;
+    aVertices[2].y = (float)(int)y2;
+    aVertices[3].x = (float)(int)x3;
+    aVertices[3].y = (float)(int)y3;
+    for (int i = 0; i < 4; i++) {
+        aVertices[i].z = z;
+        aColors[i] = rdProcEntry_CurrentColor;
+    }
+
+    aUVs[0].x = 1.0f;
+    aUVs[0].y = 0.0f;
+    aUVs[1].x = 1.0f;
+    aUVs[1].y = 1.0f;
+    aUVs[2].x = 0.0f;
+    aUVs[2].y = 1.0f;
+    aUVs[3].x = 0.0f;
+    aUVs[3].y = 0.0f;
+
+    rdCache_AddProcFace(pEntry->numVertices, rdCache_ProcFaceFLAGS_VERTICES | rdCache_ProcFaceFLAGS_UVS | rdCache_ProcFaceFLAGS_INTENSITIES);
 }
 
+// Emit an axis-aligned 2D quad spanning (x0,y0)-(x1,y1) with the given UV rect, at the
+// near clip plane, using the current material + current color. The workhorse behind the
+// 2D UI/sprite blits.
 // 0x004329C0
 void rdProcEntry_Add2DQuad(short x0, short y0, short x1, short y1, float tex_u0, float tex_v0, float tex_u1, float tex_v1)
 {
-    HANG("TODO");
+    RdCacheProcEntry* pEntry = rdCache_GetProcEntry();
+    pEntry->flags = RD_FF_ZWRITE_DISABLED | RD_FF_TEX_CLAMP_Y | RD_FF_TEX_CLAMP_X | RD_FF_TEX_TRANSLUCENT;
+    pEntry->lightingMode = RD_LIGHTING_LIT;
+    pEntry->numVertices = 4;
+    pEntry->uv_offset.x = 0.0f;
+    pEntry->uv_offset.y = 0.0f;
+    pEntry->matCelNum = 0;
+    pEntry->pMaterial = rdModel_CurrentMaterial;
+    pEntry->distance = 0.0f;
+
+    const float z = rdCamera_pCurCamera->pClipFrustum->zNear;
+    rdVector3* aVertices = pEntry->aVertices;
+    rdVector2* aUVs = pEntry->aUVCoords;
+    rdVector4* aColors = pEntry->aVertColors;
+
+    aVertices[0].x = (float)(int)x0;
+    aVertices[0].y = (float)(int)y0;
+    aVertices[1].x = (float)(int)x0;
+    aVertices[1].y = (float)(int)y1;
+    aVertices[2].x = (float)(int)x1;
+    aVertices[2].y = (float)(int)y1;
+    aVertices[3].x = (float)(int)x1;
+    aVertices[3].y = (float)(int)y0;
+    for (int i = 0; i < 4; i++) {
+        aVertices[i].z = z;
+        aColors[i] = rdProcEntry_CurrentColor;
+    }
+
+    aUVs[0].x = tex_u0;
+    aUVs[0].y = tex_v0;
+    aUVs[1].x = tex_u0;
+    aUVs[1].y = tex_v1;
+    aUVs[2].x = tex_u1;
+    aUVs[2].y = tex_v1;
+    aUVs[3].x = tex_u1;
+    aUVs[3].y = tex_v0;
+
+    rdCache_AddProcFace(pEntry->numVertices, rdCache_ProcFaceFLAGS_VERTICES | rdCache_ProcFaceFLAGS_UVS | rdCache_ProcFaceFLAGS_INTENSITIES);
 }
 
 // 0x00445c90
@@ -715,7 +891,8 @@ void swrSprite_Draw(int* arg0, swrSpriteTexture* a1, RdMaterial** a2, float a3, 
 // 0x0044F5F0
 void swrSprite_ResetCurrentMaterial()
 {
-    HANG("TODO");
+    swr_noop2();
+    swrSprite_CurrentMaterial = NULL;
 }
 
 // 0x0044F600

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -456,28 +456,28 @@ void swrText_CreateEntry2(short x, short y, char r, char g, char b, char a, char
 }
 
 // 0x004505f0
-void swrText_CreateTimeEntryFormat(int x, int y, int unused, int r, int g, int b, int a, int bFormat)
+void swrText_CreateTimeEntryFormat(int x, int y, float time, int r, int g, int b, int a, int bFormat)
 {
     char* screen_text;
 
     if (bFormat != 0)
     {
         screen_text = swrText_Translate("~r~s");
-        swrText_CreateTimeEntryPrecise(x, y, unused, r, g, b, a, screen_text);
+        swrText_CreateTimeEntryPrecise(x, y, time, r, g, b, a, screen_text);
         return;
     }
     screen_text = swrText_Translate("~s");
-    swrText_CreateTimeEntryPrecise(x, y, unused, r, g, b, a, screen_text);
+    swrText_CreateTimeEntryPrecise(x, y, time, r, g, b, a, screen_text);
 }
 
-// Format a race time (the `unused` argument is the time in seconds) as
-// [minutes:]seconds.centiseconds and enqueue it as a text entry. The centisecond version;
-// swrText_CreateTimeEntryPrecise is identical but resolves to milliseconds (%.3d).
+// Format a race time (`time`, in seconds) as [minutes:]seconds.centiseconds and enqueue it as a
+// text entry. The centisecond version; swrText_CreateTimeEntryPrecise is identical but resolves
+// to milliseconds (%.3d).
 // 0x00450670
-void swrText_CreateTimeEntry(int x, int y, int unused, int r, int g, int b, int a, char* screenText)
+void swrText_CreateTimeEntry(int x, int y, float time, int r, int g, int b, int a, char* screenText)
 {
     char buffer[256];
-    float minutesf = (float)unused * (1.0f / 60.0f);
+    float minutesf = time * (1.0f / 60.0f);
     int minutes = (int)minutesf;
     float secondsf = (minutesf - (float)minutes) * 60.0f;
     int seconds = (int)secondsf;
@@ -495,14 +495,14 @@ void swrText_CreateTimeEntry(int x, int y, int unused, int r, int g, int b, int 
     swrText_CreateTextEntry1(x, y, r, g, b, a, buffer);
 }
 
-// Format a race time (the `unused` argument is the time in seconds) as
-// [minutes:]seconds.milliseconds and enqueue it as a text entry. Millisecond-precision
-// variant of swrText_CreateTimeEntry (%.3d vs %.2d, and a finer rounding bias).
+// Format a race time (`time`, in seconds) as [minutes:]seconds.milliseconds and enqueue it as a
+// text entry. Millisecond-precision variant of swrText_CreateTimeEntry (%.3d vs %.2d, and a finer
+// rounding bias).
 // 0x00450760
-void swrText_CreateTimeEntryPrecise(int x, int y, int unused, int r, int g, int b, int a, char* screenText)
+void swrText_CreateTimeEntryPrecise(int x, int y, float time, int r, int g, int b, int a, char* screenText)
 {
     char buffer[256];
-    float minutesf = (float)unused * (1.0f / 60.0f);
+    float minutesf = time * (1.0f / 60.0f);
     int minutes = (int)minutesf;
     float secondsf = (minutesf - (float)minutes) * 60.0f;
     int seconds = (int)secondsf;

--- a/src/Swr/swrText.c
+++ b/src/Swr/swrText.c
@@ -470,45 +470,52 @@ void swrText_CreateTimeEntryFormat(int x, int y, int unused, int r, int g, int b
     swrText_CreateTimeEntryPrecise(x, y, unused, r, g, b, a, screen_text);
 }
 
+// Format a race time (the `unused` argument is the time in seconds) as
+// [minutes:]seconds.centiseconds and enqueue it as a text entry. The centisecond version;
+// swrText_CreateTimeEntryPrecise is identical but resolves to milliseconds (%.3d).
 // 0x00450670
 void swrText_CreateTimeEntry(int x, int y, int unused, int r, int g, int b, int a, char* screenText)
 {
-    // Notice the %.2d instead of the %.3d from Precise version
-    HANG("TODO");
-    int todo = 0;
     char buffer[256];
-    int mins = 0;
-    int secs = 0;
-    int mills = 0;
-
-    if (todo)
-    {
-        sprintf(buffer, "%s%.2d.%.2d", screenText, mins, secs);
+    float minutesf = (float)unused * (1.0f / 60.0f);
+    int minutes = (int)minutesf;
+    float secondsf = (minutesf - (float)minutes) * 60.0f;
+    int seconds = (int)secondsf;
+    int centis = (int)((secondsf - (float)seconds + 0.005f) * 100.0f);
+    if (centis == 100) {
+        centis = 0;
+        seconds++;
+        if (seconds == 60)
+            minutes++;
     }
+    if (minutes == 0)
+        sprintf(buffer, "%s%.2d.%.2d", screenText, seconds, centis);
     else
-    {
-        sprintf(buffer, "%s%d:%.2d.%.2d", screenText, mins, secs, mills);
-    }
+        sprintf(buffer, "%s%d:%.2d.%.2d", screenText, minutes, seconds, centis);
     swrText_CreateTextEntry1(x, y, r, g, b, a, buffer);
 }
 
+// Format a race time (the `unused` argument is the time in seconds) as
+// [minutes:]seconds.milliseconds and enqueue it as a text entry. Millisecond-precision
+// variant of swrText_CreateTimeEntry (%.3d vs %.2d, and a finer rounding bias).
 // 0x00450760
 void swrText_CreateTimeEntryPrecise(int x, int y, int unused, int r, int g, int b, int a, char* screenText)
 {
-    HANG("TODO");
-    int todo = 0;
     char buffer[256];
-    int mins = 0;
-    int secs = 0;
-    int mills = 0;
-
-    if (todo)
-    {
-        sprintf(buffer, "%s%.2d.%.3d", screenText, mins, secs);
+    float minutesf = (float)unused * (1.0f / 60.0f);
+    int minutes = (int)minutesf;
+    float secondsf = (minutesf - (float)minutes) * 60.0f;
+    int seconds = (int)secondsf;
+    int millis = (int)((secondsf - (float)seconds + 0.0005f) * 1000.0f);
+    if (millis == 1000) {
+        millis = 0;
+        seconds++;
+        if (seconds == 60)
+            minutes++;
     }
+    if (minutes == 0)
+        sprintf(buffer, "%s%.2d.%.3d", screenText, seconds, millis);
     else
-    {
-        sprintf(buffer, "%s%d:%.2d.%.3d", screenText, mins, secs, mills);
-    }
+        sprintf(buffer, "%s%d:%.2d.%.3d", screenText, minutes, seconds, millis);
     swrText_CreateTextEntry1(x, y, r, g, b, a, buffer);
 }

--- a/src/Swr/swrText.h
+++ b/src/Swr/swrText.h
@@ -120,10 +120,10 @@ void swrText_CreateColorlessFormattedEntry1(int formatInt, short x, short y, cha
 
 void swrText_CreateEntry2(short x, short y, char r, char g, char b, char a, char* screenText);
 
-void swrText_CreateTimeEntryFormat(int x, int y, int unused, int r, int g, int b, int a, int bFormat);
+void swrText_CreateTimeEntryFormat(int x, int y, float time, int r, int g, int b, int a, int bFormat);
 
-void swrText_CreateTimeEntry(int x, int y, int unused, int r, int g, int b, int a, char* screenText);
+void swrText_CreateTimeEntry(int x, int y, float time, int r, int g, int b, int a, char* screenText);
 
-void swrText_CreateTimeEntryPrecise(int x, int y, int unused, int r, int g, int b, int a, char* screenText);
+void swrText_CreateTimeEntryPrecise(int x, int y, float time, int r, int g, int b, int a, char* screenText);
 
 #endif // SWRTEXT_H

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -7,4 +7,9 @@
 // worst-case single face returned by it always fits before the next flush.
 #define RDCACHE_MIN_FREE_VERTICES (0x50)
 
+// daAlloc arena allocator (stdMemory.c).
+#define DAALLOC_PAGE_SIZE (0x7c00)       // bytes per arena page, malloc'd on demand
+#define DAALLOC_ARENA_COUNT (0x421)      // number of daAlloc_struct arena slots (1057)
+#define DAALLOC_SMALL_ALLOC_MAX (0x1000) // requests larger than this bypass the arena (daSmallAlloc)
+
 #endif // ENGINE_CONFIG_H

--- a/src/types.h
+++ b/src/types.h
@@ -2067,6 +2067,25 @@ extern "C"
         tHashFunc hashFunc;
     } tHashTable;
 
+    // daAlloc arena allocator (stdMemory.c). daAlloc_struct is daArena[DAALLOC_ARENA_COUNT];
+    // each in-use slot owns one malloc'd DAALLOC_PAGE_SIZE page carved into daBlocks.
+    typedef struct daArena
+    {
+        void* page;// malloc'd page base, or NULL when the slot is free
+        struct daBlock* bestFree;// cached largest free block in this page
+        uint32_t bestFreeSize;// usable bytes of bestFree (block size minus the 8-byte header)
+        int32_t inUse;// 1 = slot active
+    } daArena;
+
+    // 8-byte header prefixing every daAlloc block; the user pointer is at +8. Free blocks are
+    // walked by stepping (size & ~DABLOCK_ALLOCATED) bytes; a size of 0 marks the page-end sentinel.
+    typedef struct daBlock
+    {
+        uint16_t size;// total block size in bytes incl. this header; DABLOCK_ALLOCATED bit = in use
+        uint16_t prevSize;// byte size of the physically-preceding block (for backward coalescing)
+        daArena* owner;// owning arena, or NULL for a daSmallAlloc standalone block
+    } daBlock;
+
     // rdCache_GetProcEntry
     typedef struct RdCacheProcEntry
     {

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -8,6 +8,13 @@ typedef enum rdTexFormatMode
     STDCOLOR_RGBA = 0x2,
 } rdTexFormatMode;
 
+// daAlloc block header (daBlock.size): high bit flags an in-use block, low 15 bits are the size.
+typedef enum daBlockFlag
+{
+    DABLOCK_SIZE_MASK = 0x7fff,
+    DABLOCK_ALLOCATED = 0x8000,
+} daBlockFlag;
+
 // Indy stdDisplay_SetMode
 typedef enum tColorMode // i32
 {


### PR DESCRIPTION
A batch of small leaf reimplementations, one commit per subsystem so they're easy to review (or split):

- **swrText** - `CreateTimeEntry` / `CreateTimeEntryPrecise` (race-time formatting)
- **swrRender** - `Direct3d_ConfigFog2`, `rdFace_SetFogEnabled`
- **rd** - `rdModel_SetCurrentMaterial` + the render/geometry/lighting mode setters
- **stdMemory** - the full arena allocator: `daSmallAlloc` + `daAlloc` / `daFree` / `daRealloc` (with the `daArena`/`daBlock` structs, `DABLOCK_*` flags and `DAALLOC_*` constants)
- **swrSprite** - `rdProcEntry_Add2DQuad` / `_Add2DQuad4` / `_Add2DQuad2` + `getCurrentTextPos` / `ResetCurrentMaterial`

`Add2DQuad2` (the text-glyph emitter) needed the swrText bbox/clip/orientation globals named - those are in `data_symbols.syms`.

The time formatters and `Add2DQuad2` were blocked by garbled x87 float->int decompilation; I fixed `__ftol`'s calling convention in the Ghidra DB (input on ST0, return in EDX:EAX), which cleans that up DB-wide.

Full `dinput.dll` build links clean.