### PR TITLE
fix(renderer): only alpha-test meshes that enable alpha compare (#193)

### DIFF
--- a/assets/shaders/n64_shader.frag
+++ b/assets/shaders/n64_shader.frag
@@ -18,6 +18,9 @@ uniform vec4 fogColor;
 uniform uint modelId;
 uniform ivec2 mousePosition;
 
+// N64 render mode alpha_compare field: 0 = AC_NONE, 1 = AC_THRESHOLD, 3 = AC_DITHER.
+uniform int alphaCompareMode;
+
 vec3 HSV_to_RGB(float h, float s, float v) {
     h = fract(h) * 6.0;
     int i = int(h);
@@ -73,6 +76,10 @@ void main() {
     if (fogEnabled)
         color.xyz = mix(color.xyz, fogColor.xyz, clamp((passZ - fogStart) / (fogEnd - fogStart), 0, 1));
 
-    if (color.a < 0.01)
+    // Only cull pixels on their alpha when the material actually enables alpha compare.
+    // The N64 does not test alpha for opaque materials, so an unconditional discard punched
+    // holes in opaque textures that happen to carry near-zero alpha texels (issue #193, e.g.
+    // Sebulba). Threshold ~0 matches the game's own alpha test (GL_GREATER, 0: draw where a > 0).
+    if (alphaCompareMode != 0 && color.a < 0.01)
         discard;
 }

--- a/dinput_hook/n64_shader.cpp
+++ b/dinput_hook/n64_shader.cpp
@@ -203,6 +203,7 @@ get_or_compile_color_combine_shader(ImGuiState &state,
         .fog_color_pos = glGetUniformLocation(program, "fogColor"),
         .model_id_pos = glGetUniformLocation(program, "modelId"),
         .mouse_position_pos = glGetUniformLocation(program, "mousePosition"),
+        .alpha_compare_mode_pos = glGetUniformLocation(program, "alphaCompareMode"),
     };
 
     shader_map.insert_or_assign(combiners, shader);

--- a/dinput_hook/n64_shader.h
+++ b/dinput_hook/n64_shader.h
@@ -155,6 +155,7 @@ struct ColorCombineShader {
     GLint fog_color_pos;
     GLint model_id_pos;
     GLint mouse_position_pos;
+    GLint alpha_compare_mode_pos;
 };
 
 std::string dump_blend_mode(const RenderMode &mode, bool mode2);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -473,6 +473,9 @@ void debug_render_mesh(const swrModel_Mesh *mesh, int light_index, int num_enabl
     const auto &[r, g, b, a] = n64_material->primitive_color;
     glUniform4f(shader.primitive_color_pos, r / 255.0, g / 255.0, b / 255.0, a / 255.0);
 
+    // Only let the shader cull pixels on alpha when the material enables alpha compare (issue #193).
+    glUniform1i(shader.alpha_compare_mode_pos, ((const RenderMode &) render_mode).alpha_compare);
+
     glUniform1i(shader.enable_gouraud_shading_pos, vertices_have_normals);
     glUniform3fv(shader.ambient_color_pos, 1, &lightAmbientColor[light_index].x);
     glUniform3fv(shader.light_color_pos, 1, &lightColor1[light_index].x);


### PR DESCRIPTION
Fixes #193.

The N64 combiner shader was discarding every pixel with `alpha < 0.01` unconditionally — even for opaque materials. Textures like Sebulba's that carry a few near-zero alpha texels ended up with holes.

Fix: only run the discard when the material's render-mode `alpha_compare` field is set. Opaque materials now ignore alpha, matching the N64 (which only tests alpha when alpha compare is enabled) and the game's own `GL_GREATER, 0` alpha test. Cutout materials (`AC_THRESHOLD`/`AC_DITHER`) still discard as before.

Playtested: Sebulba's holes are gone, cutout textures still cut out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)