### PR TITLE
fix(cursor): stop double cursor on results screen + cursor options

### DIFF
--- a/dinput_hook/game_deltas/stdConsole_delta.cpp
+++ b/dinput_hook/game_deltas/stdConsole_delta.cpp
@@ -78,7 +78,10 @@ int stdConsole_GetCursorPos_delta(int *out_x, int *out_y) {
 
     *out_x = virtual_cursor_pos.x;
     *out_y = virtual_cursor_pos.y;
-    swrSprite_SetVisible(249, 0);
+    // Force the game's software cursor sprite hidden so only the OS pointer shows -- unless the
+    // player opted into the game cursor, in which case swrSprite_DisplayCursor draws it.
+    if (!imgui_state.cursor_use_game_sprite)
+        swrSprite_SetVisible(swrUISprite_d_cursor_rgb_0, 0);
     return 1;
 }
 

--- a/dinput_hook/game_deltas/swrSprite_delta.cpp
+++ b/dinput_hook/game_deltas/swrSprite_delta.cpp
@@ -2,6 +2,7 @@
 
 #include "../ui_transform.h"
 #include "../hook_helper.h"
+#include "../imgui_utils.h" // imgui_initialized + imgui_state.cursor_use_game_sprite
 
 extern "C" {
 #include <Swr/swrSprite.h>
@@ -10,6 +11,8 @@ extern "C" {
 
 #include <globals.h>
 #include <windows.h>
+
+#include <GLFW/glfw3.h>
 
 #include <cmath>
 
@@ -163,4 +166,54 @@ void swrSprite_SetPos_delta(short id, short x, short y) {
     // Call the ORIGINAL via the trampoline; calling swrSprite_SetPos by name would re-enter this
     // same hook (the symbol resolves to the hooked EXE address) -> infinite recursion.
     hook_call_original(swrSprite_SetPos, id, x, y);
+}
+// Cursor visibility (see imgui_state.cursor_use_game_sprite). Default is the OS pointer, so the
+// game's own software cursor sprite (swrUISprite_d_cursor_rgb_0 = 249) must stay hidden: the vanilla
+// swrSprite_DisplayCursor shows it whenever swrSprite_mouseVisible >= 1 and relies on
+// swrUI_ProcessMouse re-hiding it (via stdConsole_GetCursorPos_delta) the same frame; on screens where
+// ProcessMouse early-outs -- notably the post-race results screen -- that re-hide is skipped and the
+// software cursor leaks on top of the OS cursor (issue #192), so we force it hidden here without
+// touching swrSprite_mouseVisible (swrUI_ProcessMouse still runs its hit-testing). In game-cursor mode
+// the OS pointer is hidden instead, so we draw the sprite (and fix up its position, see below). When
+// OS-cursor management is absent (imgui not initialized, e.g. RENDERER_REPLACEMENT=OFF) the software
+// cursor IS the real cursor, so fall back to the vanilla EXE routine via its trampoline.
+typedef void (*swrSprite_DisplayCursor_t)(void);
+
+void swrSprite_DisplayCursor_delta(void) {
+    // No OS-cursor management (imgui not up, e.g. RENDERER_REPLACEMENT=OFF): the software cursor IS
+    // the real cursor, so run the vanilla routine via its trampoline.
+    if (!imgui_initialized) {
+        hook_call_original((swrSprite_DisplayCursor_t) swrSprite_DisplayCursor_ADDR);
+        return;
+    }
+    // Game-cursor mode: the OS pointer is hidden by update_os_cursor, so draw the software cursor
+    // sprite. Let vanilla handle visibility + the sprite's dim/color/flags first. Vanilla positions
+    // the sprite via stdConsole_GetCursorPos -> swrSprite_SetPos, but that path returns coords tuned
+    // for menu HIT-TESTING (layout space with the UI-centering offset removed), NOT for drawing, so
+    // the sprite lands off from the pointer. Reposition it at the true framebuffer pixel of the OS
+    // pointer, converted into the sprite's own draw space and bypassing UI-centering via the SetPos
+    // trampoline. The cursor sprite is a 640x480 widget-space sprite (draws at ui_layout_scale), so
+    // invert that scale when the resolution-independent transform is on; when off, use the per-axis
+    // vanilla stretch scale. Harmless when the sprite is hidden (vanilla already set it invisible).
+    if (imgui_state.cursor_use_game_sprite) {
+        hook_call_original((swrSprite_DisplayCursor_t) swrSprite_DisplayCursor_ADDR);
+        GLFWwindow *window = glfwGetCurrentContext();
+        int ww = 0;
+        int wh = 0;
+        glfwGetWindowSize(window, &ww, &wh);
+        if (ww > 0 && wh > 0 && swrDisplay_screenWidth > 0 && swrDisplay_screenHeight > 0) {
+            double cx = 0.0;
+            double cy = 0.0;
+            glfwGetCursorPos(window, &cx, &cy);
+            UiVec2 px = {(float) cx * (float) swrDisplay_screenWidth / (float) ww,
+                        (float) cy * (float) swrDisplay_screenHeight / (float) wh};
+            UiVec2 d = ui_enabled() ? ui_screen_to_design(UI_H_LEFT, UI_V_TOP, px)
+                                    : ui_project_px_to_design(px);
+            hook_call_original(swrSprite_SetPos, (short) swrUISprite_d_cursor_rgb_0,
+                               (short) lroundf(d.x), (short) lroundf(d.y));
+        }
+        return;
+    }
+    // OS-cursor mode (default): the OS pointer is the visible cursor, so keep sprite 249 hidden.
+    swrSprite_SetVisible(swrUISprite_d_cursor_rgb_0, 0);
 }

--- a/dinput_hook/game_deltas/swrSprite_delta.h
+++ b/dinput_hook/game_deltas/swrSprite_delta.h
@@ -31,6 +31,18 @@ void swrSprite_SetPos_delta(short id, short x, short y);
 // sprites, vs the HUD/game space (320) for direct SetPos callers.
 void swrUI_RenderElementSprites_delta(void *ui);
 
+// 0x00408220 -- swrSprite_DisplayCursor. On the GLFW/OS-cursor path the real mouse pointer is the
+// only cursor that should be visible, so the game's software cursor sprite
+// (swrUISprite_d_cursor_rgb_0 = 249) must stay hidden. The vanilla routine (called every
+// swrMain2_GuiAdvance) SHOWS sprite 249 whenever swrSprite_mouseVisible >= 1, and it is only
+// re-hidden as a side effect of swrUI_ProcessMouse -> swrUI_UpdateMouseState ->
+// stdConsole_GetCursorPos. On screens where swrUI_ProcessMouse takes an early-out (e.g. the post-race
+// results screen) that re-hide never runs, so the software cursor leaks on top of the OS cursor -> a
+// double cursor (issue #192). This wrapper force-hides sprite 249 instead of showing it, WITHOUT
+// touching swrSprite_mouseVisible (so swrUI hit-testing still works). Falls back to the vanilla
+// routine when imgui/OS-cursor management is absent (RENDERER_REPLACEMENT=OFF).
+void swrSprite_DisplayCursor_delta(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -242,6 +242,9 @@ void read_settings_ini() {
     imgui_state.show_pod_names =
         GetPrivateProfileIntW(L"settings", L"show_pod_names", 1, ini_path.c_str());
 
+    imgui_state.cursor_use_game_sprite =
+        GetPrivateProfileIntW(L"settings", L"cursor_use_game_sprite", 0, ini_path.c_str()) != 0;
+
     imgui_state.mp_allow_upgrades =
         GetPrivateProfileIntW(L"settings", L"mp_allow_upgrades", 0, ini_path.c_str());
     for (int i = 0; i < 7; i++) {
@@ -314,6 +317,9 @@ void save_settings_ini() {
 
     WritePrivateProfileStringW(L"settings", L"show_pod_names",
                                imgui_state.show_pod_names ? L"1" : L"0", ini_path.c_str());
+
+    WritePrivateProfileStringW(L"settings", L"cursor_use_game_sprite",
+                               imgui_state.cursor_use_game_sprite ? L"1" : L"0", ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"mp_allow_upgrades",
                                imgui_state.mp_allow_upgrades ? L"1" : L"0", ini_path.c_str());
@@ -506,6 +512,51 @@ void set_texture_highlighting(TEXID tex, bool enable) {
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
+// One-per-frame owner of the OS mouse-cursor visibility, run before ImGui's GLFW backend applies its
+// own cursor in ImGui_ImplGlfw_NewFrame. When the F5 debug overlay is open we hand cursor control back
+// to ImGui (so its window/text cursors work). Otherwise we take ownership via
+// ImGuiConfigFlags_NoMouseCursorChange (which makes the backend leave GLFW_CURSOR alone) and drive it:
+//   - "game cursor" mode: hide the OS pointer entirely; the game's software cursor sprite (id 249,
+//     drawn by swrSprite_DisplayCursor_delta) is the only visible cursor.
+//   - "OS cursor" mode: show the OS pointer, but hide it after CURSOR_IDLE_HIDE_SECONDS of no mouse
+//     activity so a parked pointer does not sit on screen mid-race (issue #192 follow-up). Any mouse
+//     move or button press brings it straight back.
+static void update_os_cursor(GLFWwindow *window) {
+    // Idle timeout before the OS pointer auto-hides (seconds).
+    const double CURSOR_IDLE_HIDE_SECONDS = 3.0;
+
+    ImGuiIO &io = ImGui::GetIO();
+
+    if (show_imgui) {
+        io.ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange;
+        return;
+    }
+    io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
+
+    static double last_x = 0.0;
+    static double last_y = 0.0;
+    static double last_activity = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    glfwGetCursorPos(window, &x, &y);
+    const double now = glfwGetTime();
+    const bool clicking = glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS ||
+                          glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS;
+    if (x != last_x || y != last_y || clicking) {
+        last_x = x;
+        last_y = y;
+        last_activity = now;
+    }
+
+    int desired = GLFW_CURSOR_NORMAL;
+    if (imgui_state.cursor_use_game_sprite ||
+        (now - last_activity) >= CURSOR_IDLE_HIDE_SECONDS) {
+        desired = GLFW_CURSOR_HIDDEN;
+    }
+    if (glfwGetInputMode(window, GLFW_CURSOR) != desired)
+        glfwSetInputMode(window, GLFW_CURSOR, desired);
+}
+
 void imgui_Update() {
     GLFWwindow *glfw_window = glfwGetCurrentContext();
     if (!imgui_initialized) {
@@ -535,6 +586,7 @@ void imgui_Update() {
 
     if (imgui_initialized) {
         apply_cheats();
+        update_os_cursor(glfw_window);
 
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
@@ -963,6 +1015,13 @@ static void panel_graphics_settings() {
 
     if (ImGui::Checkbox("Overhead racer labels (MP names / SP place)",
                         &imgui_state.show_pod_names)) {
+        save_settings_ini();
+    }
+
+    // Cursor: OS pointer (default; auto-hides after a few idle seconds so it does not linger on
+    // screen mid-race, issue #192 follow-up) or the game's own software cursor sprite.
+    if (ImGui::Checkbox("Use game cursor (hide OS pointer)",
+                        &imgui_state.cursor_use_game_sprite)) {
         save_settings_ini();
     }
 

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -67,6 +67,12 @@ typedef struct ImGuiState {
     // otherwise ignores every audio setting (the startup movies play at hardcoded full volume).
     float master_volume = 1.0f;  // 0..1, applied via swrSound_SetOutputGain
     float cutscene_volume = 0.7f;// 0..1, multiplied by master_volume for Smush cinematics
+
+    // Cursor source (driven each frame by update_os_cursor + swrSprite_DisplayCursor_delta).
+    // false (default): show the OS pointer, auto-hidden after a few idle seconds so a parked pointer
+    // does not linger on screen mid-race. true: hide the OS pointer and draw the game's own software
+    // cursor sprite (id 249) instead. Persisted to SW_RACER_RE.ini.
+    bool cursor_use_game_sprite = false;
 } ImGuiState;
 
 extern "C" {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1478,6 +1478,10 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) stdConsole_GetCursorPos_delta);
     hook_function("stdConsole_SetCursorPos", (uint32_t) 0x00408360,
                   (uint8_t *) stdConsole_SetCursorPos_delta);
+    // Keep the game's software cursor sprite (id 249) hidden so only the OS/GLFW pointer shows; the
+    // vanilla side-effect that re-hides it misses the post-race results screen -> double cursor (#192).
+    hook_function("swrSprite_DisplayCursor", (uint32_t) swrSprite_DisplayCursor_ADDR,
+                  (uint8_t *) swrSprite_DisplayCursor_delta);
 
     // 2D UI resolution-independent transform (gated by imgui_state.ui_resolution_independent).
     // Pairs the swrSprite_array/menu-frame scale + the text recip with the cursor remap below.


### PR DESCRIPTION
Fixes #192. On the post-race results screen the game's software cursor sprite showed on top of the OS pointer (a double cursor) until you clicked to refocus. `swrUI_ProcessMouse` early-outs on that screen, so the per-frame re-hide that normally keeps the sprite hidden never ran. Now `swrSprite_DisplayCursor_delta` keeps the sprite hidden directly.

While in there, two small cursor QoL options (one per-frame cursor manager in `update_os_cursor`):

- **Idle auto-hide (default on):** the OS pointer hides after ~3s of no mouse movement so a parked pointer doesn't sit on screen mid-race; any move/click brings it back.
- **"Use game cursor" toggle (default off):** hides the OS pointer and draws the game's own software cursor sprite instead. It's repositioned at the true mouse pixel in the sprite's draw space, since the vanilla `GetCursorPos` path is tuned for menu hit-testing (layout space + UI-centering), not drawing.

All delta-layer; no sim/reimpl changes. Playtested: results screen is single-cursor, idle-hide works in menus and races, and the game cursor tracks 1:1 across the screen (incl. with resolution-independent UI on).