### PR TITLE
reimpl(swrRender): light-setter family (11 functions)

### DIFF
--- a/src/Swr/swrRender.c
+++ b/src/Swr/swrRender.c
@@ -2,6 +2,8 @@
 
 #include "globals.h"
 
+#include <Engine/rdCamera.h>
+#include <Primitives/rdVector.h>
 #include <macros.h>
 
 // 0x00409290
@@ -28,28 +30,78 @@ int rdFace_SetFogEnabled(int mode)
     HANG("TODO");
 }
 
+// Push light slot `light_index` from the staging arrays into the active cameras: direction into
+// rdCamera_main_ptr's light position, color into the current camera's light, plus ambient. A
+// second light (secondary bank) is activated when num_lights > 1, otherwise it is disabled.
 // 0x00409510
 void rdCamera_SetLights(int light_index, int num_lights)
 {
-    HANG("TODO");
+    rdCamera_main_ptr->lightPositions[0].x = lightDirection1[light_index].x;
+    rdCamera_main_ptr->lightPositions[0].y = lightDirection1[light_index].y;
+    rdCamera_main_ptr->lightPositions[0].z = lightDirection1[light_index].z;
+    rdCamera_pCurCamera->lights[0]->color = lightColor1[light_index];
+    rdCamera_pCurCamera->lights[0]->active = 1;
+    rdCamera_SetAmbientLight(rdCamera_pCurCamera, &lightAmbientColor[light_index]);
+    if (num_lights > 1) {
+        rdCamera_main_ptr->lightPositions[1].x = lightDirection2[light_index].x;
+        rdCamera_main_ptr->lightPositions[1].y = lightDirection2[light_index].y;
+        rdCamera_main_ptr->lightPositions[1].z = lightDirection2[light_index].z;
+        rdCamera_pCurCamera->lights[1]->color = lightColor2[light_index];
+        rdCamera_pCurCamera->lights[1]->active = 1;
+    } else {
+        rdCamera_pCurCamera->lights[1]->active = 0;
+    }
 }
 
+// Set primary-bank light `light_index`: direction from the raw position, color + ambient from
+// 0-255 components scaled to 0..1 (w = 1.0). The return is the internal light_index*16 byte
+// offset left in EAX; callers ignore it.
 // 0x00409600
 float* SetLightColorsAndDirection(int light_index, short ambient_r, short ambient_g, short ambient_b, short light_r, short light_g, short light_b, short pos_x, short pos_y, short pos_z)
 {
-    HANG("TODO");
+    lightDirection1[light_index].x = (float)(int)pos_x;
+    lightDirection1[light_index].y = (float)(int)pos_y;
+    lightDirection1[light_index].z = (float)(int)pos_z;
+    lightColor1[light_index].x = (float)(int)light_r * oneOver255f;
+    lightColor1[light_index].y = (float)(int)light_g * oneOver255f;
+    lightColor1[light_index].z = (float)(int)light_b * oneOver255f;
+    lightColor1[light_index].w = 1.0f;
+    lightAmbientColor[light_index].x = (float)(int)ambient_r * oneOver255f;
+    lightAmbientColor[light_index].y = (float)(int)ambient_g * oneOver255f;
+    lightAmbientColor[light_index].z = (float)(int)ambient_b * oneOver255f;
+    lightAmbientColor[light_index].w = 1.0f;
+    return (float*)(light_index * 0x10);
 }
 
+// Copy the primary light (slot 0)'s direction/color/ambient x,y,z into slot `light_index`.
 // 0x00409700
 int SetLightColorsAndDirectionFromPrimaryLight(short light_index)
 {
-    HANG("TODO");
+    lightDirection1[light_index].x = lightDirection1[0].x;
+    lightDirection1[light_index].y = lightDirection1[0].y;
+    lightDirection1[light_index].z = lightDirection1[0].z;
+    lightColor1[light_index].x = lightColor1[0].x;
+    lightColor1[light_index].y = lightColor1[0].y;
+    lightColor1[light_index].z = lightColor1[0].z;
+    lightAmbientColor[light_index].x = lightAmbientColor[0].x;
+    lightAmbientColor[light_index].y = lightAmbientColor[0].y;
+    lightAmbientColor[light_index].z = lightAmbientColor[0].z;
+    return 0xc;
 }
 
+// Set secondary-bank light `light_index`: direction from the raw position, color from 0-255
+// components (the secondary bank has no ambient term). Return is the vestigial index offset.
 // 0x00409750
 float* SetAlternativeLightColorsAndDirection(int light_index, short light_r, short light_g, short light_b, short pos_x, short pos_y, short pos_z)
 {
-    HANG("TODO");
+    lightDirection2[light_index].x = (float)(int)pos_x;
+    lightDirection2[light_index].y = (float)(int)pos_y;
+    lightDirection2[light_index].z = (float)(int)pos_z;
+    lightColor2[light_index].x = (float)(int)light_r * oneOver255f;
+    lightColor2[light_index].y = (float)(int)light_g * oneOver255f;
+    lightColor2[light_index].z = (float)(int)light_b * oneOver255f;
+    lightColor2[light_index].w = 1.0f;
+    return (float*)(light_index * 0x10);
 }
 
 // 0x00432B80
@@ -154,28 +206,45 @@ void SetFogParameters(int fogStart_, int fogEnd_, int fogColorR, int fogColorG, 
     }
 }
 
+// Primary light (slot 0) from short[3] ambient/color/position arrays; position negated to a direction.
 // 0x0044E140
 void SetPrimaryLightColorsAndDirection(short* ambient_color, short* light_color, short* light_position)
 {
-    HANG("TODO");
+    SetLightColorsAndDirection(0, ambient_color[0], ambient_color[1], ambient_color[2], light_color[0], light_color[1], light_color[2], -light_position[0], -light_position[1], -light_position[2]);
 }
 
+// Secondary light `light_index` (stored at slot light_index+1) from short[3] arrays.
 // 0x0044E190
 void SetSecondaryLightColorsAndDirection(unsigned int light_index, short* ambient_color, short* light_color, short* light_position)
 {
-    HANG("TODO");
+    if ((int)light_index >= 0 && (int)light_index < 0xc) {
+        SetLightColorsAndDirection(light_index + 1, ambient_color[0], ambient_color[1], ambient_color[2], light_color[0], light_color[1], light_color[2], -light_position[0], -light_position[1], -light_position[2]);
+    }
 }
 
+// Copy the primary light into slot index+1 and record numEnabledLights[index] = 1.
 // 0x0044E1F0
 void SetLightColorsAndDirectionFromPrimraryLight2(unsigned int index)
 {
-    HANG("TODO");
+    if ((int)index >= 0 && (int)index < 0xc) {
+        SetLightColorsAndDirectionFromPrimaryLight((short)index + 1);
+        numEnabledLights[index] = 1;
+    }
 }
 
+// Secondary-bank light `light_index`: light_type2 == 0 -> just record it (numEnabledLights = 1);
+// otherwise record numEnabledLights = 2 and set slot light_index+1 from the color/position arrays.
 // 0x0044E220
 void SetAlternativeLightColorsAndDirection2(int light_index, BOOL light_type2, short* light_color, short* light_position)
 {
-    HANG("TODO");
+    if (light_index >= 0 && light_index < 0xc) {
+        if (light_type2 == 0) {
+            numEnabledLights[light_index] = 1;
+            return;
+        }
+        numEnabledLights[light_index] = 2;
+        SetAlternativeLightColorsAndDirection(light_index + 1, light_color[0], light_color[1], light_color[2], -light_position[0], -light_position[1], -light_position[2]);
+    }
 }
 
 // 0x0044E290
@@ -187,22 +256,78 @@ void rdProcEntry_SetCurrentColor(int a1, int a2, uint8_t r, uint8_t g, uint8_t b
     rdProcEntry_CurrentColor.w = (float) a * oneOver255f;
 }
 
+// Float-input primary/secondary light. Normalizes light_position to a length-120 direction
+// (straight down when the position is near-zero), truncates the float ambient/color/direction
+// to shorts, and dispatches to SetPrimary (a1 == -1) or SetSecondary. Return unused (vestigial).
 // 0x00483840
 float* SetLightColorsAndDirection2(int a1, rdVector3* ambient_color, rdVector3* light_color, rdVector3* light_position)
 {
-    HANG("TODO");
+    float dir_x;
+    float dir_y;
+    float dir_z;
+    float len = rdVector_Len3(light_position);
+    if (len < 0.01f) {
+        dir_x = 0.0f;
+        dir_y = 0.0f;
+        dir_z = -1.0f;
+    } else {
+        float scale = 120.0f / len;
+        dir_x = light_position->x * scale;
+        dir_y = light_position->y * scale;
+        dir_z = light_position->z * scale;
+    }
+    short ambient[3] = { (short)(int)ambient_color->x, (short)(int)ambient_color->y, (short)(int)ambient_color->z };
+    short color[3] = { (short)(int)light_color->x, (short)(int)light_color->y, (short)(int)light_color->z };
+    short direction[3] = { (short)(int)dir_x, (short)(int)dir_y, (short)(int)dir_z };
+    if (a1 == -1) {
+        SetPrimaryLightColorsAndDirection(ambient, color, direction);
+    } else {
+        SetSecondaryLightColorsAndDirection(a1, ambient, color, direction);
+    }
+    return NULL;
 }
 
+// Float-input secondary-bank variant: when light_type2 is set, normalize light_position the same
+// way and truncate the float color to shorts; then defer to SetAlternative...2. Return unused.
 // 0x00483960
 float* SetAlternativeLightColorsAndDirection3(int light_index, BOOL light_type2, float* light_color, rdVector3* light_position)
 {
-    HANG("TODO");
+    short color[3] = { 0, 0, 0 };
+    short direction[3] = { 0, 0, 0 };
+    if (light_type2 != 0) {
+        float dir_x;
+        float dir_y;
+        float dir_z;
+        float len = rdVector_Len3(light_position);
+        if (len < 0.01f) {
+            dir_x = 0.0f;
+            dir_y = 0.0f;
+            dir_z = -1.0f;
+        } else {
+            float scale = 120.0f / len;
+            dir_x = light_position->x * scale;
+            dir_y = light_position->y * scale;
+            dir_z = light_position->z * scale;
+        }
+        color[0] = (short)(int)light_color[0];
+        color[1] = (short)(int)light_color[1];
+        color[2] = (short)(int)light_color[2];
+        direction[0] = (short)(int)dir_x;
+        direction[1] = (short)(int)dir_y;
+        direction[2] = (short)(int)dir_z;
+    }
+    SetAlternativeLightColorsAndDirection2(light_index, light_type2, color, direction);
+    return NULL;
 }
 
+// Guarded wrapper: copy the primary light into slot a1+1 unless a1 == -1.
 // 0x00483A40
 int SetLightColorsAndDirectionFromPrimaryLight3(unsigned int a1)
 {
-    HANG("TODO");
+    if (a1 != 0xffffffff) {
+        SetLightColorsAndDirectionFromPrimraryLight2(a1);
+    }
+    return a1;
 }
 
 // 0x00483A60


### PR DESCRIPTION
Reimplements the swrRender light-setter family - the whole subsystem (11 functions).

The staging layer writes the `lightDirection1/2`, `lightColor1/2`, `lightAmbientColor` and `numEnabledLights` globals:
- `SetLightColorsAndDirection` (+ `FromPrimaryLight` / `Alternative` / `2` / `3`)
- the wrapper layer: `SetPrimary` / `Secondary` / `FromPrimraryLight2` / `Alternative2`

Then `rdCamera_SetLights` pushes a slot into the live cameras (direction -> `rdCamera_main_ptr->lightPositions`, color -> the current camera's `rdLight`, plus ambient), enabling the secondary light when `num_lights > 1`.

Colors scale by the existing `oneOver255f`; the `short[3]` wrappers negate position to a direction. The float-input variants normalize position to a length-120 direction (straight down when degenerate); their vestigial dangling-pointer return becomes `NULL` (every caller ignores it). The light globals/structs were already named.

Full `dinput.dll` build links clean.