### PR TITLE
reimpl: clean leaf functions (swrSprite / stdControl / swrUI / swrModel / swrViewport)

### DIFF
--- a/src/Platform/stdControl.c
+++ b/src/Platform/stdControl.c
@@ -161,5 +161,19 @@ void stdControl_ReadMouse(void)
 // 0x00486970
 void stdControl_RegisterAxis(int axisID, int min, int max, float scale)
 {
-    HANG("TODO");
+    int center;
+    float halfRange;
+
+    stdControl_aAxes[axisID].flags |= STDCONTROL_AXIS_REGISTERED;
+    center = ((max - min) + 1) / 2 + min;
+    stdControl_aAxes[axisID].min = min;
+    stdControl_aAxes[axisID].max = max;
+    stdControl_aAxes[axisID].xOffset = center;
+    halfRange = (float)(max - center);
+    stdControl_aAxes[axisID].fltMedian = 1.0f / halfRange;
+    if (scale != 0.0f) {
+        stdControl_aAxes[axisID].yOffset = (int)(scale * halfRange);
+        return;
+    }
+    stdControl_aAxes[axisID].yOffset = 0;
 }

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -5,6 +5,7 @@
 
 #include <globals.h>
 #include <macros.h>
+#include <General/stdMath.h>
 #include <Primitives/rdMath.h>
 #include <Primitives/rdMatrix.h>
 #include <Primitives/rdVector.h>
@@ -1421,6 +1422,40 @@ swrModel_Material* swrModel_NodeFindFirstMaterial(swrModel_Node* node)
         }
     }
     return NULL;
+}
+
+// Builds a translation+rotation that positions an object at `from` looking toward
+// `to`, with the given roll. Fills outTR (yaw/pitch/roll) and the 4x4 outMatrix.
+// If from/to nearly coincide only the translation is written. Handles the near-
+// vertical direction case (horizontal component ~0) with fixed +/-90 degree yaw.
+// 0x00481220
+void BuildLookAtTransform(rdVector3* from, rdVector3* to, rdMatrix44* outMatrix, swrTranslationRotation* outTR, float roll)
+{
+    rdVector3 dir;
+    float len;
+
+    outTR->translation = *from;
+    dir.x = to->x - from->x;
+    dir.y = to->y - from->y;
+    dir.z = to->z - from->z;
+    len = rdVector_Len3(&dir);
+    if (len <= 0.0001f) {
+        rdMatrix_SetTranslation44(outMatrix, from->x, from->y, from->z);
+        return;
+    }
+    rdVector_Scale3(&dir, 1.0f / len, &dir);
+    outTR->yaw_roll_pitch.y = stdMath_ArcSin(dir.z);
+    outTR->yaw_roll_pitch.z = roll;
+    if (0.0001f <= dir.y || dir.y <= -0.0001f) {
+        outTR->yaw_roll_pitch.x = stdMath_ArcTan2(-dir.x, dir.y);
+    } else if (dir.x < -0.0001f) {
+        outTR->yaw_roll_pitch.x = 90.0f;
+    } else if (0.0001f < dir.x) {
+        outTR->yaw_roll_pitch.x = -90.0f;
+    } else {
+        outTR->yaw_roll_pitch.x = 0.0f;
+    }
+    rdMatrix_SetTransform44(outMatrix, outTR);
 }
 
 // Walks the node tree accumulating parent transforms; when it reaches `target`,

--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -145,7 +145,15 @@ void swrSprite_AssignTextureToId(swrSpriteTexture* spriteTex, int id, int from_t
 // 0x00417010
 swrSpriteTexture* swrSprite_GetTextureFromId(int id)
 {
-    HANG("TODO");
+    swrSpriteTexItem* texItems;
+
+    texItems = swrSpriteTexItems;
+    do {
+        if (texItems->id == id)
+            return texItems->texture;
+        texItems = texItems + 1;
+    } while (texItems < swrSpriteTexItems + (sizeof(swrSpriteTexItems) / sizeof(swrSpriteTexItems[0])));
+    return NULL;
 }
 
 // 0x00417120 TODO: crashes on release, works fine on debug

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -651,6 +651,19 @@ void swrUI_SetSpriteSelectionBBox_Maybe(int* bbox_out, int collapsed)
     }
 }
 
+// 0x0041b380
+int swrUI_IsFocusable(swrUI_unk* element)
+{
+    // list items (widget_class low bits 0x4|0x8) are always focusable
+    if (((uint8_t)element->widget_class & 0xc) == 0xc)
+        return 1;
+    if ((element->flags & swrUI_STATIC) == 0 && (element->flags & swrUI_DISABLED) == 0) {
+        if (swrUI_IsElementVisible(element))
+            return 1;
+    }
+    return 0;
+}
+
 // 0x0041b5e0
 swrUI_unk* swrUI_GetByValue(swrUI_unk* ui, int value)
 {

--- a/src/Swr/swrViewport.c
+++ b/src/Swr/swrViewport.c
@@ -35,6 +35,58 @@ void swrViewport_UpdateCameras()
     HANG("TODO");
 }
 
+// Projects a world (or camera-relative) point through the current model MVP into
+// viewport pixel coordinates. Writes the pixel x/y (or a -1000 sentinel when the
+// point is behind the near plane or falls outside the +/-8px padded viewport box),
+// the perspective-divided depth (outZ) and raw clip w (outDepth).
+// 0x0042b710
+void swrViewport_ProjectToScreen(swrViewport* viewport, rdVector4* worldPos, float* outScreenX, float* outScreenY, float* outZ, float* outDepth, int pointIsCameraRelative)
+{
+    rdMatrix44 mvp;
+    rdVector4 relativePos;
+    rdVector4 clip;
+    int halfW;
+    int halfH;
+    float scaleX;
+    float scaleY;
+    float centerX;
+    float centerY;
+    float screenX;
+    float screenY;
+
+    mvp = rdMatrix44_model_MVP;
+    halfW = (int)viewport->viewport_scaled_x1 / 2;
+    halfH = (int)viewport->viewport_scaled_y1 / 2;
+    scaleX = (float)halfW * 0.5f;
+    scaleY = (float)halfH * 0.5f;
+    centerX = (float)((int)viewport->viewport_scaled_x2 / 4) - scaleX;
+    centerY = (float)((int)viewport->viewport_scaled_y2 / 4) - scaleY;
+    *outScreenX = -1000.0f;
+    *outScreenY = -1000.0f;
+    if (pointIsCameraRelative == 0) {
+        relativePos.x = worldPos->x - rdVector_model_translation.x;
+        relativePos.y = worldPos->y - rdVector_model_translation.y;
+        relativePos.z = worldPos->z - rdVector_model_translation.z;
+        worldPos = &relativePos;
+    }
+    rdMatrix_TransformPoint44(&clip, worldPos, &mvp);
+    if ((GameSettingFlags & 0x4000) != 0) {
+        clip.x = -clip.x;
+    }
+    if (0.01f < clip.w) {
+        screenX = (clip.x / clip.w + 1.0f) * scaleX + centerX;
+        screenY = (1.0f - clip.y / clip.w) * scaleY + centerY;
+        *outZ = clip.z / clip.w;
+        *outDepth = clip.w;
+        // keep the point only if it lands inside the viewport rect padded by 8px
+        if (centerX - 8.0f < screenX && screenX < (centerX + (float)halfW) + 8.0f &&
+            centerY - 8.0f < screenY && screenY < (centerY + (float)halfH) + 8.0f) {
+            *outScreenX = screenX;
+            *outScreenY = screenY;
+        }
+    }
+}
+
 // 0x004318c0
 int swrViewport_GetNumViewports()
 {

--- a/src/Swr/swrViewport.h
+++ b/src/Swr/swrViewport.h
@@ -47,7 +47,7 @@ void swrViewport_UpdateCameras();
 // Outputs go to outScreenX / outScreenY (set to -1000.0 if off the projection rect),
 // outZ and outDepth. pointIsCameraRelative == 0 means worldPos is absolute world space
 // and gets made camera-relative first.
-void swrViewport_ProjectToScreen(void* viewport, rdVector4* worldPos, float* outScreenX, float* outScreenY, float* outZ, float* outDepth, int pointIsCameraRelative);
+void swrViewport_ProjectToScreen(swrViewport* viewport, rdVector4* worldPos, float* outScreenX, float* outScreenY, float* outZ, float* outDepth, int pointIsCameraRelative);
 
 int swrViewport_GetNumViewports();
 swrViewport* swrViewport_Get(int index);

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -978,6 +978,7 @@ typedef enum swrUISprite
 
 typedef enum swrUI_FLAG
 {
+    swrUI_STATIC = 0x4, // non-interactive static element (set by swrUI_NewLabel); skipped by focus navigation
     swrUI_FOCUSED = 0x20, // element currently has keyboard focus (swrUI_SetFocusedElement)
     swrUI_VISIBLE = 0x40, // element is visible (swrUI_IsElementVisible walks the parent chain)
     swrUI_DISABLED = 0x100, // grayed-out / non-interactive (swrUI_DisableElement)


### PR DESCRIPTION
Five self-contained leaf reimpls:

- `swrSprite_GetTextureFromId` — linear lookup over `swrSpriteTexItems` (read counterpart of `swrSprite_AssignTextureToId`)
- `stdControl_RegisterAxis` — register an input axis (center / median / scale)
- `swrUI_IsFocusable` — focusability test; adds `swrUI_STATIC` (0x4), the non-interactive flag `swrUI_NewLabel` sets
- `BuildLookAtTransform` — from/to look-at → translation + euler + matrix, incl. the near-vertical (±90 yaw) case (FP path, unblocked by the ftol fix)
- `swrViewport_ProjectToScreen` — world / camera-relative point → viewport pixels via the model MVP; also types the param `void*` → `swrViewport*`

Zero new globals; small float consts inlined to match existing style. Builds + links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)