### PR TITLE
Name verified swrObjTest fields, flag bits, and functions (follow-up to #262)

### DIFF
--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -20,7 +20,7 @@ extern FILE* hook_log;
 #include "../imgui_utils.h"  // imgui_state.mp_disable_collision (the debug-menu toggle)
 #include "swrModel_delta.h"  // swrModel_LoadFromId_delta (loads dust models through the GL path)
 
-// The pod's cockpit->engine cables (unk344_nodeArray[10] and [11]) are bent into a curve each
+// The pod's cockpit->engine cables (partNodes[10] and [11]) are bent into a curve each
 // frame by swrRace's connection-mesh deformer (FUN_00481c30 @ 0x481c30). That deformation is
 // written to the rd3d-converted mesh, which the OpenGL renderer replacement never builds or
 // uses - it renders the original mesh plus the node transform, i.e. the flat/straight cable.
@@ -52,7 +52,7 @@ static float compute_cable_amplitude(const swrRace* player, float k) {
 void swrRace_PoddAnimateVariousThings_delta(swrRace* player) {
     hook_call_original(swrRace_PoddAnimateVariousThings, player);
 
-    swrModel_Node** nodes = player->unk344_nodeArray;
+    swrModel_Node** nodes = player->partNodes;
     if (!nodes)
         return;
 

--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -125,7 +125,7 @@ void __cdecl swrRace_ResolvePodCollision_delta(swrRace* player) {
 }
 
 // --- Ground dust/splash effect: fix the AI-full-LOD contention -------------------------------------
-// swrRace_PoddAnimateVariousThings -> swrRace_SpawnGroundDustKick_Maybe spawns the ground dust/splash
+// swrRace_PoddAnimateVariousThings -> swrRace_SpawnGroundDustKick spawns the ground dust/splash
 // trail. Each spawn takes a Toss entity from a FIXED 16-slot pool (swrEvent_AllocObj) and, on
 // swamp/soft terrain, plays the splash sound (playASound id 0x45). That path only runs for full-model
 // pods, so in vanilla only the local player triggers it. With ai_full_lod every AI pod is a full
@@ -161,17 +161,17 @@ typedef void(__cdecl* playASound_t)(int, short, float, float, int);
 
 void __cdecl playASound_delta(int sound_id, short priority, float volume, float pitch, int flags) {
     // Drop the ground-dust splash sound while a non-local pod is spawning its dust kick (flag set by
-    // swrRace_SpawnGroundDustKick_Maybe_delta below). Only the local player's splash should be heard;
+    // swrRace_SpawnGroundDustKick_delta below). Only the local player's splash should be heard;
     // AI/remote splashes play non-spatially and restart the player's looping voice.
     if (g_suppress_dust_splash_sound && sound_id == DUST_SPLASH_SOUND_ID)
         return;
     hook_call_original((playASound_t) playASound_ADDR, sound_id, priority, volume, pitch, flags);
 }
 
-typedef void(__cdecl* swrRace_SpawnGroundDustKick_Maybe_t)(swrRace*, float*, float, float, float,
+typedef void(__cdecl* swrRace_SpawnGroundDustKick_t)(swrRace*, float*, float, float, float,
                                                            float, int);
 
-void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* transform, float sx,
+void __cdecl swrRace_SpawnGroundDustKick_delta(swrRace* player, float* transform, float sx,
                                                      float sy, float sz, float param_6,
                                                      int param_7) {
     const bool is_local = player != nullptr && (player->flags0 & swrObjTest_FLAG0_LOCAL) != 0;
@@ -183,13 +183,13 @@ void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* tra
         // Keep the AI dust visual, but silence its splash sound for the duration of this call.
         g_suppress_dust_splash_sound = true;
         hook_call_original(
-            (swrRace_SpawnGroundDustKick_Maybe_t) swrRace_SpawnGroundDustKick_Maybe_ADDR, player,
+            (swrRace_SpawnGroundDustKick_t) swrRace_SpawnGroundDustKick_ADDR, player,
             transform, sx, sy, sz, param_6, param_7);
         g_suppress_dust_splash_sound = false;
         return;
     }
 
-    hook_call_original((swrRace_SpawnGroundDustKick_Maybe_t) swrRace_SpawnGroundDustKick_Maybe_ADDR,
+    hook_call_original((swrRace_SpawnGroundDustKick_t) swrRace_SpawnGroundDustKick_ADDR,
                        player, transform, sx, sy, sz, param_6, param_7);
 }
 
@@ -202,7 +202,7 @@ void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* tra
 // function does the same. A NODE_TRANSFORMED_WITH_PIVOT node writes slots [0..3] in
 // swrModel_NodeInit, so each wrapper reserves 4 contiguous swrModel_Node slots.
 // Sized so the shared pool isn't exhausted once far AI also spawn dust (see the reserve in
-// swrRace_SpawnGroundDustKick_Maybe_delta): when free slots hit the reserve, ALL AI skip that frame
+// swrRace_SpawnGroundDustKick_delta): when free slots hit the reserve, ALL AI skip that frame
 // and their trails gap while the (unchecked) player stays smooth. More headroom keeps AI continuous.
 static const int DUST_POOL_SIZE = 128;
 static swrModel_Node g_dustWrappers[DUST_POOL_SIZE * 4];

--- a/dinput_hook/game_deltas/swrRace_delta.h
+++ b/dinput_hook/game_deltas/swrRace_delta.h
@@ -15,10 +15,10 @@ void swrRace_AnimateDisplayPod_delta(swrModel_Node** nodes, void* transform, int
 void swrRace_ResolvePodCollision_delta(swrRace* player);
 
 // ai_full_lod dust/splash fix (hooked by address, both dormant/reverse-hooked originals):
-// - swrRace_SpawnGroundDustKick_Maybe_delta: for non-local pods, reserve Toss-pool headroom (so AI
+// - swrRace_SpawnGroundDustKick_delta: for non-local pods, reserve Toss-pool headroom (so AI
 //   dust never starves the player's trail) and suppress the splash sound.
 // - playASound_delta: drops the dust-splash sound while a non-local dust kick is being spawned.
-void swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* transform, float sx, float sy,
+void swrRace_SpawnGroundDustKick_delta(swrRace* player, float* transform, float sx, float sy,
                                              float sz, float param_6, int param_7);
 void playASound_delta(int sound_id, short priority, float volume, float pitch, int flags);
 

--- a/dinput_hook/node_utils.cpp
+++ b/dinput_hook/node_utils.cpp
@@ -191,7 +191,7 @@ bool is_foreign_hidden_pod_root(const swrModel_Node *node) {
     if ((owner->flags0 & (swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_DEAD)) !=
         swrObjTest_FLAG0_POD_HIDDEN)
         return false;
-    return owner->unk344_nodeArray != nullptr && node == owner->unk344_nodeArray[0];
+    return owner->partNodes != nullptr && node == owner->partNodes[0];
 }
 
 void apply_node_transform(rdMatrix44 &model_mat, const swrModel_Node *node,

--- a/dinput_hook/node_utils.h
+++ b/dinput_hook/node_utils.h
@@ -65,7 +65,7 @@ swrRace *find_entity_for_node(const swrModel_Node *node);
 // camera is hiding (POD_HIDDEN set, DEAD clear) -- a pod the stock game re-shows to other viewports
 // in swrViewport_Render, which the OpenGL renderer replaces and skips. Scene traversal uses this to
 // draw such a pod anyway (otherwise a remote player in bumper cam, or an AI on the post-race autopilot
-// cam, is invisible to everyone). Keyed on the exact node the game hides (owner->unk344_nodeArray[0])
+// cam, is invisible to everyone). Keyed on the exact node the game hides (owner->partNodes[0])
 // so the sub-nodes hidden on purpose (cockpit interior, shadows) are not un-hidden with it.
 bool is_foreign_hidden_pod_root(const swrModel_Node *node);
 

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1750,9 +1750,9 @@ extern "C" void init_renderer_hooks() {
     // trail + splash sound, draining the fixed 16-slot Toss pool and hammering the shared splash
     // voice so the player's trail/sound restarts. Reserve pool headroom + silence the sound for
     // non-local pods. Both originals are dormant (reverse-hooked); hooked by address.
-    hook_function("swrRace_SpawnGroundDustKick_Maybe",
-                  (uint32_t) swrRace_SpawnGroundDustKick_Maybe_ADDR,
-                  (uint8_t *) swrRace_SpawnGroundDustKick_Maybe_delta);
+    hook_function("swrRace_SpawnGroundDustKick",
+                  (uint32_t) swrRace_SpawnGroundDustKick_ADDR,
+                  (uint8_t *) swrRace_SpawnGroundDustKick_delta);
     hook_function("playASound", (uint32_t) playASound_ADDR, (uint8_t *) playASound_delta);
     // Enlarge the dust-kick Toss pool so full-LOD AI dust doesn't starve the player's trail.
     hook_function("swrObjToss_AddDustKickModelsToScene",

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -397,7 +397,7 @@ void swrModel_ByteSwapNode(swrModel_Node* node)
             mesh->num_vertices = SWAP16(mesh->num_vertices);
             // it seems like vertices and index buffer are not swapped, this seems weird...
 
-            mesh->splineNodeIndex = SWAP16(mesh->splineNodeIndex);
+            mesh->splineSampleIndex = SWAP16(mesh->splineSampleIndex);
             mesh->vertex_base_offset = SWAP16(mesh->vertex_base_offset);
         }
 

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -397,7 +397,7 @@ void swrModel_ByteSwapNode(swrModel_Node* node)
             mesh->num_vertices = SWAP16(mesh->num_vertices);
             // it seems like vertices and index buffer are not swapped, this seems weird...
 
-            mesh->unk1 = SWAP16(mesh->unk1);
+            mesh->splineNodeIndex = SWAP16(mesh->splineNodeIndex);
             mesh->vertex_base_offset = SWAP16(mesh->vertex_base_offset);
         }
 

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -190,8 +190,8 @@
 
 #define swrModel_SwapSceneModels_ADDR (0x0045cf30)
 #define swrModel_FxAnimGetState_Maybe_ADDR (0x0046d690)
-#define swrModel_FxAdvanceAnimTimers_Maybe_ADDR (0x0046d6a0)
-#define swrMath_ClampToRange_Maybe_ADDR (0x0046d730)
+#define swrRace_ApplyPartSinkOffset_ADDR (0x0046d6a0)
+#define swrMath_StepTowardClamped_ADDR (0x0046d730)
 #define BuildBasisFromDirection_ADDR (0x00481100)
 #define BuildLookAtTransform_ADDR (0x00481220)
 #define swrModel_ComputeNodeWorldMatrix_Maybe_ADDR (0x004816f0)
@@ -398,11 +398,13 @@ int swrModel_AnyFxAnimDone(swrModel_Animation** anims);
 // Returns zero as an always-not-done FX animation state (best guess).
 int swrModel_FxAnimGetState_Maybe(void);
 
-// Advances up to five FX or engine animation timers by the per-frame delta, gated by enable flags (best guess).
-void swrModel_FxAdvanceAnimTimers_Maybe(int entity);
+// Adds the pod's vertical sink offset (swrRace 0x250) to the Z translation of the engine /
+// cockpit part transforms (partXf[1..5]) each frame. Misnamed historically as anim timers.
+void swrRace_ApplyPartSinkOffset(int entity);
 
-// Clamps a value to a centered range and then to a min/max range (best guess).
-float swrMath_ClampToRange_Maybe(float value, float center, float min, float max, float upper, float lower);
+// Rate-limited approach: clamps value into [current - lower, current + upper], then into
+// [min, max] (asymmetric step toward a target).
+float swrMath_StepTowardClamped(float value, float current, float min, float max, float upper, float lower);
 
 swrModel_Material* swrModel_NodeFindFirstMaterial(swrModel_Node* node);
 void swrModel_NodeSetAnimationFlagsAndSpeed(swrModel_Node* node, swrModel_AnimationFlags flags_to_disable, swrModel_AnimationFlags flags_to_enable, float speed);

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -1847,8 +1847,8 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->flags0 = racer->flags0 & ~swrObjTest_FLAG0_ZOFF;
     racer->splineSampleSpacing = 0.0f;
     racer->splineTrackMesh = NULL;
-    racer->unkf8 = 0;
-    racer->unk100 = 0;
+    racer->splineProjResult1 = 0;
+    racer->splineProjResult2 = 0;
     racer->trackOffset.w = 1.0f;
     racer->trackOffset.x = 0.0f;
     racer->trackOffset.y = 0.0f;

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -418,7 +418,7 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
             firstPlaceRank = rankValues[maxIdx];
 
         swrRace* pod = swrScoresPtr[maxIdx].obj_test_ptr;
-        pod->unk128 = (int)(firstPlaceRank - rankValues[maxIdx]);
+        pod->leaderGap = firstPlaceRank - rankValues[maxIdx];
 
         if (firstLocalPlayer == NULL) {
             pod->rivalGapAhead = -0x3d380000;
@@ -564,8 +564,8 @@ void swrObjJdge_StartPostRaceSequence(swrObjJdge* jdge)
         swrRace* racer = swrScoresPtr[i].obj_test_ptr;
         if (racer != NULL) {
             racer->flags1 &= ~swrObjTest_FLAG1_BOOST_START_CANCEL;
-            // set the flags0 low-nibble race state to 1 (clears RACING == 2)
-            racer->flags0 = (racer->flags0 & 0xfffffff1) | 1;
+            // set the flags0 low-nibble race state to post-race (clears RACING == 2)
+            racer->flags0 = (racer->flags0 & ~swrObjTest_FLAG0_STATE_MASK) | swrObjTest_FLAG0_STATE_POSTRACE;
         }
     }
 }
@@ -839,7 +839,7 @@ void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge)
                     if (gap < -0.5f)
                         gap -= -1.0f;
                     gap = gap * scale * 0.022222222f - -119.0f;
-                    if (*(int*)s->unk18 == -1 || gap > 164.0f || gap < 74.0f)
+                    if (*s->pilotId == -1 || gap > 164.0f || gap < 74.0f)
                         continue;
                     short sprite = (short)(0x2b + i);
                     uint8_t a;
@@ -885,7 +885,7 @@ void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge)
                 x = 20.0f;
                 y = 215.0f - (p - 720.0f);
             }
-            if (*(int*)s->unk18 == -1)
+            if (*s->pilotId == -1)
                 continue;
             short sprite = (short)(0x2b + i);
             swrSprite_SetColor(sprite, -1, -1, -1, -1);
@@ -1005,7 +1005,7 @@ void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge)
                     xBase = 114.0f;
             }
             float y = q * 0.28901735f - -20.0f;
-            if (*(int*)s->unk18 != -1 && (s->obj_test_ptr->flags1 & (swrObjTest_FLAG1_FORCE_GROUND | swrObjTest_FLAG1_ON_LAVA)) == 0) {
+            if (*s->pilotId != -1 && (s->obj_test_ptr->flags1 & (swrObjTest_FLAG1_FORCE_GROUND | swrObjTest_FLAG1_ON_LAVA)) == 0) {
                 short sprite = (short)(0x2b + i);
                 swrSprite_SetVisible(sprite, 1);
                 swrSprite_SetPos(sprite, (short)(int)xBase, (short)(int)y);
@@ -1107,7 +1107,7 @@ int swrObjJdge_IsRacerRacing(swrObjJdge* jdge, swrRace* racer)
         return 0;
     }
 
-    if ((racer->flags1 & swrObjTest_FLAG1_FINISHED) == 0 && (4 < racer->unk10c || racer->speedValue < swrObjJdge_notRacingSpeedThreshold)) {
+    if ((racer->flags1 & swrObjTest_FLAG1_FINISHED) == 0 && (4 < racer->checkpointCount || racer->speedValue < swrObjJdge_notRacingSpeedThreshold)) {
         return 1;
     }
     return 0;
@@ -1126,7 +1126,7 @@ void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score)
 
     if ((racer->flags1 & swrObjTest_FLAG1_FINISHED) != 0) {
         swrRace_InRaceEndStatistics(jdge, score);
-        racer->flags0 &= 0xf7ffffff;
+        racer->flags0 &= ~swrObjTest_FLAG0_GUIDE_ARROW;
         if (someRootNodeChildNodes[nodeIdx] != NULL)
             swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, -4, 0x10, 3);
         swrObjJdge_HideEngineUI(score);
@@ -1135,17 +1135,17 @@ void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score)
 
     if ((jdge->flag & 0xf) == 1) {
         if (swrObjJdge_IsRacerRacing(jdge, racer) == 0) {
-            racer->flags0 &= 0xf7ffffff;
+            racer->flags0 &= ~swrObjTest_FLAG0_GUIDE_ARROW;
             if (someRootNodeChildNodes[nodeIdx] != NULL)
                 swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, -4, 0x10, 3);
         } else {
             if (someRootNodeChildNodes[nodeIdx] != NULL)
                 swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, 3, 0x10, 2);
-            racer->flags0 |= 0x8000000; // flags0 bit 0x8000000 not named in swrObjTest_FLAG0
+            racer->flags0 |= swrObjTest_FLAG0_GUIDE_ARROW;
             rdMatrix44 guideMat;
-            swrSpline_EvaluateAtOffset(&racer->unk4_mat, &guideMat, 0.5f);
-            rdVector_Copy3((rdVector3*)(racer->unk12 + 4), (rdVector3*)&guideMat.vD);
-            *(swrModel_Node**)racer->unk12 = someRootNodeChildNodes[nodeIdx];
+            swrSpline_EvaluateAtOffset(&racer->splineCursor, &guideMat, 0.5f);
+            rdVector_Copy3(&racer->guideArrowTarget, (rdVector3*)&guideMat.vD);
+            racer->guideArrowNode = someRootNodeChildNodes[nodeIdx];
         }
     }
 
@@ -1831,7 +1831,7 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     swrTranslationRotation splineRot;
     rdMatrix44 splineMat;
 
-    swrSpline_EvaluateAtOffset(&racer->unk4_mat, &splineMat, t);
+    swrSpline_EvaluateAtOffset(&racer->splineCursor, &splineMat, t);
     rdMatrix_ExtractTransform(&splineMat, &splineRot);
     racer->spawn_pos_rot.translation.x = splineRot.translation.x;
     racer->spawn_pos_rot.translation.y = splineRot.translation.y;
@@ -1841,20 +1841,20 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->spawn_pos_rot.yaw_roll_pitch.z = splineRot.yaw_roll_pitch.z;
     rdMatrix_SetTransform44(&racer->transform, &racer->spawn_pos_rot);
     // clear per-race transient state bits
-    racer->flags0 = racer->flags0 & ~(swrObjTest_FLAG0_UNDER_POWER_Maybe | swrObjTest_FLAG0_BRAKING | swrObjTest_FLAG0_TP_TO_SPLINE | swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_INPUT_STATE_Maybe | swrObjTest_FLAG0_BOOSTING);
+    racer->flags0 = racer->flags0 & ~(swrObjTest_FLAG0_THROTTLE_SETTLED | swrObjTest_FLAG0_BRAKING | swrObjTest_FLAG0_TP_TO_SPLINE | swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_LOOK_BACK | swrObjTest_FLAG0_BOOSTING);
     racer->flags1 = racer->flags1 & ~(swrObjTest_FLAG1_FLAT_CACHE | swrObjTest_FLAG1_ON_FLAT);
     bool below = t < 0.0f;
     racer->flags0 = racer->flags0 & ~swrObjTest_FLAG0_ZOFF;
-    racer->unkdc = 0;
-    racer->unkec_node = NULL;
+    racer->splineSampleSpacing = 0.0f;
+    racer->splineTrackMesh = NULL;
     racer->unkf8 = 0;
     racer->unk100 = 0;
-    racer->unk118_vec.w = 1.0f;
-    racer->unk118_vec.x = 0.0f;
-    racer->unk118_vec.y = 0.0f;
-    racer->unk118_vec.z = 1.0f;
-    racer->unk10c = 0;
-    racer->unk10e = 0;
+    racer->trackOffset.w = 1.0f;
+    racer->trackOffset.x = 0.0f;
+    racer->trackOffset.y = 0.0f;
+    racer->trackOffset.z = 1.0f;
+    racer->checkpointCount = 0;
+    racer->splineRebindResult = 0;
     racer->idleTick = 0.0f;
     racer->moveTick = 0;
     if (below)
@@ -1869,15 +1869,15 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->boostValue = 0.0f;
     racer->engineTemp = 100.0f;
     rdVector_Set3(&racer->velocityDir, 0.0f, 0.0f, 0.0f);
-    racer->unk1f00 = 0.25f;
+    racer->unk1efc = 0.25f;
     racer->turnRate = 0.0f;
     racer->turnRateTarget = 0.0f;
     racer->unk10_3 = 0;
-    racer->unk10_1 = 0.0f;
-    racer->unk10_2 = 0.0f;
+    racer->zeroGPitchRate = 0.0f;
+    racer->zeroGPitchRateTarget = 0.0f;
     racer->turnModifier = 0.0f;
     racer->autoTilt = 0.0f;
-    racer->unk8_11 = 0.0f;
+    racer->contactSteerKick = 0.0f;
     racer->tiltAngleTarget = 0.0f;
     racer->tiltAngle = 0.0f;
     rdVector_Set3(&racer->velocitySlope, 0.0f, 0.0f, 0.0f);
@@ -1888,20 +1888,20 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     rdVector_Copy3(&racer->positionPrev, (rdVector3*)&racer->transform.vD);
     rdVector_Copy3(&racer->positionDeath, (rdVector3*)&racer->transform.vD);
     racer->speedLoss = 0.0f;
-    racer->unk1f1c = 0;
-    racer->unk11_1 = 0;
-    racer->unk338 = 0;
-    racer->unk33c = 0;
-    racer->unk340 = 0;
     racer->unk1f18 = 0;
+    racer->unk11_1 = 0;
+    racer->spinoutEngineAngle = 0.0f;
+    racer->spinoutCockpitAngle = 0.0f;
+    racer->spinoutSpinRamp = 0.0f;
+    racer->unk1f14 = 0.0f;
     racer->tiltManualMult = 0.0f;
     racer->unk9 = 0;
-    racer->unk12_1 = 0.0f;
+    racer->wallHitCooldown = 0.0f;
     racer->unk19b0 = 0.0f;
     racer->groundToPodMeasure = 0.0f;
     racer->groundZ = 0.0f;
     racer->unk12_2 = 60.0f;
-    racer->unk19ac = 1.0f;
+    racer->wobbleAmplitude = 1.0f;
     racer->unk19b4 = 1.0f;
 }
 

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -444,7 +444,7 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
             firstPlaceRank = rankValues[maxIdx];
 
         swrRace* pod = swrScoresPtr[maxIdx].obj_test_ptr;
-        pod->leaderGap = firstPlaceRank - rankValues[maxIdx];
+        pod->gapToLeader = firstPlaceRank - rankValues[maxIdx];
 
         if (firstLocalPlayer == NULL) {
             pod->rivalGapAhead = -0x3d380000;

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -48,7 +48,7 @@
 #define resetInRaceInputBuffer_ADDR (0x00440d90)
 #define getInRaceInputBufferEntry_Maybe_ADDR (0x00440de0)
 #define updateInRaceInputBitsets_ADDR (0x00440df0)
-#define setInRaceInputState_Maybe_ADDR (0x00441010)
+#define swrModel_SetRaycastIgnoreFacing_ADDR (0x00441010)
 #define swrObjJudge_PollPause_ADDR (0x00445680)
 #define GetPauseState_ADDR (0x00445690)
 #define GetPauseMenuScrollInOut_ADDR (0x004456a0)
@@ -244,7 +244,7 @@
 #define swrScene_Init_ADDR (0x004491f0)
 #define swrScene_ClearTextureAnim_Maybe_ADDR (0x00449260)
 #define swrScene_UpdateTextureScroll_Maybe_ADDR (0x00449270)
-#define swrObjcMan_UpdateSplineGuideMarker_Maybe_ADDR (0x004535c0)
+#define swrObjcMan_UpdateSplineGuideMarker_ADDR (0x004535c0)
 #define swrObjHang_LoadScreenAssets_ADDR (0x004586e0)
 #define swrObjHang_SetupScreenScene_ADDR (0x00459150)
 #define swrUI_ResetMenuInputBitsets_ADDR (0x0045a3e0)
@@ -266,7 +266,7 @@
 #define swrObjHang_StepTransition_ADDR (0x00469b90)
 #define swrObjHang_TickMenuRepeatDelay_Maybe_ADDR (0x00469bf0)
 #define swrObjHang_NavigateVehicleSelect_ADDR (0x00469c30)
-#define swrRace_ClosestApproach2D_Maybe_ADDR (0x0047aee0)
+#define swrRace_ClosestApproach2D_ADDR (0x0047aee0)
 #define swrObjTrig_AddTriggerDescriptions_ADDR (0x0047d380)
 #define swrObjTrig_InitColorBands_Maybe_ADDR (0x0047d890)
 #define swrObjTrig_ApplyNodeRegionColor_Maybe_ADDR (0x0047da10)
@@ -365,14 +365,17 @@ int VerifySelectedTrack(swrObjHang* hang, int selectedTrackIdx);
 // Companion to updateInRaceInputBitsets.
 void* resetInRaceInputBuffer(void);
 
-// Returns the indexed entry from the in-race input buffer (best guess).
+// Returns the indexed entry of the 4-int table at 0x50c5b0; the sole caller
+// (swrObjHang_UpdateSplashScreen) uses entry 1 to append an extra splash screen.
+// NOT input-related despite the name; writer unknown.
 int getInRaceInputBufferEntry_Maybe(int index);
 // Build the per-player rising-edge / held / released in-race input bitsets
 // (inRaceLocalPlayerInputBitset1/2/3) from the raw per-action input bytes.
 void updateInRaceInputBitsets(void);
 
-// Stores a value into the in-race input state global (best guess).
-void setInRaceInputState_Maybe(int value);
+// Sets the flag read by swrModel_CollideMeshNodeRay / CollideRayWithMesh that skips the
+// material-facing classification during raycasts (callers bracket a raycast with 1 / 0).
+void swrModel_SetRaycastIgnoreFacing(int value);
 
 void swrObjJudge_PollPause();
 int GetPauseState();
@@ -424,8 +427,9 @@ void swrObjcMan_UpdateTerrainVisuals(swrObjcMan* cman);
 // along the track spline relative to the pod.
 void swrObjcMan_UpdateSplineCamera(swrObjcMan* cman);
 
-// Per frame advances and positions a trailing spline guide-marker node, setting its color (best guess).
-void swrObjcMan_UpdateSplineGuideMarker_Maybe(int cman);
+// Draws the HUD spline guide arrow for the camera's pod: gated on FLAG0_GUIDE_ARROW,
+// orients guideArrowNode toward guideArrowTarget and tints it.
+void swrObjcMan_UpdateSplineGuideMarker(int cman);
 // Applies FOV/near/far to the viewport and updates fog color/distance and the
 // clear color each frame (swrViewport_SetCameraParameters + SetFogParameters).
 void swrObjcMan_UpdateFogAndViewport(swrObjcMan* cman);
@@ -770,8 +774,9 @@ int swrObjTest_F4(swrRace* player, int* subEvent, int ghost);
 
 void swrObjTest_UpdateControlAndMove(swrRace* player);
 
-// Computes the closest-approach parameter and points between two 2D segments (best guess).
-float swrRace_ClosestApproach2D_Maybe(rdVector2* a0, float* a1, rdVector2* b0, float* b1, rdVector2* outA, rdVector2* outB, rdVector2* outDirA, rdVector2* outDirB);
+// Closest-approach time of two moving 2D points (t clamped to [0,1]) and both positions at
+// that time; used by the pod-pod collision pass.
+float swrRace_ClosestApproach2D(rdVector2* a0, float* a1, rdVector2* b0, float* b1, rdVector2* outA, rdVector2* outB, rdVector2* outDirA, rdVector2* outDirB);
 
 void swrObjTest_UpdatePhysicsContact(swrRace* player);
 void swrObjToss_F2(swrObjToss* toss);

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -366,8 +366,9 @@ int VerifySelectedTrack(swrObjHang* hang, int selectedTrackIdx);
 void* resetInRaceInputBuffer(void);
 
 // Returns the indexed entry of the 4-int table at 0x50c5b0; the sole caller
-// (swrObjHang_UpdateSplashScreen) uses entry 1 to append an extra splash screen.
-// NOT input-related despite the name; writer unknown.
+// (swrObjHang_UpdateSplashScreen) uses entry 1 to append an extra splash screen. NOT
+// input-related despite the name. The table is never written anywhere in the retail
+// binary (BSS, always 0), so the extra splash never shows.
 int getInRaceInputBufferEntry_Maybe(int index);
 // Build the per-player rising-edge / held / released in-race input bitsets
 // (inRaceLocalPlayerInputBitset1/2/3) from the raw per-action input bytes.

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -826,7 +826,7 @@ void swrRace_SetAngleFromTurnRate(float* out_tilt, float cur_turnrate, void* unu
 }
 
 // 0x0044afb0
-void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos)
+void swrRace_GetEngineNodeOffsetPos(void** nodePair, rdVector3* outPos)
 {
     if (nodePair == NULL) {
         rdVector_Set3(outPos, 0.0f, 0.0f, 0.0f);
@@ -852,7 +852,7 @@ void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos)
 }
 
 // 0x0044b270
-void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos)
+void swrRace_SetEngineNodeTranslation(void** nodePair, rdVector3* pos)
 {
     if (nodePair == NULL)
         return;
@@ -872,7 +872,7 @@ void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos)
     }
     rdMatrix44 offsetMat;
     swrModel_NodeGetTransform(offsetNode, &offsetMat);
-    // remove the engine-height offset applied by swrRace_GetEngineNodeOffsetPos_Maybe
+    // remove the engine-height offset applied by swrRace_GetEngineNodeOffsetPos
     rdVector_Scale3Add3((rdVector3*) &out.vD, (rdVector3*) &out.vD, -offsetMat.vD.y, (rdVector3*) &out.vB);
     swrModel_NodeSetTransform(node, &out);
 }

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1585,20 +1585,20 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNorm
 
     swrRace_ResetCollisionHit();
     if ((player->flags1 & swrObjTest_FLAG1_FULL_RAYCAST) == 0)
-        hitDist = swrModel_CollideRayWithMesh((swrModel_Mesh*) player->unkec_node, ray,
+        hitDist = swrModel_CollideRayWithMesh((swrModel_Mesh*) player->splineTrackMesh, ray,
                                               (float*) &outPoint, (float*) &outNormal);
     else
         hitDist = -1.0f;
 
     if (hitDist < 0.0)
-        hitDist = swrRace_RaycastModel(player->model_unk, ray, &outPoint, &outNormal);
+        hitDist = swrRace_RaycastModel(player->collisionModel, ray, &outPoint, &outNormal);
 
     if (((player->flags1 & swrObjTest_FLAG1_MAGNET) != 0) && (hitDist < 0.0)) {
         // surface-relative cast missed: retry straight down (world gravity)
         ray[3] = player->world_gravity.x;
         ray[4] = player->world_gravity.y;
         ray[5] = player->world_gravity.z;
-        hitDist = swrRace_RaycastModel(player->model_unk, ray, &outPoint, &outNormal);
+        hitDist = swrRace_RaycastModel(player->collisionModel, ray, &outPoint, &outNormal);
     }
 
     player->terrainModel = swrRace_GetCollisionHit();
@@ -1654,7 +1654,7 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
             up->x = player->up.x;
             up->y = player->up.y;
             up->z = player->up.z;
-            player->terrainModel = player->unkec_node;
+            player->terrainModel = player->splineTrackMesh;
             flags1 = player->flags1 | swrObjTest_FLAG1_GROUND_CACHED;
         }
         player->flags1 = flags1;
@@ -1687,13 +1687,13 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
 
         if ((((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) && ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0) &&
             (0.0f <= progress && progress <= 1.0f)) {
-            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0);
             velocity[2] = progress * (splineMat.vD.z - velocity[2]) + velocity[2];
         }
 
         if ((player->flags1 & swrObjTest_FLAG1_ON_FLAT) == 0) {
             if ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0) {
-                swrRace_CollideBlockMove((rdVector3*) velocity, &prevPos, player->model_unk, &collideNormal);
+                swrRace_CollideBlockMove((rdVector3*) velocity, &prevPos, player->collisionModel, &collideNormal);
             } else {
                 rdVector3 before;
                 before.x = velocity[0];
@@ -1719,10 +1719,10 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
                                                  groundDist, &up->x);
         }
     } else {
-        player->terrainModel = player->unkec_node;
+        player->terrainModel = player->splineTrackMesh;
         player->flags1 = player->flags1 | swrObjTest_FLAG1_GROUND_CACHED;
         if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) {
-            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0);
             velocity[2] = splineMat.vD.z;
         }
         groundDist = 2.0f;
@@ -1917,7 +1917,7 @@ void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos
     int subEvent[4];
     subEvent[0] = 0x42697473; // 'Bits'
     swrEvent_CallF4(0x54657374, subEvent); // 'Test'
-    player->unk324 = engineSlot;
+    player->fireballEngineSlot = engineSlot;
 
     // Build a random orientation+scale basis for the fireball node.
     rdMatrix44 m;
@@ -1949,13 +1949,13 @@ void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos
 
     // When a valid engine slot is set, position the fireball at that engine's matrix;
     // otherwise use the caller-supplied point.
-    if (player->unk324 >= 0) {
-        pos = (rdVector3*) ((char*) player + (player->unk324 + 0xe) * 0x40);
+    if (player->fireballEngineSlot >= 0) {
+        pos = (rdVector3*) ((char*) player + (player->fireballEngineSlot + 0xe) * 0x40);
     }
     rdVector_Copy3((rdVector3*) &m.vD, pos);
 
     swrModel_Node* src =
-        (player->unk344_nodeArray == NULL) ? player->unk348_node : player->unk344_nodeArray[1];
+        (player->partNodes == NULL) ? player->lodBodyNode : player->partNodes[1];
     swrRace_RandomizeMeshNodes(fireballNodePtr, src);
     rdMatrix_Copy44(&swrRace_fireballTransform, &m);
     swrModel_NodeSetTransform((swrModel_NodeTransformed*) fireballNodePtr, &m);
@@ -2096,12 +2096,12 @@ void swrRace_UpdateTurn2(swrRace* player, rdVector3* pos, rdVector3* turnInput)
         player->transform.vC.y = rc * vCy + rs * vCx;
     }
 
-    player->unk1e6c = player->unk1e6c - 1;
-    if (player->unk1e6c < 0) {
+    player->orthoRenormCounter = player->orthoRenormCounter - 1;
+    if (player->orthoRenormCounter < 0) {
         rdVector_Normalize3Acc((rdVector3*) &player->transform.vA);
         rdVector_Normalize3Acc((rdVector3*) &player->transform.vB);
         rdVector_Normalize3Acc((rdVector3*) &player->transform.vC);
-        player->unk1e6c = 8;
+        player->orthoRenormCounter = 8;
     }
     player->transform.vD.x = pos->x;
     player->transform.vD.y = pos->y;
@@ -2449,9 +2449,9 @@ void swrRace_IntegrateMotion(swrRace* player, rdVector3* b, rdVector3* c, rdVect
     rdVector3 outNormal;
     float savedX = c->x, savedY = c->y, savedZ = c->z;
     int iter;
-    int hit = swrRace_CollideTrack(c, b, player->model_unk, &outNormal);
+    int hit = swrRace_CollideTrack(c, b, player->collisionModel, &outNormal);
     for (iter = 0; hit != 0 && iter < 6; iter++)
-        hit = swrRace_CollideTrack(c, b, player->model_unk, &outNormal);
+        hit = swrRace_CollideTrack(c, b, player->collisionModel, &outNormal);
     if (0 < iter && (player->flags0 & swrObjTest_FLAG0_AI) != 0)
         player->accelThrust *= stdMath_Decelerator(5.0f, swrRace_deltaTimeSecs);
     player->wallPushback.x = c->x - savedX;

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -164,7 +164,7 @@
 #define swrRace_UpdateCatchup_ADDR (0x0046ce30)
 
 // collision / ground-contact physics + explosion spawn
-#define swrRace_SpawnExplosionEffect_ADDR (0x0046ba30)
+#define swrRace_SpawnFlameAttack_ADDR (0x0046ba30)
 #define swrRace_RaycastGround_ADDR (0x004772f0)
 #define swrRace_UpdateHoverPads_ADDR (0x00476740)
 #define swrRace_ApplySlopeSteering_ADDR (0x004791d0)
@@ -219,9 +219,9 @@
 #define swrRace_ResetAllProfiles_ADDR (0x0043d970)
 #define swrRace_CheatUnlockAll_ADDR (0x0043d9a0)
 #define swrRace_ComputeUpgradePrices_ADDR (0x0043eb50)
-#define swrRace_GetEngineNodeOffsetPos_Maybe_ADDR (0x0044afb0)
-#define swrRace_SetEngineNodeRotScale_Maybe_ADDR (0x0044b180)
-#define swrRace_SetEngineNodeTranslation_Maybe_ADDR (0x0044b270)
+#define swrRace_GetEngineNodeOffsetPos_ADDR (0x0044afb0)
+#define swrRace_SetEngineNodeRotScale_ADDR (0x0044b180)
+#define swrRace_SetEngineNodeTranslation_ADDR (0x0044b270)
 #define swrRace_InitDefaultGameData_ADDR (0x0044e320)
 #define swrRace_ComputeSaveChecksum_ADDR (0x0044e440)
 #define swrRace_Crc32_ADDR (0x0044e460)
@@ -233,18 +233,18 @@
 #define swrRace_GetProfileRecordVec3_Maybe_ADDR (0x0044e5a0)
 #define swrRace_UpdatePitDroidModels_Maybe_ADDR (0x00456200)
 #define swrRace_UpdateAIGlidePitch_ADDR (0x0046aec0)
-#define swrRace_SendFlameEvent_Maybe_ADDR (0x0046bb30)
-#define swrRace_SpawnExplosionByIndex_Maybe_ADDR (0x0046bb50)
-#define swrRace_GetEngineUiBarColor_Maybe_ADDR (0x0046bc50)
-#define swrRace_UpdateEngineFireballNode_Maybe_ADDR (0x0046ebf0)
-#define swrRace_ApplyEngineProximityPush_Maybe_ADDR (0x0046ecd0)
-#define swrRace_SpawnGroundDustKick_Maybe_ADDR (0x0046fd60)
-#define swrRace_SmoothEngineExhaustSize_Maybe_ADDR (0x00470510)
-#define swrRace_ResetGravityDown_Maybe_ADDR (0x004764a0)
-#define swrRace_HandleWallScrapeHit_Maybe_ADDR (0x00479d40)
-#define swrRace_UpdateScrapeContact_Maybe_ADDR (0x0047a3a0)
-#define swrRace_UpdateSplineOrientation_Maybe_ADDR (0x0047a610)
-#define swrRace_GetSplineProgressValue_Maybe_ADDR (0x0047f890)
+#define swrRace_SendFlameAttackEvent_ADDR (0x0046bb30)
+#define swrRace_SpawnFlameAttackByIndex_ADDR (0x0046bb50)
+#define swrRace_GetBoostBarColor_ADDR (0x0046bc50)
+#define swrRace_UpdateEngineFireballNode_ADDR (0x0046ebf0)
+#define swrRace_ApplyEngineProximityPush_ADDR (0x0046ecd0)
+#define swrRace_SpawnGroundDustKick_ADDR (0x0046fd60)
+#define swrRace_SmoothEngineExhaustSize_ADDR (0x00470510)
+#define swrRace_ResetGravityDown_ADDR (0x004764a0)
+#define swrRace_HandleWallScrapeHit_ADDR (0x00479d40)
+#define swrRace_ApplySmokProximityPush_ADDR (0x0047a3a0)
+#define swrRace_UpdateSplineOrientation_ADDR (0x0047a610)
+#define swrRace_GetTrackMeshAtCursor_ADDR (0x0047f890)
 
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4);
 
@@ -345,13 +345,13 @@ void swrRace_UpdateTurn(float* param_1, float* param_2, float param_3, float par
 void swrRace_SetAngleFromTurnRate(float* out_tilt, float cur_turnrate, void* unused, float max_turnrate, float max_angle);
 
 // Reads an engine node's world translation and offsets it by the paired node's Y position (best guess).
-void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos);
+void swrRace_GetEngineNodeOffsetPos(void** nodePair, rdVector3* outPos);
 
 // Builds a rotation and scale transform for an engine node, offset by the paired node's Y (best guess).
-void swrRace_SetEngineNodeRotScale_Maybe(void** nodePair, float scale, float angle);
+void swrRace_SetEngineNodeRotScale(void** nodePair, float scale, float angle);
 
 // Copies an engine node's transform and sets its translation minus the paired node's Y offset (best guess).
-void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos);
+void swrRace_SetEngineNodeTranslation(void** nodePair, rdVector3* pos);
 
 void swrRace_ReplaceMarsGuoWithJinnReeso(void);
 void swrRace_ReplaceBullseyeWithCyYunga(void);
@@ -387,8 +387,8 @@ void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotio
 // Extracts pitch + signed-roll angles of a forward/right basis relative to a reference (down) vector.
 void swrRace_ComputeTiltAngles(rdVector3* fwd, rdVector3* right, rdVector3* ref, rdVector3* out);
 
-// Resets the pod's gravity field and down-reference vector to negative Z (best guess).
-void swrRace_ResetGravityDown_Maybe(int player);
+// Resets the pod's gravityScale to its default and world_gravity to negative Z.
+void swrRace_ResetGravityDown(int player);
 // Builds a surface-aligned basis from the pod forward + surface normal and accumulates the heading/tilt
 // correction into pRDot (turn input). The +-85 deg pitch clamp + the magnet (flags1 0x400) gating live here.
 void swrRace_AlignToSurface(swrRace* player, rdVector3* up, rdVector3* fwd_vB, rdVector3* vA_fallback,
@@ -444,10 +444,10 @@ void swrRace_UpdateEngineSound(swrRace* player);
 void swrRace_UpdateEngineDamageFX(swrRace* player);
 
 // Spawns a per-planet ground dust kick with a scrape sound during a vehicle reaction (best guess).
-void swrRace_SpawnGroundDustKick_Maybe(swrRace* player, float* transform, float sx, float sy, float sz, float param_6, int param_7);
+void swrRace_SpawnGroundDustKick(swrRace* player, float* transform, float sx, float sy, float sz, float param_6, int param_7);
 
 // Smooths a per-side engine exhaust size toward a target over time (best guess).
-void swrRace_SmoothEngineExhaustSize_Maybe(int player, float side, float a, float b, float c, float rate, int param_7, int param_8);
+void swrRace_SmoothEngineExhaustSize(int player, float side, float a, float b, float c, float rate, int param_7, int param_8);
 
 // pod state + engine secondary-motion helpers:
 // Counts down the death timer; on expiry dispatches the 'Snap' event and resets engine health/flags.
@@ -471,10 +471,10 @@ void swrRace_RandomizeMeshNodes(swrModel_Node* dst, swrModel_Node* src);
 void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos, float scale);
 
 // Animates the engine fireball node's transform and hides it when its animation finishes (best guess).
-void swrRace_UpdateEngineFireballNode_Maybe(int player);
+void swrRace_UpdateEngineFireballNode(int player);
 
 // Projects a relative position onto the two engine bases to push pods apart in proximity (best guess).
-void swrRace_ApplyEngineProximityPush_Maybe(swrRace* player, float* otherPos, rdVector3* out);
+void swrRace_ApplyEngineProximityPush(swrRace* player, float* otherPos, rdVector3* out);
 
 // player/AI/autopilot control + engine-damage helpers:
 // Sets the respawn flag (flags0 0x1000) when the player's reset input bit is held.
@@ -493,23 +493,25 @@ void swrRace_ApplyPodProximityForce(swrRace* player);
 // Autopilot/pre-race control: snap events and tilt while not under player input.
 void swrRace_UpdateAutopilotControl(swrRace* player);
 
-// Fills the HUD engine-bar color and fill amount from the pod's engine state.
-void swrRace_GetEngineUiBarColor_Maybe(int player, uint8_t* outRgb, uint8_t* outRgba, float* outFill);
+// Fills the HUD boost-bar colors and fill from boostIndicatorStatus: 0 = green speed fill
+// (speed / (0.75 * maxSpeed)), 1 = orange boost-charge fill, 2 = yellow ready (full).
+void swrRace_GetBoostBarColor(int player, uint8_t* outRgb, uint8_t* outRgba, float* outFill);
 // Human player control: maps input to turn/pitch/brake/boost, drives force
 // feedback and tilt, and sets projTurnRate/pitch/throttle.
 void swrRace_UpdatePlayerControl(swrRace* player);
 // Runs AI steering for AI pods and computes the rubber-band/catch-up multiplier.
 void swrRace_UpdateCatchup(swrRace* player);
 
-// collision / ground-contact physics + explosion spawn:
-// Spawns the explosion effect (type-8 Smok) and destruction sounds for the pod.
-void swrRace_SpawnExplosionEffect(swrRace* player);
+// Sebulba's flame attack: plays the two flame-burst sounds and attaches a type-8 Smok to the
+// pod (handle in flameSmokeHandle, cooldown in unk12_2). Triggered by the AI in F0, by the
+// local player's taunt double-tap, and by the 'flam' network event via SpawnFlameAttackByIndex.
+void swrRace_SpawnFlameAttack(swrRace* player);
 
-// Sends a 'flam' flame multiplayer event for the given player (best guess).
-void swrRace_SendFlameEvent_Maybe(int player, double param_2, void* param_3, void* param_4, int param_5);
+// Sends the 'flam' flame-attack multiplayer event for the given player.
+void swrRace_SendFlameAttackEvent(int player, double param_2, void* param_3, void* param_4, int param_5);
 
-// Spawn the explosion effect for the racer at the given index (best guess).
-void swrRace_SpawnExplosionByIndex_Maybe(int racerIndex);
+// 'flam' event receiver: spawns the flame attack on swrScores[racerIndex]'s pod.
+void swrRace_SpawnFlameAttackByIndex(int racerIndex);
 // Raycasts the terrain collision mesh; sets terrainModel (0x140) and ground height, returns distance.
 float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNormal);
 // Samples the 4 hover-pad ground heights and builds the shadow transforms (0x1290); returns hover height.
@@ -522,7 +524,7 @@ void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeD
 void swrRace_ApplyWallCollision(swrRace* player, rdVector3* normal, rdVector3* dir);
 
 // Handles a wall-scrape hit: spawns spray and sends the scrape multiplayer event (best guess).
-void swrRace_HandleWallScrapeHit_Maybe(swrRace* player);
+void swrRace_HandleWallScrapeHit(swrRace* player);
 
 // pod init + death/scrape/collision-toggle helpers:
 // Initializes a pod for a race: loads stats from the racer data, sets the spawn
@@ -546,11 +548,15 @@ void swrRace_BuildStretchedQuad(rdMatrix44* a, rdMatrix44* b, float param_3, flo
 // Wall-contact dispatch: wall-scrape + collision response when fast/airborne, else terrain follow.
 float swrRace_UpdateWallContact(swrRace* player, float* param_2, float* param_3, rdVector3* param_4);
 
-// Decays the scrape timer, finds nearby smoke, and computes the scrape reflection force (best guess).
-void swrRace_UpdateScrapeContact_Maybe(int player, int param_2);
+// Reaction to nearby 'Smok' objects (fire geysers / smoke columns): computes a decaying yaw
+// kick into contactSteerKick (FLAG1_SLIDE_LOCK while active); a close type-2 Smok can also
+// set a random engine-damage bit.
+void swrRace_ApplySmokProximityPush(int player, int param_2);
 
-// Integrates spline-bound pod orientation, rebuilding the basis and applying turn, pitch, and roll (best guess).
-void swrRace_UpdateSplineOrientation_Maybe(int player, rdVector3* up);
+// Spline-follow (AI / zero-g exit) orientation: eases aiLookAhead, blends the forward vector
+// toward the cursor lookahead point, rebuilds the basis, then applies yaw (turnRate), pitch
+// (zeroGPitchRate) and roll (gravityTubeAngle) rotations.
+void swrRace_UpdateSplineOrientation(int player, rdVector3* up);
 // Pod-to-pod collision: finds a nearby pod and resolves the 2D collision (push apart + DeathSpeed).
 void swrRace_ResolvePodCollision(swrRace* player);
 
@@ -558,8 +564,9 @@ void swrRace_TriggerHandler(int player, int a, char b);
 
 float swrRace_LapProgress(int a);
 
-// Returns a component of the spline progress values for a spline cursor (best guess).
-float swrRace_GetSplineProgressValue_Maybe(void* splineCursor);
+// Returns the baked track mesh at the cursor's spline sample (the spline_progress_values
+// scratch block stores 10 mesh pointers per control point, indexed by segmentT * 10).
+struct swrModel_Node* swrRace_GetTrackMeshAtCursor(void* splineCursor);
 
 bool swrRace_LapCompletion(void* engineData, int param_2);
 

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -505,8 +505,9 @@ void swrSpline_ForEachSample(swrSpline* spline, float step, void* arg3, void* ar
 }
 
 // spline_progress_values packs two per-node regions in one array: the [node] entry
-// (.x = arc-length progress, .y = segment delta) and a 10-float scratch block at
-// +0xfc (stride 5 rdVector2 per node). Clear both for one node.
+// (.x = arc-length progress, .y = segment delta) and, at +0xfc, the baked sample->track-mesh
+// table (10 mesh pointers per node, written by swrSpline_BakeSampleTrackMesh, read by
+// swrRace_GetTrackMeshAtCursor). Clear both for one node.
 // 0x0047f6c0
 void swrSpline_ResetNodeProgress(int nodeIndex)
 {
@@ -519,7 +520,7 @@ void swrSpline_ResetNodeProgress(int nodeIndex)
 
 // Returns the .rdata sample-spacing constant at 0x004adf40 (0.0f in retail).
 // 0x0047f800
-float swrSpline_GetSampleSpacing_Maybe(void)
+float swrSpline_GetSampleSpacing(void)
 {
     return 0.0f;
 }

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -27,14 +27,16 @@
 #define swrSpline_GetTrackLength_ADDR (0x0047e870)
 #define swrSpline_CursorInit_ADDR (0x0047e880)
 #define swrSpline_CursorSeekToProgress_ADDR (0x0047e8b0)
-#define swrSpline_ProjectPointStub_Maybe_ADDR (0x0047eb50)
+#define swrSpline_BakeSampleTrackMesh_ADDR (0x0047ea20)
+#define swrSpline_ProjectPointStub_ADDR (0x0047eb50)
 #define swrSpline_ProjectPoint_ADDR (0x0047eb60)
+#define swrSpline_ValidateSampleTrackMesh_ADDR (0x0047ece0)
 #define swrSpline_ForEachSample_ADDR (0x0047ee20)
 #define swrSpline_TraceProgress_ADDR (0x0047f060)
 #define swrSpline_BuildProgressTable_ADDR (0x0047f470)
 #define swrSpline_ResetNodeProgress_ADDR (0x0047f6c0)
 #define swrSpline_Build_ADDR (0x0047f6f0)
-#define swrSpline_GetSampleSpacing_Maybe_ADDR (0x0047f800)
+#define swrSpline_GetSampleSpacing_ADDR (0x0047f800)
 #define swrSpline_CollectNearbyPoints_ADDR (0x00480170)
 #define swr_SetFixedDeltaTime_ADDR (0x00480480)
 
@@ -84,8 +86,22 @@ void* swrSpline_CursorInit(void* cursor, swrSpline* spline);
 // the remainder becomes the segment parameter, then fill the node lookahead chain.
 void swrSpline_CursorSeekToProgress(void* cursor, int progress);
 
-// A stubbed spline helper that writes zero and returns zero (best guess).
-int swrSpline_ProjectPointStub_Maybe(void* cursor, int* out);
+// Retired/compiled-out projection: writes 0 to the out-slot and returns 0 unconditionally
+// (the swrRace 0xf4..0x100 block it feeds is therefore always zero in retail).
+int swrSpline_ProjectPointStub(void* cursor, int* out);
+
+// ForEachSample callback (10 samples/node, from swrSpline_Build): raycasts down (then up)
+// 5000 units from the spline sample (facing check disabled), stores the hit track mesh into
+// the baked sample->mesh table (spline_progress_values scratch region), stamps mesh
+// splineSampleIndex with the first sample that hit it, and marks meshes shared between
+// traversal orders as spline-ambiguous (behavior unk1 bit 8; assigns the static behavior
+// @0x4c7be8 if the mesh has none).
+void swrSpline_BakeSampleTrackMesh(void* cursor, float samplesPerNode, swrModel_Node* trackModel, unsigned short* order);
+
+// Optional debug pass over the baked sample->mesh table (gated on the global at 0xe259a0 in
+// swrSpline_Build): re-seeks a cursor to each mesh's anchor sample and distance-checks it;
+// the mismatch branch is a stripped debug print.
+void swrSpline_ValidateSampleTrackMesh(void* cursor, float samplesPerNode);
 
 // Advance the cursor to the point on the spline nearest the given world point
 // (used to map a world position back to a spline parameter / progress).
@@ -105,12 +121,13 @@ void swrSpline_BuildProgressTable(swrSpline* spline, float segmentLength, unsign
 // Clear the runtime progress/state arrays for one node index.
 void swrSpline_ResetNodeProgress(int nodeIndex);
 
-// Top level post-load processing (called by LoadTrackSpline): resets junction
-// nodes, builds the progress table, then tessellates.
-void swrSpline_Build(swrSpline* spline, int unk);
+// Top level post-load processing (called by LoadTrackSpline): resets junction nodes, builds
+// the arc-length progress table (100-unit tracing), then bakes the 10-samples-per-node
+// sample->track-mesh table against the track model (+ an optional debug validation pass).
+void swrSpline_Build(swrSpline* spline, struct swrModel_Node* trackModel);
 
 // Returns the .rdata sample-spacing constant (0.0f in retail).
-float swrSpline_GetSampleSpacing_Maybe(void);
+float swrSpline_GetSampleSpacing(void);
 
 // Returns the integrated track/spline length (swrSpline_trackLength, set by swrSpline_TraceProgress).
 float swrSpline_GetTrackLength(void);

--- a/src/types.h
+++ b/src/types.h
@@ -467,10 +467,10 @@ extern "C"
         float lapCompMax;
         struct swrModel_Node* splineTrackMesh; // 0xec. baked track mesh under the spline cursor (swrRace_GetTrackMeshAtCursor); raycast target when FULL_RAYCAST is clear; copied to terrainModel on the cached-ground path
         struct swrModel_Node* splineTrackMeshPrev; // 0xf0. previous frame's splineTrackMesh; a change (pod crossed into the next track chunk) zeroes unk1f24
-        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress; the stub always writes 0 (projection compiled out of retail), so 0xf4..0x100 are always zero
-        int unkf8; // 0xf8. its return value (always 0 in retail)
-        int unkfc; // 0xfc. out-slot of the 2nd call (always 0)
-        int unk100; // 0x100. its return value (always 0)
+        int splineProjOut1; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress; the stub always writes 0 (projection compiled out of retail), so 0xf4..0x100 are always zero
+        int splineProjResult1; // 0xf8. its return value (always 0 in retail)
+        int splineProjOut2; // 0xfc. out-slot of the 2nd call (always 0)
+        int splineProjResult2; // 0x100. its return value (always 0)
         float aiLookAhead;    // 0x104. AI autopilot look-ahead offset (spline param, eased within [0.01, 2.0])
         float aiLookAheadDistSq; // 0x108. AI autopilot target look-ahead segment length^2 (init 8100 = 90^2)
         short checkpointCount; // 0x10c. incremented per lap, reset to 0 when off-track; swrObjJdge_IsRacerRacing gates on > 4
@@ -555,7 +555,7 @@ extern "C"
         int tauntTapState; // 0x2f8. byte @0x2f9 = consecutive-tap counter; > 1 within the window fires the taunt (and, for Sebulba, the flame attack)
         float pitch; // 0x2fc .8 pitch down -.8 pitch up
         int current_light_index;
-        int unk304; // 0x304. pod light color mode 0/1/2 read by swrObjcMan_UpdateLighting (2 = second local player)
+        int lightColorMode; // 0x304. pod light color mode 0/1/2 read by swrObjcMan_UpdateLighting (2 = second local player)
         float vehicleBumpTimer; // 0x308. set rand[2,8) on the 'Hitt'/'VhLt' vehicle-bump event; counts down in UpdatePhysicsContact
         float respawnInvincibilityTimer; // 0x30c
         float deathExplodeTimer; // 0x310. set rand[2,3) in swrRace_Explode; HandleDeathSnap / UpdatePhysicsContact count it down to the 'Snap' event / respawn

--- a/src/types.h
+++ b/src/types.h
@@ -467,10 +467,10 @@ extern "C"
         float lapCompMax;
         struct swrModel_Node* splineTrackMesh; // 0xec. baked track mesh under the spline cursor (swrRace_GetTrackMeshAtCursor); raycast target when FULL_RAYCAST is clear; copied to terrainModel on the cached-ground path
         struct swrModel_Node* splineTrackMeshPrev; // 0xf0. previous frame's splineTrackMesh; a change (pod crossed into the next track chunk) zeroes unk1f24
-        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress
-        int unkf8; // 0xf8. its return value
-        int unkfc; // 0xfc. out-slot of the 2nd call
-        int unk100; // 0x100. its return value
+        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress; the stub always writes 0 (projection compiled out of retail), so 0xf4..0x100 are always zero
+        int unkf8; // 0xf8. its return value (always 0 in retail)
+        int unkfc; // 0xfc. out-slot of the 2nd call (always 0)
+        int unk100; // 0x100. its return value (always 0)
         float aiLookAhead;    // 0x104. AI autopilot look-ahead offset (spline param, eased within [0.01, 2.0])
         float aiLookAheadDistSq; // 0x108. AI autopilot target look-ahead segment length^2 (init 8100 = 90^2)
         short checkpointCount; // 0x10c. incremented per lap, reset to 0 when off-track; swrObjJdge_IsRacerRacing gates on > 4
@@ -533,7 +533,7 @@ extern "C"
         float surfaceSpeedFactor; // 0x244
         float surfaceGripFactor; // 0x248
         float slide2; // 0x24c
-        int unk11_1; // 0x250. vertical Z offset applied per-frame to the engine/cockpit part transforms (swrRace_ApplyPartSinkOffset), binder endpoints and cMan camera targets; only zero writes found
+        int unk11_1; // 0x250. vertical Z offset applied per-frame to the engine/cockpit part transforms (swrRace_ApplyPartSinkOffset), binder endpoints and cMan camera targets; no non-zero writer exists in the retail binary (vestigial sink mechanism)
         struct swrModel_Node* guideArrowNode; // 0x254. HUD spline guide arrow node (written by swrObjJdge_UpdatePlayerHUD while FLAG0_GUIDE_ARROW; drawn by swrObjcMan_UpdateSplineGuideMarker)
         rdVector3 guideArrowTarget; // 0x258. spline point 0.5 ahead that the guide arrow points at
         float wallHitCooldown; // 0x264. set 0.1 on a hard wall impact (ApplyWallCollision, clearing FLAG0_THROTTLE_SETTLED); counts down in F0; expiry re-sets the flag
@@ -617,16 +617,16 @@ extern "C"
         int remoteId; // 0x1eb4. network id of the owning remote player (-1 = unassigned; set by the 'RmHi' event, REMO pods only)
         char remoteState[64]; // 0x1eb8. remote-pod staging: controls @+0/+4/+8 ('RmCn'), steer target @+0x10 ('RmTh', consumed by CalcTargetTurnRate -> turnRateTarget), pos+rot 6 floats @+0x14 ('RmLc'/'RmHi')
         float unk1ef8; // 0x1ef8. never referenced (label was 4 bytes off pre-2026-07: unk1ebc)
-        float unk1efc; // 0x1efc. init 0.25 (Init/ResetToSpline); reader unknown
-        float unk1f00; // 0x1f00. init 80.0; reader unknown
+        float unk1efc; // 0x1efc. init 0.25 (Init/ResetToSpline); no reader in the retail binary
+        float unk1f00; // 0x1f00. init 80.0; no reader in the retail binary
         int unk1f04;
         char unk1f08[8];
         int unk1f10;
-        float unk1f14; // 0x1f14. free-running countdown in UpdatePlayerControl; setter unknown
-        int unk1f18; // 0x1f18. zeroed at the end of UpdatePhysicsContact each frame
+        float unk1f14; // 0x1f14. decremented every frame by UpdatePlayerControl but never set or read (vestigial)
+        int unk1f18; // 0x1f18. zeroed at the end of UpdatePhysicsContact each frame; never set or read otherwise
         int unk1f1c;
         int unk1f20;
-        int unk1f24; // 0x1f24. zeroed by UpdateRaceProgress when the cursor's track mesh changes
+        int unk1f24; // 0x1f24. zeroed by UpdateRaceProgress when the cursor's track mesh changes; no other access (vestigial)
     } swrRace; // at 0x00e29c44 sizeof(0x1f28)
 
     typedef struct swrObjToss
@@ -1422,7 +1422,7 @@ extern "C"
         union Vtx* vertices;
         uint16_t num_collision_vertices;
         uint16_t num_vertices;
-        uint16_t splineNodeIndex; // for track collision meshes: the baked spline control-point index this mesh belongs to (swrRace_UpdateSplineBinding re-seeks the cursor here)
+        uint16_t splineSampleIndex; // for track collision meshes: the first baked spline sample index (node * 10 + sub, 0 = unset) that hit this mesh (swrSpline_BakeSampleTrackMesh); swrRace_UpdateSplineBinding re-seeks the cursor to it
         int16_t vertex_base_offset; // only set for mesh parts with bone animtation, equal to "v0" in display list.
     } swrModel_Mesh;
 
@@ -1547,7 +1547,7 @@ extern "C"
     // packing on this one
     typedef struct swrModel_Behavior
     {
-        uint16_t unk1;
+        uint16_t unk1; // bit 0x8 = spline-ambiguous mesh (shared between spline branches; set at bake time by swrSpline_BakeSampleTrackMesh, blocks swrRace_UpdateSplineBinding and marks the not-racing zone in swrObjJdge_IsRacerRacing); 0x10 = force full raycast (no cached-mesh shortcut); 0x20 = surface-magnet gravity
         uint8_t fog_flags;
         uint8_t fog_color[3];
         uint16_t fog_start;

--- a/src/types.h
+++ b/src/types.h
@@ -435,6 +435,21 @@ extern "C"
 
     // TODO 0x00475ad0
 
+    // Runtime cursor walking a spline graph (0x30 bytes). swrRace embeds one at +0xac,
+    // swrObjJdge at +0x34. See swrSpline_CursorInit / CursorSeek / CursorEvaluate.
+    typedef struct swrSplineCursor
+    {
+        struct swrSpline* spline; // 0x00
+        float velocity; // 0x04 signed; sign selects step direction
+        float segmentT; // 0x08 parameter along the current segment, clamped 0..1
+        float tangentLength; // 0x0c length of the evaluated path tangent
+        int nodeLookahead[4]; // 0x10 current node + 3-level lookahead window
+        int endFlag; // 0x20 set when the forward end of the path is reached
+        int startFlag; // 0x24 set when the backward start of the path is reached
+        int branchSelector; // 0x28
+        int branchFlags; // 0x2c
+    } swrSplineCursor; // sizeof(0x30)
+
     typedef struct swrRace // swrObjTest
     {
         swrObj obj;
@@ -445,30 +460,30 @@ extern "C"
         char unk1_1[2];
         PodHandlingData podStats;
         char unk4[4];
-        rdMatrix34 unk4_mat; // 0xac. Not a matrix ? LapCompStruct
-        int unkdc;
+        swrSplineCursor splineCursor; // 0xac. the pod's track-spline cursor (advanced by swrRace_UpdateRaceProgress; progress source for lapComp)
+        float splineSampleSpacing; // 0xdc. = swrSpline_GetSampleSpacing() each frame; that returns the .rdata const @0x4adf40 which is 0.0 in retail (vestigial)
         float lapComp;
         float lapCompPrev;
         float lapCompMax;
-        struct swrModel_Node* unkec_node;
-        int unkf0;
-        int unkf4;
-        int unkf8;
-        int unkfc;
-        int unk100;
+        struct swrModel_Node* splineTrackMesh; // 0xec. baked track mesh under the spline cursor (swrRace_GetTrackMeshAtCursor); raycast target when FULL_RAYCAST is clear; copied to terrainModel on the cached-ground path
+        struct swrModel_Node* splineTrackMeshPrev; // 0xf0. previous frame's splineTrackMesh; a change (pod crossed into the next track chunk) zeroes unk1f24
+        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress
+        int unkf8; // 0xf8. its return value
+        int unkfc; // 0xfc. out-slot of the 2nd call
+        int unk100; // 0x100. its return value
         float aiLookAhead;    // 0x104. AI autopilot look-ahead offset (spline param, eased within [0.01, 2.0])
         float aiLookAheadDistSq; // 0x108. AI autopilot target look-ahead segment length^2 (init 8100 = 90^2)
-        short unk10c;
-        short unk10e;
+        short checkpointCount; // 0x10c. incremented per lap, reset to 0 when off-track; swrObjJdge_IsRacerRacing gates on > 4
+        short splineRebindResult; // 0x10e. last swrRace_UpdateSplineBinding result (-1 blocked / 0 no rebind / 1 rebound to the stood-on mesh)
         float idleTick; // See fn 0x47fdd0
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
-        rdVector4 unk118_vec;
-        int unk128;
+        rdVector4 trackOffset; // 0x118. lateral offset from the racing line: xyz = unit direction spline->pod, w = raw distance (swrRace_ComputeTrackOffset; {0,0,1,dist} within threshold)
+        float leaderGap; // 0x128. race leader's progress minus this racer's (written by swrObjJdge_UpdateStandings)
         float aiLineOffset;  // 0x12c. AI lateral offset from the racing line (also a HUD rival-gap slot)
         float rivalGapAhead; // 0x130. signed progress gap to the rival ahead (AI rubber-band + splitscreen catchup)
         float rivalGapBehind;// 0x134. signed progress gap to the rival behind
         float aiSteerTarget; // 0x138. AI cross-track steer target (written by swrRace_AI)
-        struct swrModel_Node* model_unk; // 0x13c. Collision related ?
+        struct swrModel_Node* collisionModel; // 0x13c. track collision model (Init param); sole target of RaycastModel / CollideBlockMove / CollideTrack
         struct swrModel_Node* terrainModel;
         rdVector3 bumpDirection;
         float speedLoss;
@@ -497,7 +512,7 @@ extern "C"
         float turnRateTarget; // 0x1f0
         float turnModifier; // 0x1f4
         float autoTilt; // 0x1f8. slope auto-tilt torque (drives the pod's bank toward the downhill/surface alignment)
-        float unk8_11; // 0x1fc
+        float contactSteerKick; // 0x1fc. decaying signed yaw impulse from wall scrapes / nearby Smok blasts (swrRace_ApplySmokProximityPush); added to the turn in UpdateControlAndMove; FLAG1_STEER_KICK marks it active
         float tiltAngleTarget; // 0x200
         float tiltAngle; // 0x204
         float tiltManualMult; // 0x208 -1 tilt left, 0 neutral, 1 tilt right
@@ -506,9 +521,9 @@ extern "C"
         float boostChargeTimer; // 0x214
         float engineTemp; // 0x218
         float gravityTubeAngle;
-        float unk10_1; // 0x220
-        float unk10_2; // 0x224
-        int unk10_3; // 0x228
+        float zeroGPitchRate; // 0x220. zero-g secondary (pitch) turn rate, ramped toward zeroGPitchRateTarget at turnResponse while ZON; X-axis rotation rate in swrRace_UpdateSplineOrientation
+        float zeroGPitchRateTarget; // 0x224. target for the above, from pitch input in zero-g (0 otherwise)
+        int unk10_3; // 0x228. float bits: set to 3.0f on the ZOn->ZOff spline-follow transition (swrRace_UpdateSurfaceTag); reader unknown
         float paceMultiplier; // 0x22c. Applied speed multiplier this frame; for AI, the smoothed value swrRace_AI ramps toward aiSpeedTarget
         float aiSpeedTarget;    // 0x230. AI target speed multiplier (base swrRace_AILevel, modulated by rank/spread)
         float aiDecisionTimer;  // 0x234. AI countdown to the next target-rank reroll
@@ -518,10 +533,11 @@ extern "C"
         float surfaceSpeedFactor; // 0x244
         float surfaceGripFactor; // 0x248
         float slide2; // 0x24c
-        int unk11_1; // 0x250
-        char unk12[16];
-        float unk12_1; // 0x264
-        float unk12_2; // 0x268 an angle of some kind ?
+        int unk11_1; // 0x250. vertical Z offset applied per-frame to the engine/cockpit part transforms (swrRace_ApplyPartSinkOffset), binder endpoints and cMan camera targets; only zero writes found
+        struct swrModel_Node* guideArrowNode; // 0x254. HUD spline guide arrow node (written by swrObjJdge_UpdatePlayerHUD while FLAG0_GUIDE_ARROW; drawn by swrObjcMan_UpdateSplineGuideMarker)
+        rdVector3 guideArrowTarget; // 0x258. spline point 0.5 ahead that the guide arrow points at
+        float wallHitCooldown; // 0x264. set 0.1 on a hard wall impact (ApplyWallCollision, clearing FLAG0_THROTTLE_SETTLED); counts down in F0; expiry re-sets the flag
+        float unk12_2; // 0x268. Sebulba flame-attack timer: 15 on spawn, pinned >= 5 while the flame Smok lives, ticks down otherwise; reader unknown
         int collisionToggles; // 0x26C. Some flag. See FUN_0047a930
         float engineHealthMin[6]; // engine health related
         float engineHealth[6]; // 0x288 left top-mid-bot, right top-mid-bot
@@ -535,30 +551,32 @@ extern "C"
         rdVector3 nextRotation; //
         rdVector3 turnInput; // 0x2e4
         int unk2f0;
-        int unk2f4;
-        int unk2f8;
+        float tauntTapTime; // 0x2f4. timetotal stamp of the last taunt-button tap (double-tap window check in UpdatePlayerControl)
+        int tauntTapState; // 0x2f8. byte @0x2f9 = consecutive-tap counter; > 1 within the window fires the taunt (and, for Sebulba, the flame attack)
         float pitch; // 0x2fc .8 pitch down -.8 pitch up
         int current_light_index;
-        int unk304;
-        int unk308;
+        int unk304; // 0x304. pod light color mode 0/1/2 read by swrObjcMan_UpdateLighting (2 = second local player)
+        float vehicleBumpTimer; // 0x308. set rand[2,8) on the 'Hitt'/'VhLt' vehicle-bump event; counts down in UpdatePhysicsContact
         float respawnInvincibilityTimer; // 0x30c
-        int unk310;
-        int unk314;
-        int unk318;
-        int unk31c;
+        float deathExplodeTimer; // 0x310. set rand[2,3) in swrRace_Explode; HandleDeathSnap / UpdatePhysicsContact count it down to the 'Snap' event / respawn
+        struct swrObjSmok* engineDamageSmoke[2]; // 0x314. persistent R/L engine damage smoke handles (Spawn type 6 + SetOwnerHandle in UpdateEngineDamageFX)
+        struct swrObjSmok* flameSmokeHandle; // 0x31c. Sebulba flame-attack Smok (type 8), auto-nulled via SetOwnerHandle; killed on death/reset
         int unk320;
-        int unk324;
+        int fireballEngineSlot; // 0x324. engine index whose fireball FX is burning (-1 = none); anchors the fireball node at that engine matrix
         int unk328;
         int unk32c;
         float exhaustSizeLeft;
         float exhaustSizeRight;
-        int unk338;
-        int unk33c;
-        int unk340;
-        struct swrModel_Node** unk344_nodeArray;
-        struct swrModel_Node* unk348_node;
-        struct swrModel_Node* unk34c_node;
-        rdMatrix44 unk350_mat;
+        float spinoutEngineAngle; // 0x338. accumulated engine spin during the death spinout (AnimateSpinoutEngines)
+        float spinoutCockpitAngle; // 0x33c. same for the cockpit
+        float spinoutSpinRamp; // 0x340. ramp toward 1.0 scaling both spinout spin rates
+        struct swrModel_Node** partNodes; // 0x344. pod part-node array (podModel param of Init): [1..4] engines, [5] cockpit, [0x3e..0x40] shadows, [0x41/0x42] scrape sparks, [0x43/0x44] exhausts; NULL = far-LOD pod
+        struct swrModel_Node* lodBodyNode; // 0x348. single-node far-LOD pod body (transform = farLodPodXf), used when partNodes == NULL
+        struct swrModel_Node* lodSelectorNode; // 0x34c. LOD selector node; F3 selects child (lodDistance < 101 ? 0 : 1)
+        // 0x350..0x1610 is one rdMatrix44[75] per-part transform array, index-aligned with
+        // partNodes (Init resets all 75 in a single loop); the named engineXf*/cockpitXf/
+        // shadowXf*/scrapeSparkXf*/engineExhaustXf*/farLodPodXf members are its elements.
+        rdMatrix44 unk350_mat; // 0x350. partXf[0] (root)
         rdMatrix44 engineXfR;
         rdMatrix44 engineXfL;
         rdMatrix44 engineXfR2;
@@ -572,42 +590,43 @@ extern "C"
         rdMatrix44 scrapeSparkXf2;
         rdMatrix44 engineExhaustXfR;
         rdMatrix44 engineExhaustXfL;
-        rdMatrix44 unk1490_mat;
-        rdMatrix44 unk14d0_mat;
-        char unk1510[192];
-        rdMatrix44 unk15d0_mat;
-        char unk1610[900];
+        rdMatrix44 engineGlowXfR; // 0x1490. right engine afterburner-glow billboard transform (diagonal scale, PoddAnimateVariousThings -> partNodes[0x45])
+        rdMatrix44 engineGlowXfL; // 0x14d0. left engine glow billboard (partNodes[0x46])
+        char unk1510[192]; // 0x1510. partXf[71..73], never referenced
+        rdMatrix44 farLodPodXf; // 0x15d0. transform of the single-node far-LOD pod (0.004-scaled pod transform; set on lodBodyNode in F3)
+        char unk1610[900]; // 0x1610. rdVector3 partOffset[75], index-aligned with partNodes: per-part positional offset / animation accumulators (exhaust size at [side].y, steering-part spin at +400)
         struct swrModel_Node* reflectionNode; // 0x1994. pod's planar ground-reflection node (drawn by swrRace_UpdateReflectionNode on ON_MIRR surfaces)
         int lodDistance;
-        char unk199c[16];
-        float unk19ac;
+        float wobblePhase[4]; // 0x199c. per-part wobble sine phases, random-seeded in Init, advanced by dt (AnimateEngineWobble)
+        float wobbleAmplitude; // 0x19ac. engine-wobble amplitude: forced 1.0 on HIT_BOTTOM, decays to a 0.4 floor
         float unk19b0;
-        float unk19b4;
-        int unk19b8;
-        rdMatrix44 matArray[18];
-        int unk1e3c;
-        int unk1e40;
-        int unk1e44;
-        rdVector3 unk1e48_vec;
-        rdVector3 unk1e54_vec;
-        int unk1e60;
-        int unk1e64_flag;
-        int unk1e68_flag;
-        int unk1e6c;
+        float unk19b4; // 0x19b4. cockpit bob delta from thrust/speed (PoddAnimateEngines)
+        int unk19b8; // 0x19b8. float bits: smoothed engine tilt (TiltEngines)
+        rdMatrix44 transformHistory[18]; // 0x19bc. ring buffer of recent pod transforms; engines lag 16 frames, cockpit 10 (PoddAnimateEngines)
+        int historyWriteIdx; // 0x1e3c. (idx + 1) % 18 each frame
+        int historyLagEngines; // 0x1e40. constant 16, rewritten each frame
+        int historyLagCockpit; // 0x1e44. constant 10, rewritten each frame
+        rdVector3 cockpitSpringPos; // 0x1e48. cockpit lag-spring position state
+        rdVector3 cockpitSpringVel; // 0x1e54. cockpit lag-spring velocity state (stdMath_Decelerator)
+        int unk1e60; // 0x1e60. float bits: previous-frame cockpit gravity-projection scalar
+        int unk1e64_flag; // 0x1e64. float bits: pod footprint half-extent X from the shadow node AABB (default 2.0, Neva Kee 3.0); also the engine-proximity push radius
+        int unk1e68_flag; // 0x1e68. float bits: half-extent Y (default 2.0, Neva Kee 5.0)
+        int orthoRenormCounter; // 0x1e6c. every 8 frames UpdateTurn2 re-normalizes the transform basis vectors
         struct swrScore* score_ptr;
         char unk1e74[64];
-        int unk1eb4;
-        char unk1eb8[64];
-        float unk1ebc;
-        float unk1f00;
+        int remoteId; // 0x1eb4. network id of the owning remote player (-1 = unassigned; set by the 'RmHi' event, REMO pods only)
+        char remoteState[64]; // 0x1eb8. remote-pod staging: controls @+0/+4/+8 ('RmCn'), steer target @+0x10 ('RmTh', consumed by CalcTargetTurnRate -> turnRateTarget), pos+rot 6 floats @+0x14 ('RmLc'/'RmHi')
+        float unk1ef8; // 0x1ef8. never referenced (label was 4 bytes off pre-2026-07: unk1ebc)
+        float unk1efc; // 0x1efc. init 0.25 (Init/ResetToSpline); reader unknown
+        float unk1f00; // 0x1f00. init 80.0; reader unknown
         int unk1f04;
-        int unk1f08;
-        char unk1f0c[8];
-        int unk1f14;
-        int unk1f18;
+        char unk1f08[8];
+        int unk1f10;
+        float unk1f14; // 0x1f14. free-running countdown in UpdatePlayerControl; setter unknown
+        int unk1f18; // 0x1f18. zeroed at the end of UpdatePhysicsContact each frame
         int unk1f1c;
         int unk1f20;
-        int unk1f24;
+        int unk1f24; // 0x1f24. zeroed by UpdateRaceProgress when the cursor's track mesh changes
     } swrRace; // at 0x00e29c44 sizeof(0x1f28)
 
     typedef struct swrObjToss
@@ -730,21 +749,6 @@ extern "C"
         char podiumCharacters[3];
         char unkcf;
     } swrObjHang; // sizeof(0xd0)
-
-    // Runtime cursor walking a spline graph (0x30 bytes). swrObjJdge embeds one
-    // at +0x34. See swrSpline_CursorInit / CursorSeek / CursorEvaluate.
-    typedef struct swrSplineCursor
-    {
-        struct swrSpline* spline; // 0x00
-        float velocity; // 0x04 signed; sign selects step direction
-        float segmentT; // 0x08 parameter along the current segment, clamped 0..1
-        float tangentLength; // 0x0c length of the evaluated path tangent
-        int nodeLookahead[4]; // 0x10 current node + 3-level lookahead window
-        int endFlag; // 0x20 set when the forward end of the path is reached
-        int startFlag; // 0x24 set when the backward start of the path is reached
-        int branchSelector; // 0x28
-        int branchFlags; // 0x2c
-    } swrSplineCursor; // sizeof(0x30)
 
     typedef struct swrObjJdge
     {
@@ -1081,7 +1085,7 @@ extern "C"
         char unke[2];
         int sfxChannel; // 0x10. low byte = per-racer SFX channel index (swrSound_SetSfxFlag / swrSound_TestSfxFlag)
         int unk14;
-        int unk18; // holds a pointer to the racer's sound source (dereferenced in swrObjJdge_F2 for the finish-line SFX)
+        int* pilotId; // 0x18. points at the racer's selected pilot/vehicle index (0..22, -1 = none); selects the pilot voice bank (swrSound_ResolveSfxId bounds-checks 0..0x16) and gates pilot specials (2 = Sebulba flame attack, 0xe = Neva Kee fused engines)
         PodHandlingData podStats;
         short unk58;
         short unk5a;
@@ -1418,7 +1422,7 @@ extern "C"
         union Vtx* vertices;
         uint16_t num_collision_vertices;
         uint16_t num_vertices;
-        uint16_t unk1;
+        uint16_t splineNodeIndex; // for track collision meshes: the baked spline control-point index this mesh belongs to (swrRace_UpdateSplineBinding re-seeks the cursor here)
         int16_t vertex_base_offset; // only set for mesh parts with bone animtation, equal to "v0" in display list.
     } swrModel_Mesh;
 

--- a/src/types.h
+++ b/src/types.h
@@ -478,7 +478,7 @@ extern "C"
         float idleTick; // See fn 0x47fdd0
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
         rdVector4 trackOffset; // 0x118. lateral offset from the racing line: xyz = unit direction spline->pod, w = raw distance (swrRace_ComputeTrackOffset; {0,0,1,dist} within threshold)
-        float leaderGap; // 0x128. race leader's progress minus this racer's (written by swrObjJdge_UpdateStandings)
+        float gapToLeader; // 0x128. race leader's progress minus this racer's, so >= 0 (written by swrObjJdge_UpdateStandings)
         float aiLineOffset;  // 0x12c. AI lateral offset from the racing line (also a HUD rival-gap slot)
         float rivalGapAhead; // 0x130. signed progress gap to the rival ahead (AI rubber-band + splitscreen catchup)
         float rivalGapBehind;// 0x134. signed progress gap to the rival behind

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -74,15 +74,21 @@ typedef enum GameSettingFlag
 // (swrRace_Init/swrRace_AI/swrObjTest_F0/F4) and annodue's Test entity RE.
 typedef enum swrObjTest_FLAG0
 {
+    // The low nibble (& STATE_MASK) is a small state field, not independent bits:
+    // 0 = inert / pre-race (countdown), 1 = post-race coast, 2 = actively racing.
+    // Values 4/8 are never written in retail.
+    swrObjTest_FLAG0_STATE_MASK = 0xf,
+    swrObjTest_FLAG0_STATE_POSTRACE = 0x1, // post-race / finished coast (set per pod by swrObjJdge_StartPostRaceSequence)
     swrObjTest_FLAG0_RACING = 0x2, // actively racing (low nibble == 2, set on the 'Go!!' event)
-    swrObjTest_FLAG0_UNDER_POWER_Maybe = 0x10, // set while the pod is under engine power (accelerating);
-    // gates the engine-damage steering pull in swrRace_UpdatePlayerControl; latched for AI/remote racers
-    // once the start timer (unk12_1) expires. Cleared on reset. Best-guess name.
+    swrObjTest_FLAG0_THROTTLE_SETTLED = 0x10, // wallHitCooldown expired since the last hard wall impact
+    // (ApplyWallCollision clears it and arms the 0.1s cooldown); autopilot picks full throttle on it and
+    // it gates the engine-damage steering pull in swrRace_UpdatePlayerControl.
     swrObjTest_FLAG0_LOCAL = 0x20, // 'Locl' racer (local human)
     swrObjTest_FLAG0_REMOTE = 0x40, // 'REMO' racer (remote/network)
     swrObjTest_FLAG0_AI = 0x80, // 'AAII' racer (computer)
     swrObjTest_FLAG0_AI_SIMPLE = 0x100, // simplified AI path (set from score->flag & 0x20)
     swrObjTest_FLAG0_BRAKING = 0x200, // is braking
+    swrObjTest_FLAG0_REPAIRING = 0x400, // repair input held / AI post-finish auto-repair (swrRace_Repair pins repairTimer = 0.1 while set)
     swrObjTest_FLAG0_RESET = 0x800, // 'reset pod' requested (death-snap)
     swrObjTest_FLAG0_RESPAWN = 0x1000, // 'respawn pod' requested
     swrObjTest_FLAG0_RESPAWN_INVINC = 0x2000, // respawn invincibility
@@ -90,19 +96,23 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_AI_RIVAL_AHEAD = 0x8000, // AI pacing to the rival ahead
     swrObjTest_FLAG0_AI_RIVAL_BEHIND = 0x10000, // AI pacing to the rival behind
     swrObjTest_FLAG0_TP_TO_SPLINE = 0x20000, // teleport to spline point requested
+    swrObjTest_FLAG0_WALL_IMPACT_CLAMP = 0x40000, // one-shot from a strong wall impact (ApplyWallCollision); UpdatePhysicsContact consumes it to clamp accelThrust
     swrObjTest_FLAG0_POD_HIDDEN = 0x80000, // hide the pod in its OWN camera view (first-person /
     // bumper cam, and demo mode). swrRace_PoddAnimateEngines clears the pod root node's visible
     // flag when this is set (and DEAD is clear); vanilla re-shows the pod to the OTHER viewport in
     // swrViewport_Render. Cleared each frame in swrObjTest_F0.
-    swrObjTest_FLAG0_INPUT_STATE_Maybe = 0x100000, // per-frame input-derived state set in
-    // swrRace_UpdatePlayerControl (from in-race input bitset3 bit 0x8 / the analog control config);
-    // consumer not yet identified. Cleared on reset. Best-guess name.
-    swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost
+    swrObjTest_FLAG0_LOOK_BACK = 0x100000, // rear-view / look-back input held (in-race input bitset3 bit 0x8);
+    // the camera manager reads it to flip the chase/first-person camera basis, then clears it.
+    swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost (speed > 0.75 * maxSpeed, alive)
     swrObjTest_FLAG0_BOOSTING = 0x800000, // boost active
     swrObjTest_FLAG0_HIT_BOTTOM = 0x1000000, // hard-landing debounce ('HittBotm' event)
     swrObjTest_FLAG0_ZON = 0x2000000, // zero-g ON / orbit
     swrObjTest_FLAG0_ZOFF = 0x4000000, // zero-g OFF transition
+    swrObjTest_FLAG0_GUIDE_ARROW = 0x8000000, // HUD spline guide arrow shown (set/cleared by swrObjJdge_UpdatePlayerHUD; read by swrObjcMan_UpdateSplineGuideMarker)
+    swrObjTest_FLAG0_SCRAPE_SPARK_R = 0x10000000, // scrape-spark emitter active on partNodes[0x41] (SetupScrapeSpray side 1; self-clears in UpdateScrapeSparks)
+    swrObjTest_FLAG0_SCRAPE_SPARK_L = 0x20000000, // scrape-spark emitter active on partNodes[0x42]
     swrObjTest_FLAG0_WAS_BOOSTING = 0x40000000, // was boosting last frame
+    // 0x80000000 is cleared every frame by UpdatePlayerControl but never set or read (vestigial).
 } swrObjTest_FLAG0;
 
 // swrRace (swrObjTest) flags1 @ +0x64. The ON_* terrain bits are derived from
@@ -113,7 +123,7 @@ typedef enum swrObjTest_FLAG1
     swrObjTest_FLAG1_SPLINE_SNAP = 0x2, // pending snap to spline point
     swrObjTest_FLAG1_NOT_ACCEL = 0x4, // not accelerating
     swrObjTest_FLAG1_SLIDING = 0x8, // sliding
-    swrObjTest_FLAG1_SLIDE_LOCK = 0x10, // freezes the slide2 easing
+    swrObjTest_FLAG1_SLIDE_LOCK = 0x10, // a contactSteerKick (wall scrape / Smok blast push) is decaying; pins slide2 = 0.25 while set
     swrObjTest_FLAG1_ON_SIDE = 0x20, // Side terrain
     swrObjTest_FLAG1_ON_MIRR = 0x40, // Mirr terrain
     swrObjTest_FLAG1_FULL_RAYCAST = 0x80, // skip cached terrain-mesh raycast (behavior unk1 & 0x10)
@@ -130,6 +140,7 @@ typedef enum swrObjTest_FLAG1
     swrObjTest_FLAG1_ON_SOFT = 0x100000, // Soft terrain
     swrObjTest_FLAG1_FLAT_CACHE = 0x400000, // flat-ground raycast cache valid
     swrObjTest_FLAG1_ON_FLAT = 0x800000, // Flat terrain
+    swrObjTest_FLAG1_RESPAWN_RELIGHT = 0x200000, // one-shot when respawn invincibility expires; cMan reloads terrain lighting/fog, then clears it
     swrObjTest_FLAG1_FINISHED = 0x2000000, // race complete
     swrObjTest_FLAG1_FORCE_GROUND = 0x4000000, // gates the full ground/spline update
     swrObjTest_FLAG1_GROUNDED = 0x8000000, // grounded

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -104,6 +104,8 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_LOOK_BACK = 0x100000, // rear-view / look-back input held (in-race input bitset3 bit 0x8);
     // the camera manager reads it to flip the chase/first-person camera basis, then clears it.
     swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost (speed > 0.75 * maxSpeed, alive)
+    // 0x400000: read by UpdatePlayerControl (pins throttle 1.2 during boost charge) and cleared by
+    // BoostCharge, but no setter exists in the retail binary - dead code, left unnamed.
     swrObjTest_FLAG0_BOOSTING = 0x800000, // boost active
     swrObjTest_FLAG0_HIT_BOTTOM = 0x1000000, // hard-landing debounce ('HittBotm' event)
     swrObjTest_FLAG0_ZON = 0x2000000, // zero-g ON / orbit


### PR DESCRIPTION
Follow-up to #262, same theme: names verified by a full decompile sweep of the swrObjTest orbit (every constant read from the binary, evidence in the commit messages).

Highlights:
- swrRace +0xac is a `swrSplineCursor`, not a matrix - it's the pod's track-spline cursor (typedef moved above swrRace).
- Fixes the long-standing swrRace sizeof bug (0x1f24 vs 0x1f28): every label after 0x1eb8 was 4 bytes off and one trailing dword was missing. Offsets are now compiler-verified (`_Static_assert` checked locally).
- The "spline progress values" scratch table actually stores baked track-mesh pointers: +0xec/+0xf0 are the current/previous track mesh under the cursor, `swrModel_Mesh` +0x3c is that mesh's spline node index, and `swrRace_UpdateSplineBinding` uses it to re-seek the cursor to the mesh the pod is standing on.
- swrScore +0x18 points at the racer's pilot id (0..22). That unlocked the pilot specials: pilot 2 = Sebulba's flame attack (the `SpawnExplosionEffect` / `SendFlameEvent` / `SpawnExplosionByIndex` trio is that whole networked mechanism, renamed to `*FlameAttack*` - it's not the death explosion), pilot 14 = Neva Kee's fused engines (cockpitXf copied onto both engineXf in F3).
- flags0's low nibble is a state field (0 pre-race / 1 post-race / 2 racing); new named bits: REPAIRING, WALL_IMPACT_CLAMP, LOOK_BACK, GUIDE_ARROW (kills the raw 0x8000000 in swrObjJdge_UpdatePlayerHUD), SCRAPE_SPARK_R/L, THROTTLE_SETTLED, plus flags1 RESPAWN_RELIGHT. The two _Maybe bits from #262 are superseded - 0x100000's missing consumer is the camera manager's look-back flip.
- ~20 functions drop `_Maybe` or get corrected names; the notable misnames: `UpdateScrapeContact` is really a Smok-geyser proximity push, `setInRaceInputState` is a raycast ignore-facing toggle, `FxAdvanceAnimTimers` applies the pod's vertical part sink offset.

Full dinput_hook build + link green; dup/data-symbol/hook-annotation scripts clean; my Ghidra DB renamed to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)