### PR TITLE
Fix scrambled N64 mip/LOD textures (Oovo IV tunnels, Ord Ibanna plates)

### DIFF
--- a/dinput_hook/game_deltas/std3D_delta.cpp
+++ b/dinput_hook/game_deltas/std3D_delta.cpp
@@ -2,6 +2,7 @@
 #include <glad/glad.h>
 
 #include "../imgui_utils.h"
+#include "../renderer_hook.h"
 
 extern "C" {
 #include <macros.h>
@@ -339,6 +340,7 @@ void std3D_AllocSystemTexture_delta(tSystemTexture *pTexture, tVBuffer **apVBuff
 void std3D_ClearTexture_delta(tSystemTexture *pTex) {
     if (pTex->pD3DSrcTexture) {
         GLuint gl_tex = (GLuint) pTex->pD3DSrcTexture;
+        deswizzle_forget_texture(gl_tex);
         glDeleteTextures(1, &gl_tex);
     }
 

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -57,6 +57,7 @@ extern "C" {
 #include <thread>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <algorithm>
 
 
@@ -349,6 +350,69 @@ void parse_display_list_commands(const rdMatrix44 &model_matrix, const swrModel_
     }
 }
 
+// Handles already unscrambled by deswizzle_lod_texture. Cleared per-handle when the underlying
+// texture is freed (deswizzle_forget_texture, called from std3D_ClearTexture_delta) so a GL name
+// reused for a fresh texture after a track reload is unscrambled again rather than skipped.
+static std::unordered_set<GLuint> g_deswizzled_lod_textures;
+
+void deswizzle_forget_texture(GLuint handle) {
+    g_deswizzled_lod_textures.erase(handle);
+}
+
+// A handful of LOD/mip textures (e.g. the Oovo IV tunnel walls f_mip_build02, the Ord Ibanna plates
+// and scaffolds) survived the N64->PC port still in the N64's swizzled TMEM layout: within the
+// original tile, every odd row has its adjacent 8-texel blocks swapped. Nothing in the PC pipeline
+// undoes this, so they upload as a scrambled checkerboard.
+//
+// The wrinkle: the game's texture converter bakes a texture's mirrored-UV wrapping into the upload,
+// duplicating the tile into a 2x-wide and/or 2x-tall image (mirror X then mirror Y). The swizzle
+// lives only in the original tile, so we deswizzle just that tile (top-left ow x oh) and then rebuild
+// the mirror copies from the corrected tile, in the converter's order. Doing the swap on the whole
+// mirrored upload instead re-scrambles the mirrored halves (the Y mirror flips row parity).
+//
+// Done once per GL texture; ow/oh and the mirror flags come from the model's texture spec.
+static void deswizzle_lod_texture(GLuint handle, int ow, int oh, bool mirror_x, bool mirror_y) {
+    if (handle == 0 || g_deswizzled_lod_textures.contains(handle))
+        return;
+
+    glBindTexture(GL_TEXTURE_2D, handle);
+    GLint gw = 0, gh = 0;
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &gw);
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &gh);
+    // The block swap pairs 8-texel blocks along the tile width, so that width must be a whole number
+    // of block pairs and fit the upload. Mark anything else done so we don't retry it every frame.
+    if (gw <= 0 || gh <= 0 || ow <= 0 || oh <= 0 || (ow % 16) != 0 || ow > gw || oh > gh) {
+        g_deswizzled_lod_textures.insert(handle);
+        return;
+    }
+
+    std::vector<uint32_t> buf(size_t(gw) * gh);
+    glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, buf.data());
+
+    // 1) Deswizzle the original tile: on odd rows, swap adjacent 8-texel blocks.
+    std::vector<uint32_t> row(ow);
+    for (int y = 1; y < oh; y += 2) {
+        uint32_t *r = &buf[size_t(y) * gw];
+        std::copy(r, r + ow, row.begin());
+        for (int x = 0; x < ow; x++)
+            r[x + ((x / 8) % 2 == 0 ? 8 : -8)] = row[x];
+    }
+    // 2) Rebuild the baked mirror copies from the corrected tile (X into the right half, then Y into
+    //    the bottom half -- the same order the converter used).
+    if (mirror_x)
+        for (int y = 0; y < oh; y++)
+            for (int x = ow; x < 2 * ow && x < gw; x++)
+                buf[size_t(y) * gw + x] = buf[size_t(y) * gw + (2 * ow - 1 - x)];
+    if (mirror_y)
+        for (int y = oh; y < 2 * oh && y < gh; y++)
+            for (int x = 0; x < gw; x++)
+                buf[size_t(y) * gw + x] = buf[size_t(2 * oh - 1 - y) * gw + x];
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, gw, gh, 0, GL_RGBA, GL_UNSIGNED_BYTE, buf.data());
+    glGenerateMipmap(GL_TEXTURE_2D);
+    g_deswizzled_lod_textures.insert(handle);
+}
+
 void debug_render_mesh(const swrModel_Mesh *mesh, int light_index, int num_enabled_lights,
                        bool mirrored, const rdMatrix44 &proj_matrix, const rdMatrix44 &view_matrix,
                        const rdMatrix44 &model_matrix, MODELID model_id) {
@@ -415,6 +479,19 @@ void debug_render_mesh(const swrModel_Mesh *mesh, int light_index, int num_enabl
         tSystemTexture *sys_tex = tex->loaded_material->aTextures;
         current_texture_handle = GLuint(sys_tex->pD3DSrcTexture);
         glBindTexture(GL_TEXTURE_2D, current_texture_handle);
+
+        // A texture carrying a mip pyramid (more than one tile spec) is stored in the N64's swizzled
+        // TMEM layout in the PC release and uploads scrambled. That mip chain is the LOD marker: it
+        // holds for both the LOD_FRACTION-combiner surfaces (e.g. Oovo tunnels) and the _mipcut_
+        // alpha-cutout ones whose colour combiner never references LOD_FRACTION. Unscramble it the
+        // first time it is bound (skip user replacements, which are already correct).
+        if (tex->specs[1] && !is_replacement_texture_handle(current_texture_handle)) {
+            // Mirror flags share the spec bits the UV scale uses (0x10000000 = mirror X, 0x01000000
+            // = mirror Y); tex->width/height are the original tile dims before the mirror bake.
+            const uint32_t flags = tex->specs[0] ? tex->specs[0]->flags : 0;
+            deswizzle_lod_texture(current_texture_handle, tex->width, tex->height,
+                                  flags & 0x10'00'00'00, flags & 0x01'00'00'00);
+        }
 
         // Magnification filter (see TexMagFilterMode). Unlike the 2D/UI std3D path, the world-mesh
         // path has no per-material point/linear bit to honor (swrModel_Material keeps only the

--- a/dinput_hook/renderer_hook.h
+++ b/dinput_hook/renderer_hook.h
@@ -11,3 +11,7 @@ extern GLuint default_framebuffer;
 extern "C" int stdDisplay_Update_Hook();
 
 extern "C" void init_renderer_hooks();
+
+// Drop a GL texture name from the LOD-deswizzle "already done" set when its texture is freed, so a
+// reused name (after a track reload) is unscrambled again. Called from std3D_ClearTexture_delta.
+void deswizzle_forget_texture(GLuint handle);

--- a/dinput_hook/texture_replacement.cpp
+++ b/dinput_hook/texture_replacement.cpp
@@ -124,3 +124,12 @@ void end_texture_replacement() {
 
     replacement_backup.clear();
 }
+
+bool is_replacement_texture_handle(GLuint handle) {
+    if (handle == 0)
+        return false;
+    for (const auto &[id, tex]: replacement_textures)
+        if (tex.handle == handle)
+            return true;
+    return false;
+}

--- a/dinput_hook/texture_replacement.h
+++ b/dinput_hook/texture_replacement.h
@@ -22,3 +22,6 @@ void refresh_replacement_textures();
 
 void begin_texture_replacement();
 void end_texture_replacement();
+
+// True if handle is a loaded user-replacement texture (already correct, must not be deswizzled).
+bool is_replacement_texture_handle(GLuint handle);


### PR DESCRIPTION
A few `_mip_`/`_mipcut_` textures render as a scrambled checkerboard in the GL renderer — the Oovo IV tunnel walls (`f_mip_build02`), the Ord Ibanna plates/scaffolds/railings, etc. They came across from the N64 still in its swizzled TMEM layout (within the tile, adjacent 8-texel blocks are swapped on every odd row) and nothing in the PC path undoes it.

This deswizzles them in the world-mesh path, detected by their **mip pyramid** (a texture with more than one tile spec) rather than a hardcoded texture list — that catches both the `LOD_FRACTION`-combiner surfaces and the `_mipcut_` alpha-cutout ones. Each texture is fixed once on first bind.

The one wrinkle: the texture converter bakes a texture's mirrored-UV wrapping into a doubled (2×) upload, so the fix deswizzles only the original tile and then rebuilds the mirror copies from it — swapping over the whole mirrored image re-scrambles the mirrored halves (the Y mirror flips row parity). User texture replacements are skipped (already correct).

Playtested on Oovo IV and Ord Ibanna; clean textures untouched.