### PR TITLE
reimpl(rdClip): Face3S + Face3TOrtho triangle clippers

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -944,6 +944,18 @@ rdParticle_aFaceVertices 0x00df8760 rdVector3[4]
 
 rdParticle_aTransformedVertices 0x00df8b20 rdVector3
 
+# rdClip Sutherland-Hodgman scratch buffers + ping-pong pointers (shared by the rdClip_Face3* family)
+rdClip_pSrcTexVerts 0x00df9ea8 rdVector2*
+rdClip_pDstTexVerts 0x00df9eac rdVector2*
+rdClip_pDstIntensities 0x00df9eb0 rdVector4*
+rdClip_pDstVerts 0x00df9eb4 rdVector3*
+rdClip_workTexVerts 0x00df9eb8 rdVector2[80]
+rdClip_pSrcVerts 0x00dfa138 rdVector3*
+rdClip_pSrcIntensities 0x00dfa13c rdVector4*
+rdClip_workVerts 0x00dfa140 rdVector3[80]
+rdClip_workIntensities 0x00dfa500 rdVector4[80]
+rdClip_faceStatus 0x00dfaa04 int
+
 g_hWnd 0x00dfaa28 HWND
 g_nCmdShow 0x00dfaa2c int
 g_WndProc 0x00dfaa30 Window_MSGHANDLER

--- a/src/Engine/rdClip.c
+++ b/src/Engine/rdClip.c
@@ -1,5 +1,7 @@
 #include "rdClip.h"
 
+#include "globals.h"
+
 #include <macros.h>
 #include <math.h>
 
@@ -115,10 +117,288 @@ int rdClip_Face3WOrtho(rdClipFrustum* pFrustrum, rdVector3* aVertices, int numVe
     HANG("TODO");
 }
 
+// Clips a shaded (position-only) triangle against the perspective view frustum
+// using Sutherland-Hodgman, ping-ponging between the caller's vertex array and
+// rdClip_workVerts. Returns the clipped vertex count (< 3 means fully culled).
 // 0x00495d50
 int rdClip_Face3S(rdClipFrustum* pFrustrum, rdVector3* aVertices, int numVertices)
 {
-    HANG("TODO");
+    rdVector3* pPrev;
+    rdVector3* pCur;
+    rdVector3* pDst;
+    rdVector3* pSwap;
+    int numIn;
+    int numOut;
+    int i;
+    float prevBound;
+    float curBound;
+    float dR;
+    float dC;
+    float denom;
+    float cross;
+    float iC;
+    float adR;
+    float adC;
+    float t;
+
+    rdClip_faceStatus = 0;
+    rdClip_pSrcVerts = aVertices;
+    rdClip_pDstVerts = rdClip_workVerts;
+
+    // ---- pass 1: rightPlane, clip x, keep x >= plane * y ----
+    numOut = 0;
+    if (numVertices > 0) {
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numVertices - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numVertices;
+        do {
+            prevBound = pFrustrum->rightPlane * pPrev->y;
+            curBound = pFrustrum->rightPlane * pCur->y;
+            if (prevBound <= pPrev->x || curBound <= pCur->x) {
+                if (pPrev->x != prevBound && pCur->x != curBound && (pPrev->x < prevBound || pCur->x < curBound)) {
+                    dR = pCur->y - pPrev->y;
+                    dC = pCur->x - pPrev->x;
+                    denom = pFrustrum->rightPlane * dR - dC;
+                    cross = pPrev->x * pCur->y - pPrev->y * pCur->x;
+                    if (denom != 0.0) {
+                        cross = cross / denom;
+                    }
+                    iC = pFrustrum->rightPlane * cross;
+                    adR = dR < 0.0 ? -dR : dR;
+                    adC = dC < 0.0 ? -dC : dC;
+                    t = adR <= adC ? (iC - pPrev->x) / dC : (cross - pPrev->y) / dR;
+                    pDst[numOut].x = iC;
+                    pDst[numOut].y = cross;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_PLANE_A;
+                }
+                if (curBound <= pCur->x) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+    }
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 2: bottomPlane, clip x, keep x <= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        prevBound = pFrustrum->bottomPlane * pPrev->y;
+        curBound = pFrustrum->bottomPlane * pCur->y;
+        if (pPrev->x <= prevBound || pCur->x <= curBound) {
+            if (pPrev->x != prevBound && pCur->x != curBound && (prevBound < pPrev->x || curBound < pCur->x)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->x - pPrev->x;
+                denom = pFrustrum->bottomPlane * dR - dC;
+                cross = pPrev->x * pCur->y - pPrev->y * pCur->x;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->bottomPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->x) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = iC;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_B;
+            }
+            if (pCur->x <= curBound) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 3: leftPlane, clip z, keep z <= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        prevBound = pFrustrum->leftPlane * pPrev->y;
+        curBound = pFrustrum->leftPlane * pCur->y;
+        if (pPrev->z <= prevBound || pCur->z <= curBound) {
+            if (pPrev->z != prevBound && pCur->z != curBound && (prevBound < pPrev->z || curBound < pCur->z)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->z - pPrev->z;
+                denom = pFrustrum->leftPlane * dR - dC;
+                cross = pPrev->z * pCur->y - pPrev->y * pCur->z;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->leftPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->z) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = iC;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_C;
+            }
+            if (pCur->z <= curBound) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 4: orthoBottomPlane, clip z, keep z >= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        prevBound = pFrustrum->orthoBottomPlane * pPrev->y;
+        curBound = pFrustrum->orthoBottomPlane * pCur->y;
+        if (prevBound <= pPrev->z || curBound <= pCur->z) {
+            if (pPrev->z != prevBound && pCur->z != curBound && (pPrev->z < prevBound || pCur->z < curBound)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->z - pPrev->z;
+                denom = pFrustrum->orthoBottomPlane * dR - dC;
+                cross = pPrev->z * pCur->y - pPrev->y * pCur->z;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->orthoBottomPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->z) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = iC;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_D;
+            }
+            if (curBound <= pCur->z) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 5: zNear, clip y against constant, keep y >= zNear ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (pFrustrum->zNear <= pPrev->y || pFrustrum->zNear <= pCur->y) {
+            if (pPrev->y != pFrustrum->zNear && pCur->y != pFrustrum->zNear && (pPrev->y < pFrustrum->zNear || pCur->y < pFrustrum->zNear)) {
+                t = (pFrustrum->zNear - pPrev->y) / (pCur->y - pPrev->y);
+                pDst[numOut].y = pFrustrum->zNear;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_NEARZ;
+            }
+            if (pFrustrum->zNear <= pCur->y) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        rdClip_faceStatus |= rdClip_FaceStatus_DEGENERATE;
+        return numOut;
+    }
+
+    // ---- pass 6: zFar, clip y against constant, keep y <= zFar (only if far clip enabled) ----
+    if (pFrustrum->bFarClip != 0) {
+        pSwap = rdClip_pSrcVerts;
+        rdClip_pSrcVerts = rdClip_pDstVerts;
+        rdClip_pDstVerts = pSwap;
+
+        numIn = numOut;
+        numOut = 0;
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numIn - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numIn;
+        do {
+            if (pPrev->y <= pFrustrum->zFar || pCur->y <= pFrustrum->zFar) {
+                if (pPrev->y != pFrustrum->zFar && pCur->y != pFrustrum->zFar && (pFrustrum->zFar < pPrev->y || pFrustrum->zFar < pCur->y)) {
+                    t = (pFrustrum->zFar - pPrev->y) / (pCur->y - pPrev->y);
+                    pDst[numOut].y = pFrustrum->zFar;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_FARZ;
+                }
+                if (pCur->y <= pFrustrum->zFar) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+        if (numOut < 3) {
+            return numOut;
+        }
+    }
+
+    if (rdClip_pDstVerts != aVertices) {
+        for (i = 0; i < numOut; i++) {
+            aVertices[i] = rdClip_pDstVerts[i];
+        }
+    }
+    return numOut;
 }
 
 // 0x004966f0
@@ -157,8 +437,386 @@ int rdClip_Face3T(rdClipFrustum* pFrustrum, rdVector3* aVertices, rdVector2* aTe
     HANG("TODO");
 }
 
+// Clips a textured, per-vertex-lit triangle against the orthographic view box
+// (Sutherland-Hodgman), interpolating position, UVs and intensities at each
+// crossing. Ping-pongs the three attribute streams between the caller's arrays
+// and the rdClip work buffers. Returns the clipped vertex count (< 3 = culled).
 // 0x0049b7d0
 int rdClip_Face3TOrtho(rdClipFrustum* pFrustum, rdVector3* aVertices, rdVector2* aTexVertices, rdVector4* aIntensities, int numVertices)
 {
-    HANG("TODO");
+    rdVector3* pPrev;
+    rdVector3* pCur;
+    rdVector3* pDst;
+    rdVector3* pSwapV;
+    rdVector2* pPrevTex;
+    rdVector2* pCurTex;
+    rdVector2* pDstTex;
+    rdVector2* pSwapT;
+    rdVector4* pPrevInt;
+    rdVector4* pCurInt;
+    rdVector4* pDstInt;
+    rdVector4* pSwapI;
+    int numIn;
+    int numOut;
+    int i;
+    float plane;
+    float t;
+
+    rdClip_faceStatus = 0;
+    rdClip_pSrcVerts = aVertices;
+    rdClip_pDstVerts = rdClip_workVerts;
+    rdClip_pSrcTexVerts = aTexVertices;
+    rdClip_pDstTexVerts = rdClip_workTexVerts;
+    rdClip_pSrcIntensities = aIntensities;
+    rdClip_pDstIntensities = rdClip_workIntensities;
+
+    // ---- pass 1: nearPlane, clip x, keep x >= nearPlane ----
+    numOut = 0;
+    plane = pFrustum->nearPlane;
+    if (numVertices > 0) {
+        pDst = rdClip_pDstVerts;
+        pDstTex = rdClip_pDstTexVerts;
+        pDstInt = rdClip_pDstIntensities;
+        pPrev = rdClip_pSrcVerts + numVertices - 1;
+        pCur = rdClip_pSrcVerts;
+        pPrevTex = rdClip_pSrcTexVerts + numVertices - 1;
+        pCurTex = rdClip_pSrcTexVerts;
+        pPrevInt = rdClip_pSrcIntensities + numVertices - 1;
+        pCurInt = rdClip_pSrcIntensities;
+        i = numVertices;
+        do {
+            if (plane <= pPrev->x || plane <= pCur->x) {
+                if (pPrev->x != plane && pCur->x != plane && (pPrev->x < plane || pCur->x < plane)) {
+                    t = (plane - pPrev->x) / (pCur->x - pPrev->x);
+                    pDst[numOut].x = plane;
+                    pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                    pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                    pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                    pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                    pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_PLANE_A;
+                }
+                if (plane <= pCur->x) {
+                    pDst[numOut] = *pCur;
+                    pDstTex[numOut] = *pCurTex;
+                    pDstInt[numOut] = *pCurInt;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            pPrevTex = pCurTex;
+            pCurTex++;
+            pPrevInt = pCurInt;
+            pCurInt++;
+            i--;
+        } while (i != 0);
+    }
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 2: orthoLeftPlane, clip x, keep x <= orthoLeftPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->orthoLeftPlane;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (pPrev->x <= plane || pCur->x <= plane) {
+            if (pPrev->x != plane && pCur->x != plane && (plane < pPrev->x || plane < pCur->x)) {
+                t = (plane - pPrev->x) / (pCur->x - pPrev->x);
+                pDst[numOut].x = plane;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_B;
+            }
+            if (pCur->x <= plane) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 3: farPlane, clip z, keep z <= farPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->farPlane;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (pPrev->z <= plane || pCur->z <= plane) {
+            if (pPrev->z != plane && pCur->z != plane && (plane < pPrev->z || plane < pCur->z)) {
+                t = (plane - pPrev->z) / (pCur->z - pPrev->z);
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = plane;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_C;
+            }
+            if (pCur->z <= plane) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 4: orthoTopPlane, clip z, keep z >= orthoTopPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->orthoTopPlane;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (plane <= pPrev->z || plane <= pCur->z) {
+            if (pPrev->z != plane && pCur->z != plane && (pPrev->z < plane || pCur->z < plane)) {
+                t = (plane - pPrev->z) / (pCur->z - pPrev->z);
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = plane;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_D;
+            }
+            if (plane <= pCur->z) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 5: zNear, clip y, keep y >= zNear ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->zNear;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (plane <= pPrev->y || plane <= pCur->y) {
+            if (pPrev->y != plane && pCur->y != plane && (pPrev->y < plane || pCur->y < plane)) {
+                t = (plane - pPrev->y) / (pCur->y - pPrev->y);
+                pDst[numOut].y = plane;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                // NOTE: faithful to the original - the zNear pass interpolates the
+                // intensity y/z deltas against prevInt.x (not .y/.z). This is a bug
+                // in the shipped game, isolated to this pass; kept for byte fidelity.
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->x) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->x) * t + pPrevInt->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_NEARZ;
+            }
+            if (plane <= pCur->y) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        rdClip_faceStatus |= rdClip_FaceStatus_DEGENERATE;
+        return numOut;
+    }
+
+    // ---- pass 6: zFar, clip y, keep y <= zFar (only if far clip enabled) ----
+    if (pFrustum->bFarClip != 0) {
+        pSwapV = rdClip_pSrcVerts;
+        rdClip_pSrcVerts = rdClip_pDstVerts;
+        rdClip_pDstVerts = pSwapV;
+        pSwapT = rdClip_pSrcTexVerts;
+        rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+        rdClip_pDstTexVerts = pSwapT;
+        pSwapI = rdClip_pSrcIntensities;
+        rdClip_pSrcIntensities = rdClip_pDstIntensities;
+        rdClip_pDstIntensities = pSwapI;
+
+        numIn = numOut;
+        numOut = 0;
+        plane = pFrustum->zFar;
+        pDst = rdClip_pDstVerts;
+        pDstTex = rdClip_pDstTexVerts;
+        pDstInt = rdClip_pDstIntensities;
+        pPrev = rdClip_pSrcVerts + numIn - 1;
+        pCur = rdClip_pSrcVerts;
+        pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+        pCurTex = rdClip_pSrcTexVerts;
+        pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+        pCurInt = rdClip_pSrcIntensities;
+        i = numIn;
+        do {
+            if (pPrev->y <= plane || pCur->y <= plane) {
+                if (pPrev->y != plane && pCur->y != plane && (plane < pPrev->y || plane < pCur->y)) {
+                    t = (plane - pPrev->y) / (pCur->y - pPrev->y);
+                    pDst[numOut].y = plane;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                    pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                    pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                    pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                    pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                    pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_FARZ;
+                }
+                if (pCur->y <= plane) {
+                    pDst[numOut] = *pCur;
+                    pDstTex[numOut] = *pCurTex;
+                    pDstInt[numOut] = *pCurInt;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            pPrevTex = pCurTex;
+            pCurTex++;
+            pPrevInt = pCurInt;
+            pCurInt++;
+            i--;
+        } while (i != 0);
+        if (numOut < 3) {
+            return numOut;
+        }
+    }
+
+    if (rdClip_pDstVerts != aVertices) {
+        for (i = 0; i < numOut; i++) {
+            aVertices[i] = rdClip_pDstVerts[i];
+            aTexVertices[i] = rdClip_pDstTexVerts[i];
+            aIntensities[i] = rdClip_pDstIntensities[i];
+        }
+    }
+    return numOut;
 }

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -4264,4 +4264,20 @@ typedef enum StdControlAxisFlag
 #define TGADataType_COMPRESSEDCOLORMAPPED (2)
 #define TGADataType_COMPRESSEDCOLORMAPPEDQUADTREE (3)
 
+// rdClip_faceStatus bits: one flag per Sutherland-Hodgman clip pass, OR'd in
+// when that pass actually clips an edge. The four lateral-plane bits (A..D)
+// map to different frustum planes in the perspective vs ortho clippers because
+// each clips a different plane set in that slot; NEARZ/FARZ/DEGENERATE are
+// consistent across the family.
+typedef enum rdClip_FaceStatus
+{
+    rdClip_FaceStatus_NEARZ = 0x1,
+    rdClip_FaceStatus_FARZ = 0x2,
+    rdClip_FaceStatus_PLANE_C = 0x4,
+    rdClip_FaceStatus_PLANE_D = 0x8,
+    rdClip_FaceStatus_PLANE_A = 0x10,
+    rdClip_FaceStatus_PLANE_B = 0x20,
+    rdClip_FaceStatus_DEGENERATE = 0x40,
+} rdClip_FaceStatus;
+
 #endif // TYPES_ENUMS_H


### PR DESCRIPTION
Reimplements two of the `rdClip_Face3*` Sutherland-Hodgman triangle clippers and names the shared scratch-buffer infrastructure the whole family uses. The `__ftol` decompiler fix made these legible again.

**`rdClip_Face3S`** (`0x495d50`) — position-only perspective clipper. Six passes: four projective side planes (clip x/z against `plane * y`), then zNear/zFar against constants, ping-ponging between the caller's array and `rdClip_workVerts`.

**`rdClip_Face3TOrtho`** (`0x49b7d0`) — textured, per-vertex-lit ortho clipper. Same structure with parallel UV (`rdVector2`) and intensity (`rdVector4`) interpolation across three ping-ponged attribute streams.

**New globals** (`data_symbols.syms`): the three work buffers (verts / tex / intensities, `[80]` each) + their src/dst ping-pong pointers, and `rdClip_faceStatus`. Sizes come from the address gaps between them.

**New enum** (`types_enums.h`): `rdClip_FaceStatus` names the per-pass clip-status bits (previously raw `| 0x1`..`0x40`). They're an internal accumulator (which planes clipped), only read within the clip family.

Field offsets and the clip math were checked against the disassembly. One faithful quirk: the zNear pass of `Face3TOrtho` reproduces an original-game bug where the intensity y/z interpolation deltas read `prevInt.x` instead of `.y`/`.z` (verified in the disasm at `0x49c3e5`/`0x49c3f9`, isolated to that pass) — kept for byte fidelity with a comment.

This names the scratch infra shared by all ten `rdClip_Face3*` variants, so the remaining ones become much cheaper follow-ups. Builds + links clean (verified in a clean worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)