### PR TITLE
fix(hangar): 3-lap record name order + Anakin favorite portrait

### DIFF
--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -1129,8 +1129,8 @@ LAB_0043b9b4:
             if (hang->track_index < DEFAULT_NB_TRACKS && DAT_00e365f4[iVar6] < 3599.0f) {
 
                 uint8_t PilotIdx = DAT_00e37404[iVar6];
-                char *pNameFirst = swrText_Translate(swrRacer_PodData[PilotIdx].lastname);
-                char *pNameLast = swrText_Translate(swrRacer_PodData[PilotIdx].name);
+                char *pNameFirst = swrText_Translate(swrRacer_PodData[PilotIdx].name);
+                char *pNameLast = swrText_Translate(swrRacer_PodData[PilotIdx].lastname);
 
                 sprintf(local_40, "~f4~c~s%s %s", pNameFirst, pNameLast);
                 swrText_CreateTextEntry1(100, 78, 163, 190, 17, 255, local_40);
@@ -1169,6 +1169,13 @@ LAB_0043b9b4:
                                  swrText_Translate(g_pTxtTrackFavorite));
         sprintf(local_40, "~f4~c~s%s %s", pNameFirst, pNameLast);
         swrText_CreateTextEntry1(240, 137, 163, 190, 17, 255, local_40);
+        // The favorite portrait uses the "+0" pilot-face sprite group (slots [0,23)), whose low
+        // indices are shared with other front-end sprites that overwrite the slot's texture -- most
+        // visibly slot 0, so the favorite comes up blank whenever the favorite pilot is Anakin
+        // (index 0). The same pilot's face also lives in the "+23"/"+46" record-portrait groups,
+        // which only ever get their position/visibility/color changed (never their texture), so
+        // restore the favorite slot's face from its intact "+23" sibling before drawing it.
+        swrSprite_NewSprite(FavPilotIdx, swrSprite_array[FavPilotIdx + 23].texture);
         swrSprite_SetVisible(FavPilotIdx, true);
         swrSprite_SetPos(FavPilotIdx, 208, 145);
         swrSprite_SetDim(FavPilotIdx, 1.0, 1.0);


### PR DESCRIPTION
Two small bugs on the course-info screen (`swrRace_CourseInfoMenu`), both spotted while playtesting track select.

**1. 3-lap record holder shown lastname-first.** In the 3-lap block the `pNameFirst`/`pNameLast` locals were assigned swapped relative to the `sprintf` order, so it printed e.g. "Skywalker Anakin". The adjacent best-lap block and the original binary both do name-then-lastname; this just matches them. (The swap dates back to the original port of this screen, not a recent change.)

**2. Track-favorite portrait broken when the favorite is Anakin.** The favorite portrait draws from the "+0" pilot-face sprite group, and slot 0 gets its texture (and draw state) overwritten by another front-end sprite. So for Anakin (pilot 0) the favorite slot came up blank, and the clobbered sprite rendered elsewhere on the screen as a stray duplicate portrait; higher-index favorites are unaffected. The same pilot's face is still intact in the "+23"/"+46" record-portrait groups (those only ever get position/visibility/color changed, never their texture), so I re-init the favorite slot from its "+23" sibling before drawing — restoring the correct texture and clearing the stale draw flags. Verified in-game on Boonta (fixes both the blank slot and the stray portrait).

Diff is 9 lines in one file. Left the `+ 23`/`+ 46` group offsets as-is to match the existing record blocks.