### PR TITLE
reimpl(swrUI): New + Front_TextMenu + Front_MenuAxisHorizontal

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -606,6 +606,8 @@ DAT_0050c554 0x0050c554 int
 nb_AI_racers 0x0050c558 int # g_uNumRacers
 DAT_0050c55c 0x0050c55c char
 DAT_0050c560 0x0050c560 char
+swrUI_menuArrowAlphaLeft 0x0050c584 float # front-end menu left selector-arrow glow alpha (swrUI_Front_MenuAxisHorizontal)
+swrUI_menuArrowAlphaRight 0x0050c588 float # front-end menu right selector-arrow glow alpha
 
 rdMatrixStack44_size 0x0050c5e8 int
 
@@ -670,6 +672,7 @@ swrEvent_f0SkipMask 0x0050c87c int
 swrEvent_lastManager 0x0050c880 swrEventManager*
 
 debug_showSurfaceFlags 0x0050c88c int
+swrObjHang_menuTextPulsePhase 0x0050c8f4 float # selected menu-item text-color pulse phase (degrees after *360, fed to SinCos)
 
 swrUI_localPlayersInputDownBitset 0x0050C908 int[4]
 swrUI_localPlayersInputPressedBitset 0x0050C918 int[4]
@@ -1046,6 +1049,10 @@ dustKickChildNodes 0x00E28A20 swrModel_Node*[16]
 swrScene_ChildNodes 0x00e29160 swrModel_Node*[151]
 
 swrRace_Transition 0x00e295a0 float
+swrRace_MenuNavLeftActive 0x00e295b0 int # left menu-nav input active this frame (shows marker sprite 0xaf)
+swrRace_MenuNavRightActive 0x00e295b4 int # right menu-nav input active this frame (shows marker sprite 0xac)
+swrRace_MenuCanScrollLeft 0x00e295b8 int # selection > 0 (left selector-arrow glow enabled)
+swrRace_MenuCanScrollRight 0x00e295bc int # selection < max-1 (right selector-arrow glow enabled)
 
 g_bCircuitIdxInRange 0x00e295c4 int
 g_CircuitIdxMax 0x00e295c8 int

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -5,6 +5,9 @@
 #include "swrSprite.h"
 #include "swrText.h"
 
+#include <General/stdMath.h>
+#include <Primitives/rdVector.h>
+
 #include <macros.h>
 
 // 0x00408640
@@ -468,6 +471,12 @@ void swrUI_SetBBox(swrUI_unk* ui, int x, int y, int x2, int y2)
     }
 }
 
+// 0x00415850
+int swrUI_DefaultElementProc(swrUI_unk* ui, unsigned int msg, void* param, int param2)
+{
+    HANG("TODO");
+}
+
 // 0x00416840
 void swrUI_Enqueue(swrUI_unk* ui1, swrUI_unk* toEnqueue)
 {
@@ -502,9 +511,40 @@ int swrUI_HandleKeyEvent2(void* forward2, int)
 }
 
 // 0x00416d90
-swrUI_unk* swrUI_New(swrUI_unk* ui, int id, int new_index, char* mondo_text, int flag, int size_unk2, int size_unk1, swrUI_unk_F1* f1, swrUI_unk_F2* f2)
+swrUI_unk* swrUI_New(swrUI_unk* ui, int id, int new_index, char* mondo_text, int flag, int size_unk2, int size_unk1, swrUI_unk_F1 f1, swrUI_unk_F2 f2)
 {
-    HANG("TODO, easy");
+    unsigned int alloc_size = (size_unk1 + size_unk2) * 4 + 0x15c0;
+    swrUI_unk* elem = (swrUI_unk*)malloc(alloc_size);
+    for (unsigned int i = 0; i < alloc_size >> 2; i++) {
+        ((int*)elem)[i] = 0;
+    }
+
+    if (f1 == NULL) {
+        f1 = (swrUI_unk_F1)swrUI_DefaultElementProc;
+    }
+    elem->str_allocated = swrUI_replaceAllocatedStr(elem->str_allocated, mondo_text);
+    elem->id = id;
+    elem->flags = flag;
+    elem->size_unk2 = size_unk2;
+    elem->size_unk1 = size_unk1;
+    elem->unk01_10 = elem->unk538 + size_unk1 * 4 + 0x38;
+    elem->fun = f1;
+    elem->fun2 = f2;
+    elem->font_index = 0;
+    swrUI_SetBBox(elem, 0, 0, 0x27f, 0x1df);
+    swrUI_SetColorUnk(elem, 0xb7, 0xf5, 0xff, 0xff);
+    swrUI_SetColorUnk2(elem, 0xb7, 0xf5, 0xff, 0xff);
+    swrUI_SetColorUnk4(elem, 0xb7, 0xf5, 0xff, 0xff);
+    swrUI_SetColorUnk3(elem, 0xff, 0xff, 0xff, 0xff);
+    swrUI_SetColorUnk5(elem, 0xff, 0xff, 0xff, 0xff);
+    swrUI_RunCallbacksScreenText(elem, mondo_text, 0);
+    if (new_index == -1) {
+        new_index = 0;
+    }
+    swrUI_ReplaceIndex(elem, new_index);
+    swrUI_Enqueue(ui, elem);
+    swrUI_RunCallbacks(elem, 0xf, 0, 0);
+    return elem;
 }
 
 // 0x00416f20
@@ -615,15 +655,83 @@ void swrUI_Front_HandleCircuits(swrObjHang* hang)
 }
 
 // 0x0043fce0
-void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText)
+void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int rowSpacing, int selectedIndex, int itemIndex, char* screenText)
 {
-    HANG("TODO");
+    rdVector3 color = { 163.0f, 190.0f, 17.0f };
+    rdVector3 colorBase = { 163.0f, 190.0f, 17.0f };
+    rdVector3 colorAlt = { 0.0f, 255.0f, 0.0f };
+
+    if (selectedIndex == itemIndex) {
+        float sin_val;
+        float cos_val;
+        stdMath_SinCos(swrObjHang_menuTextPulsePhase * 360.0f, &sin_val, &cos_val);
+        float t = (sin_val + 1.0f) * 0.5f;
+        rdVector_Scale3Add3_both(&color, t, &colorBase, 1.0f - t, &colorAlt);
+    }
+
+    if (hang->menuScreen == swrObjHang_STATE_MAIN_MENU && hang->activeMenu == 1) {
+        if (selectedIndex == 0 && itemIndex == 0) {
+            swrSprite_SetColor(0x82, (uint8_t)color.x, (uint8_t)color.y, (uint8_t)color.z, 0xff);
+        }
+        if (selectedIndex == 1 && itemIndex == 1) {
+            swrSprite_SetColor(0x83, (uint8_t)color.x, (uint8_t)color.y, (uint8_t)color.z, 0xff);
+        }
+    }
+
+    if (selectedIndex == itemIndex) {
+        swrText_CreateTextEntry1(posX, itemIndex * rowSpacing + posY, (int)color.x, (int)color.y, (int)color.z, -1, screenText);
+    } else {
+        swrText_CreateTextEntry1(posX, itemIndex * rowSpacing + posY, 0x32, -1, -1, -1, screenText);
+    }
 }
 
 // 0x00440150
 void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY)
 {
-    HANG("TODO");
+    float rateLeft = swrRace_MenuCanScrollLeft ? 838.2f : -838.2f;
+    swrUI_menuArrowAlphaLeft += rateLeft * swrRace_fdeltaTimeSecs;
+    if (swrUI_menuArrowAlphaLeft > 254.0f) {
+        swrUI_menuArrowAlphaLeft = 254.0f;
+    }
+    if (swrUI_menuArrowAlphaLeft < 0.0f) {
+        swrUI_menuArrowAlphaLeft = 0.0f;
+    }
+
+    float rateRight = swrRace_MenuCanScrollRight ? 838.2f : -838.2f;
+    swrUI_menuArrowAlphaRight += rateRight * swrRace_fdeltaTimeSecs;
+    if (swrUI_menuArrowAlphaRight > 254.0f) {
+        swrUI_menuArrowAlphaRight = 254.0f;
+    }
+    if (swrUI_menuArrowAlphaRight < 0.0f) {
+        swrUI_menuArrowAlphaRight = 0.0f;
+    }
+
+    swrSprite_SetVisible(0xae, 1);
+    swrSprite_SetPos(0xae, 0x13, posY - 0xe);
+    swrSprite_SetColor(0xae, 0xa3, 0xbe, 0x11, 0xfe);
+    swrSprite_SetVisible(0xad, 1);
+    swrSprite_SetPos(0xad, 0x16, posY - 7);
+    swrSprite_SetColor(0xad, 0x32, 0xff, 0xff, (uint8_t)swrUI_menuArrowAlphaLeft);
+    swrSprite_SetVisible(0xab, 1);
+    swrSprite_SetPos(0xab, 0x10b, posY - 0xe);
+    swrSprite_SetColor(0xab, 0xa3, 0xbe, 0x11, 0xfe);
+    swrSprite_SetVisible(0xaa, 1);
+    swrSprite_SetPos(0xaa, 0x112, posY - 7);
+    swrSprite_SetColor(0xaa, 0x32, 0xff, 0xff, (uint8_t)swrUI_menuArrowAlphaRight);
+    swrSprite_SetVisible(0xb0, 1);
+    swrSprite_SetPos(0xb0, 0x30, posY - 4);
+    swrSprite_SetColor(0xb0, 0xa3, 0xbe, 0x11, 0xfe);
+    swrSprite_SetDim(0xb0, 73.0f, 1.0f);
+    if (swrRace_MenuNavRightActive != 0) {
+        swrSprite_SetVisible(0xac, 1);
+        swrSprite_SetPos(0xac, 0xe8, posY - 0x13);
+        swrSprite_SetColor(0xac, 0x32, 0xff, 0xff, 0xfe);
+    }
+    if (swrRace_MenuNavLeftActive != 0) {
+        swrSprite_SetVisible(0xaf, 1);
+        swrSprite_SetPos(0xaf, 0xc, posY - 0x13);
+        swrSprite_SetColor(0xaf, 0x32, 0xff, 0xff, 0xfe);
+    }
 }
 
 // 0x004403e0

--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -437,7 +437,7 @@ void swrUI_SetBBox(swrUI_unk* ui, int x, int y, int x2, int y2);
 void swrUI_Enqueue(swrUI_unk* ui1, swrUI_unk* toEnqueue);
 
 int swrUI_HandleKeyEvent2(void* forward2, int);
-swrUI_unk* swrUI_New(swrUI_unk* ui, int id, int new_index, char* mondo_text, int flag, int size_unk2, int size_unk1, swrUI_unk_F1* f1, swrUI_unk_F2* f2);
+swrUI_unk* swrUI_New(swrUI_unk* ui, int id, int new_index, char* mondo_text, int flag, int size_unk2, int size_unk1, swrUI_unk_F1 f1, swrUI_unk_F2 f2);
 
 void swrUI_ClearAllSprites(swrUI_unk* ui);
 
@@ -455,7 +455,7 @@ void swrUI_Front_HandleCircuits(swrObjHang* hang);
 // Counts playable tracks up to the active one and leaves that as the menu selected index (best guess).
 void swrUI_Front_SeekToCurrentTrack_Maybe(swrObjHang* hang);
 
-void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int param_4, int param_5, int param_6, char* screenText);
+void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int rowSpacing, int selectedIndex, int itemIndex, char* screenText);
 
 void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY);
 


### PR DESCRIPTION
Reimplements three swrUI frontier functions (every callee already reimplemented), picked so nothing here touches the GL-takeover render path.

- **swrUI_New** (0x00416d90) — the generic widget constructor: alloc + zero-init, default element proc, string copy, id/flags/sizes/procs, `SetBBox` + the five `SetColorUnk*` defaults, `RunCallbacksScreenText`, `ReplaceIndex`, `Enqueue`, `RunCallbacks(0xF)`. Also corrects its `f1`/`f2` param types (`swrUI_unk_F1*`/`F2*` → plain `swrUI_unk_F1`/`F2`) — they're assigned straight into the `fun`/`fun2` fn-ptr fields, so the pointer-to-fn-ptr decls were a bug.
- **swrUI_Front_TextMenu** (0x0043fce0) — draws a menu text row; pulses the selected item's colour orange↔green via `SinCos(phase*360)` and tints sprites 0x82/0x83 on the main menu.
- **swrUI_Front_MenuAxisHorizontal** (0x00440150) — ramps the two selector-arrow glow alphas by ±838.2·dt (gated on the can-scroll flags), clamps [0,254], positions/colours the arrow/bar sprites + two conditional press-markers.

Names 7 globals (writers traced via `swrObjHang_NavigateVehicleSelect`/`UpdateJunkyard`): `swrRace_MenuCanScrollLeft/Right`, `swrRace_MenuNavLeftActive/RightActive`, `swrUI_menuArrowAlphaLeft/Right`, `swrObjHang_menuTextPulsePhase`.

Adds a `HANG` stub for `swrUI_DefaultElementProc` (0x00415850, called by `swrUI_New`) so the dll still links.

Verified: `-O3`/`-O0` compile clean under both `-Werror` gates, `-O0` disasm call sequences match Ghidra, full `libdinput_hook.dll` link succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)