### PR TITLE
fix(renderer): faithful near/far clip in GL scene projection

### DIFF
--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -228,6 +228,15 @@ void read_settings_ini() {
     float fov_scale = (float) wcstod(fov_scale_buf, nullptr);
     imgui_state.fov_scale = (fov_scale >= 0.5f && fov_scale <= 2.0f) ? fov_scale : 1.0f;
 
+    imgui_state.console_far_clip =
+        GetPrivateProfileIntW(L"settings", L"console_far_clip", 0, ini_path.c_str());
+    wchar_t far_scale_buf[32] = {0};
+    GetPrivateProfileStringW(L"settings", L"console_far_scale", L"1.0", far_scale_buf, 32,
+                             ini_path.c_str());
+    float console_far_scale = (float) wcstod(far_scale_buf, nullptr);
+    imgui_state.console_far_scale =
+        (console_far_scale >= 0.05f && console_far_scale <= 1.0f) ? console_far_scale : 1.0f;
+
     wchar_t vol_buf[32] = {0};
     GetPrivateProfileStringW(L"settings", L"master_volume", L"1.0", vol_buf, 32, ini_path.c_str());
     float master_volume = (float) wcstod(vol_buf, nullptr);
@@ -298,6 +307,11 @@ void save_settings_ini() {
                                ini_path.c_str());
     WritePrivateProfileStringW(L"settings", L"fov_scale",
                                std::to_wstring(imgui_state.fov_scale).c_str(), ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"console_far_clip",
+                               imgui_state.console_far_clip ? L"1" : L"0", ini_path.c_str());
+    WritePrivateProfileStringW(L"settings", L"console_far_scale",
+                               std::to_wstring(imgui_state.console_far_scale).c_str(),
+                               ini_path.c_str());
 
     WritePrivateProfileStringW(L"settings", L"master_volume",
                                std::to_wstring(imgui_state.master_volume).c_str(),
@@ -959,6 +973,19 @@ static void panel_graphics_settings() {
     // Camera FOV multiplier (1.0 = game default; aspect handled automatically via Hor+).
     if (ImGui::SliderFloat("FOV scale", &imgui_state.fov_scale, 0.5f, 2.0f, "%.2f")) {
         save_settings_ini();
+    }
+
+    // Far-plane clip. Off (default) = PC behavior: infinite far plane, draws to the fog horizon. On =
+    // console-style hard far clip at the game's own draw distance times the scale below (1.0 = full
+    // draw distance, lower = shorter / more aggressive pop-in). Near plane stays at zNear.
+    if (ImGui::Checkbox("Console far clip", &imgui_state.console_far_clip)) {
+        save_settings_ini();
+    }
+    if (imgui_state.console_far_clip) {
+        if (ImGui::SliderFloat("Far clip (x draw distance)", &imgui_state.console_far_scale, 0.05f,
+                               1.0f, "%.2f")) {
+            save_settings_ini();
+        }
     }
 
     if (ImGui::Checkbox("Overhead racer labels (MP names / SP place)",

--- a/dinput_hook/imgui_utils.h
+++ b/dinput_hook/imgui_utils.h
@@ -60,6 +60,16 @@ typedef struct ImGuiState {
     // handled in the projection (Hor+: the 4:3 vertical fov is held constant across ratios). Persisted.
     float fov_scale = 1.0f;
 
+    // Far-plane clip. The PC release draws to the fog horizon with no hard far clip (rdCamera_New
+    // passes bFarClip = 0), so the GL scene projection defaults to an infinite far plane. The console
+    // versions honored a hard far clip (short draw distance / geometry pop-in); console_far_clip
+    // reproduces that by clipping at the game's own per-viewport far_clipping (the camera-man's
+    // draw distance, already scaled by the VIDEO_DRAWDISTANCE config) times console_far_scale.
+    // scale 1.0 == the game's full draw distance; lower == shorter / more aggressive console pop-in.
+    // The near plane stays at the game's zNear. Persisted.
+    bool console_far_clip = false;
+    float console_far_scale = 1.0f;
+
     // Audio volumes the vanilla engine never persisted, kept mod-side (SW_RACER_RE.ini [settings]).
     // master_volume drives the A3D device output gain (scales every swrSound channel); the engine
     // forces that gain to 1.0 at the tail of swrSound_Startup on every boot, so we re-apply this.

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1008,8 +1008,7 @@ void swrViewport_Render_Hook(int x) {
     const bool mirrored = (GameSettingFlags & 0x4000) != 0;
 
     const rdClipFrustum *frustum = rdCamera_pCurCamera->pClipFrustum;
-    float f = frustum->zFar;
-    float n = frustum->zNear;
+    const float n = frustum->zNear;
     const float t = 1.0f / tan(0.5 * rdCamera_pCurCamera->fov / 180.0 * 3.14159);
     // The game's fov is the HORIZONTAL fov, calibrated for 4:3. Hold the 4:3 VERTICAL fov constant
     // across aspect ratios (Hor+) so widescreen reveals more horizontally instead of cropping the
@@ -1019,11 +1018,39 @@ void swrViewport_Render_Hook(int x) {
     const float fov_scale = imgui_state.fov_scale > 0.0f ? imgui_state.fov_scale : 1.0f;
     const float yscale = (h > 0) ? (float) (t * design_aspect / fov_scale) : t;
     const float xscale = (w > 0) ? (float) (yscale * (float) h / (float) w) : t;
+    // Perspective projection (view space is right-handed, forward = -z; see n64_shader.vert where
+    // passZ = -posView.z). Row 3 is (0,0,-1,0) so clip.w = -z and a real near plane at zNear cleanly
+    // near-clips (the old matrix used vD.w = 1 -> clip.w = 1 - z, which rendered geometry up to ~1
+    // unit BEHIND the camera and tore triangles straddling the camera plane -- the pod engines
+    // vanishing during the opening orbit / backward cam).
+    //
+    // Far plane: the PC release disables the far clip (rdCamera_New passes bFarClip = 0), so we
+    // default to an infinite far plane (projC/projD below): clip.z = -z - 2n, NDC z = 1 + 2n/z,
+    // which never far-clips and draws to the fog horizon. The "Console far clip" toggle instead uses
+    // a finite far plane to reproduce the console versions' hard far clip (short draw distance /
+    // pop-in). It clips at the game's OWN per-viewport far_clipping -- the camera-man's draw distance
+    // (swrViewport_SetCameraParameters, already scaled by the VIDEO_DRAWDISTANCE config) -- times a
+    // user scale.
+    //
+    // Near and far deliberately come from different sources: n stays on the rdCamera frustum because
+    // that is the value the vanilla clipper actually near-clips at (rdCache_SendFaceListToHardware
+    // sets rdCache_currentZNear = frustum->zNear), and it is effectively constant. The live draw
+    // distance is only tracked on the viewport; the static rdCamera frustum zFar (15 at init) is
+    // never updated to it, so far must be read from vp, not the frustum.
+    float projC = -1.0f;      // vC.z (infinite far)
+    float projD = -2.0f * n;  // vD.z
+    if (imgui_state.console_far_clip) {
+        const float far_dist = vp.far_clipping * imgui_state.console_far_scale;
+        if (far_dist > n) {// guard against an unset/degenerate viewport far clip (menus etc.)
+            projC = -(far_dist + n) / (far_dist - n);
+            projD = -2.0f * far_dist * n / (far_dist - n);
+        }
+    }
     const rdMatrix44 proj_mat{
         {mirrored ? -xscale : xscale, 0, 0, 0},
         {0, yscale, 0, 0},
-        {0, 0, -(f + n) / (f - n), -1},
-        {0, 0, -2 * f * n / (f - n), 1},
+        {0, 0, projC, -1},
+        {0, 0, projD, 0},
     };
 
     rdMatrix44 view_mat;


### PR DESCRIPTION
The GL scene projection built its perspective matrix with a stray `vD.w = 1` (so `clip.w = 1 - z` instead of `-z`). That's not a real perspective -- it rendered geometry up to ~1 unit *behind* the camera and tore triangles crossing the camera plane. The visible symptom was the pod engines clipping off during the opening orbit and backward cam.

Fix: proper perspective (`clip.w = -z`) with a real near plane at `zNear`.

For the far plane I default to an **infinite** far plane, matching the PC release (which disables the far clip -- `rdCamera_New` passes `bFarClip = 0`), so the scene draws to the fog horizon. I also added an optional **"Console far clip"** toggle (Graphics settings, off by default) that reproduces the console versions' hard far clip -- clipping at the game's own per-viewport `far_clipping` (the live draw distance from `swrViewport_SetCameraParameters`) scaled by a slider.

Note: near reads `frustum->zNear` (what the vanilla clipper actually near-clips at) while far reads `vp.far_clipping` -- the static `rdCamera` frustum `zFar` is stale and never updated to the live draw distance.