### PR TITLE
reimpl(rdClip): four more Face3 triangle clippers

### DIFF
--- a/src/Engine/rdClip.c
+++ b/src/Engine/rdClip.c
@@ -105,16 +105,521 @@ int rdClip_CalcOutcode2(rdCanvas* canvas, int x, int y)
     return result;
 }
 
+// Clips a shaded (position-only) triangle against the perspective view frustum,
+// same as rdClip_Face3S but using the top/orthoRight side planes instead of
+// right/left. Sutherland-Hodgman, ping-ponging through rdClip_workVerts.
 // 0x00494c60
 int rdClip_Face3W(rdClipFrustum* pFrustrum, rdVector3* aVertices, int numVertices)
 {
-    HANG("TODO");
+    rdVector3* pPrev;
+    rdVector3* pCur;
+    rdVector3* pDst;
+    rdVector3* pSwap;
+    int numIn;
+    int numOut;
+    int i;
+    float prevBound;
+    float curBound;
+    float dR;
+    float dC;
+    float denom;
+    float cross;
+    float iC;
+    float adR;
+    float adC;
+    float t;
+
+    rdClip_faceStatus = 0;
+    rdClip_pSrcVerts = aVertices;
+    rdClip_pDstVerts = rdClip_workVerts;
+
+    // ---- pass 1: topPlane, clip x, keep x >= plane * y ----
+    numOut = 0;
+    if (numVertices > 0) {
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numVertices - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numVertices;
+        do {
+            prevBound = pFrustrum->topPlane * pPrev->y;
+            curBound = pFrustrum->topPlane * pCur->y;
+            if (prevBound <= pPrev->x || curBound <= pCur->x) {
+                if (pPrev->x != prevBound && pCur->x != curBound && (pPrev->x < prevBound || pCur->x < curBound)) {
+                    dR = pCur->y - pPrev->y;
+                    dC = pCur->x - pPrev->x;
+                    denom = pFrustrum->topPlane * dR - dC;
+                    cross = pPrev->x * pCur->y - pPrev->y * pCur->x;
+                    if (denom != 0.0) {
+                        cross = cross / denom;
+                    }
+                    iC = pFrustrum->topPlane * cross;
+                    adR = dR < 0.0 ? -dR : dR;
+                    adC = dC < 0.0 ? -dC : dC;
+                    t = adR <= adC ? (iC - pPrev->x) / dC : (cross - pPrev->y) / dR;
+                    pDst[numOut].x = iC;
+                    pDst[numOut].y = cross;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_PLANE_A;
+                }
+                if (curBound <= pCur->x) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+    }
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 2: bottomPlane, clip x, keep x <= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        prevBound = pFrustrum->bottomPlane * pPrev->y;
+        curBound = pFrustrum->bottomPlane * pCur->y;
+        if (pPrev->x <= prevBound || pCur->x <= curBound) {
+            if (pPrev->x != prevBound && pCur->x != curBound && (prevBound < pPrev->x || curBound < pCur->x)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->x - pPrev->x;
+                denom = pFrustrum->bottomPlane * dR - dC;
+                cross = pPrev->x * pCur->y - pPrev->y * pCur->x;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->bottomPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->x) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = iC;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_B;
+            }
+            if (pCur->x <= curBound) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 3: orthoRightPlane, clip z, keep z <= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        prevBound = pFrustrum->orthoRightPlane * pPrev->y;
+        curBound = pFrustrum->orthoRightPlane * pCur->y;
+        if (pPrev->z <= prevBound || pCur->z <= curBound) {
+            if (pPrev->z != prevBound && pCur->z != curBound && (prevBound < pPrev->z || curBound < pCur->z)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->z - pPrev->z;
+                denom = pFrustrum->orthoRightPlane * dR - dC;
+                cross = pPrev->z * pCur->y - pPrev->y * pCur->z;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->orthoRightPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->z) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = iC;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_C;
+            }
+            if (pCur->z <= curBound) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 4: orthoBottomPlane, clip z, keep z >= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        prevBound = pFrustrum->orthoBottomPlane * pPrev->y;
+        curBound = pFrustrum->orthoBottomPlane * pCur->y;
+        if (prevBound <= pPrev->z || curBound <= pCur->z) {
+            if (pPrev->z != prevBound && pCur->z != curBound && (pPrev->z < prevBound || pCur->z < curBound)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->z - pPrev->z;
+                denom = pFrustrum->orthoBottomPlane * dR - dC;
+                cross = pPrev->z * pCur->y - pPrev->y * pCur->z;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->orthoBottomPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->z) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = iC;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_D;
+            }
+            if (curBound <= pCur->z) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 5: zNear, clip y against constant, keep y >= zNear ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (pFrustrum->zNear <= pPrev->y || pFrustrum->zNear <= pCur->y) {
+            if (pPrev->y != pFrustrum->zNear && pCur->y != pFrustrum->zNear && (pPrev->y < pFrustrum->zNear || pCur->y < pFrustrum->zNear)) {
+                t = (pFrustrum->zNear - pPrev->y) / (pCur->y - pPrev->y);
+                pDst[numOut].y = pFrustrum->zNear;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_NEARZ;
+            }
+            if (pFrustrum->zNear <= pCur->y) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        rdClip_faceStatus |= rdClip_FaceStatus_DEGENERATE;
+        return numOut;
+    }
+
+    // ---- pass 6: zFar, clip y against constant, keep y <= zFar (only if far clip enabled) ----
+    if (pFrustrum->bFarClip != 0) {
+        pSwap = rdClip_pSrcVerts;
+        rdClip_pSrcVerts = rdClip_pDstVerts;
+        rdClip_pDstVerts = pSwap;
+
+        numIn = numOut;
+        numOut = 0;
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numIn - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numIn;
+        do {
+            if (pPrev->y <= pFrustrum->zFar || pCur->y <= pFrustrum->zFar) {
+                if (pPrev->y != pFrustrum->zFar && pCur->y != pFrustrum->zFar && (pFrustrum->zFar < pPrev->y || pFrustrum->zFar < pCur->y)) {
+                    t = (pFrustrum->zFar - pPrev->y) / (pCur->y - pPrev->y);
+                    pDst[numOut].y = pFrustrum->zFar;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_FARZ;
+                }
+                if (pCur->y <= pFrustrum->zFar) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+        if (numOut < 3) {
+            return numOut;
+        }
+    }
+
+    if (rdClip_pDstVerts != aVertices) {
+        for (i = 0; i < numOut; i++) {
+            aVertices[i] = rdClip_pDstVerts[i];
+        }
+    }
+    return numOut;
 }
 
+// Position-only clip against the orthographic view box. Identical plane set and
+// logic to rdClip_Face3SOrtho (the shipped game has two matching routines).
 // 0x00495600
 int rdClip_Face3WOrtho(rdClipFrustum* pFrustrum, rdVector3* aVertices, int numVertices)
 {
-    HANG("TODO");
+    rdVector3* pPrev;
+    rdVector3* pCur;
+    rdVector3* pDst;
+    rdVector3* pSwap;
+    int numIn;
+    int numOut;
+    int i;
+    float plane;
+    float t;
+
+    rdClip_faceStatus = 0;
+    rdClip_pSrcVerts = aVertices;
+    rdClip_pDstVerts = rdClip_workVerts;
+
+    // ---- pass 1: nearPlane, clip x, keep x >= nearPlane ----
+    numOut = 0;
+    plane = pFrustrum->nearPlane;
+    if (numVertices > 0) {
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numVertices - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numVertices;
+        do {
+            if (plane <= pPrev->x || plane <= pCur->x) {
+                if (pPrev->x != plane && pCur->x != plane && (pPrev->x < plane || pCur->x < plane)) {
+                    t = (plane - pPrev->x) / (pCur->x - pPrev->x);
+                    pDst[numOut].x = plane;
+                    pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_PLANE_A;
+                }
+                if (plane <= pCur->x) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+    }
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 2: orthoLeftPlane, clip x, keep x <= orthoLeftPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustrum->orthoLeftPlane;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (pPrev->x <= plane || pCur->x <= plane) {
+            if (pPrev->x != plane && pCur->x != plane && (plane < pPrev->x || plane < pCur->x)) {
+                t = (plane - pPrev->x) / (pCur->x - pPrev->x);
+                pDst[numOut].x = plane;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_B;
+            }
+            if (pCur->x <= plane) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 3: farPlane, clip z, keep z <= farPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustrum->farPlane;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (pPrev->z <= plane || pCur->z <= plane) {
+            if (pPrev->z != plane && pCur->z != plane && (plane < pPrev->z || plane < pCur->z)) {
+                t = (plane - pPrev->z) / (pCur->z - pPrev->z);
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = plane;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_C;
+            }
+            if (pCur->z <= plane) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 4: orthoTopPlane, clip z, keep z >= orthoTopPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustrum->orthoTopPlane;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (plane <= pPrev->z || plane <= pCur->z) {
+            if (pPrev->z != plane && pCur->z != plane && (pPrev->z < plane || pCur->z < plane)) {
+                t = (plane - pPrev->z) / (pCur->z - pPrev->z);
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = plane;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_D;
+            }
+            if (plane <= pCur->z) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 5: zNear, clip y, keep y >= zNear ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustrum->zNear;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (plane <= pPrev->y || plane <= pCur->y) {
+            if (pPrev->y != plane && pCur->y != plane && (pPrev->y < plane || pCur->y < plane)) {
+                t = (plane - pPrev->y) / (pCur->y - pPrev->y);
+                pDst[numOut].y = plane;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_NEARZ;
+            }
+            if (plane <= pCur->y) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        rdClip_faceStatus |= rdClip_FaceStatus_DEGENERATE;
+        return numOut;
+    }
+
+    // ---- pass 6: zFar, clip y, keep y <= zFar (only if far clip enabled) ----
+    if (pFrustrum->bFarClip != 0) {
+        pSwap = rdClip_pSrcVerts;
+        rdClip_pSrcVerts = rdClip_pDstVerts;
+        rdClip_pDstVerts = pSwap;
+
+        numIn = numOut;
+        numOut = 0;
+        plane = pFrustrum->zFar;
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numIn - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numIn;
+        do {
+            if (pPrev->y <= plane || pCur->y <= plane) {
+                if (pPrev->y != plane && pCur->y != plane && (plane < pPrev->y || plane < pCur->y)) {
+                    t = (plane - pPrev->y) / (pCur->y - pPrev->y);
+                    pDst[numOut].y = plane;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_FARZ;
+                }
+                if (pCur->y <= plane) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+        if (numOut < 3) {
+            return numOut;
+        }
+    }
+
+    if (rdClip_pDstVerts != aVertices) {
+        for (i = 0; i < numOut; i++) {
+            aVertices[i] = rdClip_pDstVerts[i];
+        }
+    }
+    return numOut;
 }
 
 // Clips a shaded (position-only) triangle against the perspective view frustum
@@ -401,10 +906,238 @@ int rdClip_Face3S(rdClipFrustum* pFrustrum, rdVector3* aVertices, int numVertice
     return numOut;
 }
 
+// Clips a shaded (position-only) triangle against the orthographic view box,
+// same plane set as rdClip_Face3TOrtho but without UV/intensity interpolation.
+// Sutherland-Hodgman, ping-ponging through rdClip_workVerts.
 // 0x004966f0
 int rdClip_Face3SOrtho(rdClipFrustum* pFrustum, rdVector3* aVertices, int numVertices)
 {
-    HANG("TODO");
+    rdVector3* pPrev;
+    rdVector3* pCur;
+    rdVector3* pDst;
+    rdVector3* pSwap;
+    int numIn;
+    int numOut;
+    int i;
+    float plane;
+    float t;
+
+    rdClip_faceStatus = 0;
+    rdClip_pSrcVerts = aVertices;
+    rdClip_pDstVerts = rdClip_workVerts;
+
+    // ---- pass 1: nearPlane, clip x, keep x >= nearPlane ----
+    numOut = 0;
+    plane = pFrustum->nearPlane;
+    if (numVertices > 0) {
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numVertices - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numVertices;
+        do {
+            if (plane <= pPrev->x || plane <= pCur->x) {
+                if (pPrev->x != plane && pCur->x != plane && (pPrev->x < plane || pCur->x < plane)) {
+                    t = (plane - pPrev->x) / (pCur->x - pPrev->x);
+                    pDst[numOut].x = plane;
+                    pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_PLANE_A;
+                }
+                if (plane <= pCur->x) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+    }
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 2: orthoLeftPlane, clip x, keep x <= orthoLeftPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->orthoLeftPlane;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (pPrev->x <= plane || pCur->x <= plane) {
+            if (pPrev->x != plane && pCur->x != plane && (plane < pPrev->x || plane < pCur->x)) {
+                t = (plane - pPrev->x) / (pCur->x - pPrev->x);
+                pDst[numOut].x = plane;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_B;
+            }
+            if (pCur->x <= plane) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 3: farPlane, clip z, keep z <= farPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->farPlane;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (pPrev->z <= plane || pCur->z <= plane) {
+            if (pPrev->z != plane && pCur->z != plane && (plane < pPrev->z || plane < pCur->z)) {
+                t = (plane - pPrev->z) / (pCur->z - pPrev->z);
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = plane;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_C;
+            }
+            if (pCur->z <= plane) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 4: orthoTopPlane, clip z, keep z >= orthoTopPlane ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->orthoTopPlane;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (plane <= pPrev->z || plane <= pCur->z) {
+            if (pPrev->z != plane && pCur->z != plane && (pPrev->z < plane || pCur->z < plane)) {
+                t = (plane - pPrev->z) / (pCur->z - pPrev->z);
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = (pCur->y - pPrev->y) * t + pPrev->y;
+                pDst[numOut].z = plane;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_D;
+            }
+            if (plane <= pCur->z) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwap = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwap;
+
+    // ---- pass 5: zNear, clip y, keep y >= zNear ----
+    numIn = numOut;
+    numOut = 0;
+    plane = pFrustum->zNear;
+    pDst = rdClip_pDstVerts;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    i = numIn;
+    do {
+        if (plane <= pPrev->y || plane <= pCur->y) {
+            if (pPrev->y != plane && pCur->y != plane && (pPrev->y < plane || pCur->y < plane)) {
+                t = (plane - pPrev->y) / (pCur->y - pPrev->y);
+                pDst[numOut].y = plane;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_NEARZ;
+            }
+            if (plane <= pCur->y) {
+                pDst[numOut] = *pCur;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        rdClip_faceStatus |= rdClip_FaceStatus_DEGENERATE;
+        return numOut;
+    }
+
+    // ---- pass 6: zFar, clip y, keep y <= zFar (only if far clip enabled) ----
+    if (pFrustum->bFarClip != 0) {
+        pSwap = rdClip_pSrcVerts;
+        rdClip_pSrcVerts = rdClip_pDstVerts;
+        rdClip_pDstVerts = pSwap;
+
+        numIn = numOut;
+        numOut = 0;
+        plane = pFrustum->zFar;
+        pDst = rdClip_pDstVerts;
+        pPrev = rdClip_pSrcVerts + numIn - 1;
+        pCur = rdClip_pSrcVerts;
+        i = numIn;
+        do {
+            if (pPrev->y <= plane || pCur->y <= plane) {
+                if (pPrev->y != plane && pCur->y != plane && (plane < pPrev->y || plane < pCur->y)) {
+                    t = (plane - pPrev->y) / (pCur->y - pPrev->y);
+                    pDst[numOut].y = plane;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_FARZ;
+                }
+                if (pCur->y <= plane) {
+                    pDst[numOut] = *pCur;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            i--;
+        } while (i != 0);
+        if (numOut < 3) {
+            return numOut;
+        }
+    }
+
+    if (rdClip_pDstVerts != aVertices) {
+        for (i = 0; i < numOut; i++) {
+            aVertices[i] = rdClip_pDstVerts[i];
+        }
+    }
+    return numOut;
 }
 
 // 0x00496e40
@@ -431,10 +1164,437 @@ int rdClip_Face3GTOrtho(rdClipFrustum* pFrustrum, rdVector3* aVertices, rdVector
     HANG("TODO");
 }
 
+// Clips a textured, per-vertex-lit triangle against the perspective view frustum
+// (Sutherland-Hodgman), interpolating position, UVs and intensities at each
+// crossing. Same plane set as rdClip_Face3S; the textured/lit counterpart of it
+// and the perspective counterpart of rdClip_Face3TOrtho. Returns the clipped
+// vertex count (< 3 = culled). Ping-pongs the three attribute streams through the
+// rdClip work buffers.
 // 0x0049a390
 int rdClip_Face3T(rdClipFrustum* pFrustrum, rdVector3* aVertices, rdVector2* aTexVertices, rdVector4* aIntensities, int numVertices)
 {
-    HANG("TODO");
+    rdVector3* pPrev;
+    rdVector3* pCur;
+    rdVector3* pDst;
+    rdVector3* pSwapV;
+    rdVector2* pPrevTex;
+    rdVector2* pCurTex;
+    rdVector2* pDstTex;
+    rdVector2* pSwapT;
+    rdVector4* pPrevInt;
+    rdVector4* pCurInt;
+    rdVector4* pDstInt;
+    rdVector4* pSwapI;
+    int numIn;
+    int numOut;
+    int i;
+    float dR;
+    float dC;
+    float denom;
+    float cross;
+    float iC;
+    float adR;
+    float adC;
+    float t;
+
+    rdClip_faceStatus = 0;
+    rdClip_pSrcVerts = aVertices;
+    rdClip_pDstVerts = rdClip_workVerts;
+    rdClip_pSrcTexVerts = aTexVertices;
+    rdClip_pDstTexVerts = rdClip_workTexVerts;
+    rdClip_pSrcIntensities = aIntensities;
+    rdClip_pDstIntensities = rdClip_workIntensities;
+
+    // ---- pass 1: rightPlane, clip x, keep x >= plane * y ----
+    numOut = 0;
+    if (numVertices > 0) {
+        pDst = rdClip_pDstVerts;
+        pDstTex = rdClip_pDstTexVerts;
+        pDstInt = rdClip_pDstIntensities;
+        pPrev = rdClip_pSrcVerts + numVertices - 1;
+        pCur = rdClip_pSrcVerts;
+        pPrevTex = rdClip_pSrcTexVerts + numVertices - 1;
+        pCurTex = rdClip_pSrcTexVerts;
+        pPrevInt = rdClip_pSrcIntensities + numVertices - 1;
+        pCurInt = rdClip_pSrcIntensities;
+        i = numVertices;
+        do {
+            if (pFrustrum->rightPlane * pPrev->y <= pPrev->x || pFrustrum->rightPlane * pCur->y <= pCur->x) {
+                if (pPrev->x != pFrustrum->rightPlane * pPrev->y && pCur->x != pFrustrum->rightPlane * pCur->y &&
+                    (pPrev->x < pFrustrum->rightPlane * pPrev->y || pCur->x < pFrustrum->rightPlane * pCur->y)) {
+                    dR = pCur->y - pPrev->y;
+                    dC = pCur->x - pPrev->x;
+                    denom = pFrustrum->rightPlane * dR - dC;
+                    cross = pCur->y * pPrev->x - pPrev->y * pCur->x;
+                    if (denom != 0.0) {
+                        cross = cross / denom;
+                    }
+                    iC = pFrustrum->rightPlane * cross;
+                    adR = dR < 0.0 ? -dR : dR;
+                    adC = dC < 0.0 ? -dC : dC;
+                    t = adR <= adC ? (iC - pPrev->x) / dC : (cross - pPrev->y) / dR;
+                    pDst[numOut].x = iC;
+                    pDst[numOut].y = cross;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                    pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                    pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                    pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                    pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                    pDstInt[numOut].w = (pCurInt->w - pPrevInt->w) * t + pPrevInt->w;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_PLANE_A;
+                }
+                if (pFrustrum->rightPlane * pCur->y <= pCur->x) {
+                    pDst[numOut] = *pCur;
+                    pDstTex[numOut] = *pCurTex;
+                    pDstInt[numOut] = *pCurInt;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            pPrevTex = pCurTex;
+            pCurTex++;
+            pPrevInt = pCurInt;
+            pCurInt++;
+            i--;
+        } while (i != 0);
+    }
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 2: bottomPlane, clip x, keep x <= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (pPrev->x <= pFrustrum->bottomPlane * pPrev->y || pCur->x <= pFrustrum->bottomPlane * pCur->y) {
+            if (pPrev->x != pFrustrum->bottomPlane * pPrev->y && pCur->x != pFrustrum->bottomPlane * pCur->y &&
+                (pFrustrum->bottomPlane * pPrev->y < pPrev->x || pFrustrum->bottomPlane * pCur->y < pCur->x)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->x - pPrev->x;
+                denom = pFrustrum->bottomPlane * dR - dC;
+                cross = pCur->y * pPrev->x - pPrev->y * pCur->x;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->bottomPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->x) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = iC;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                pDstInt[numOut].w = (pCurInt->w - pPrevInt->w) * t + pPrevInt->w;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_B;
+            }
+            if (pCur->x <= pFrustrum->bottomPlane * pCur->y) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 3: leftPlane, clip z, keep z <= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (pPrev->z <= pFrustrum->leftPlane * pPrev->y || pCur->z <= pFrustrum->leftPlane * pCur->y) {
+            if (pPrev->z != pFrustrum->leftPlane * pPrev->y && pCur->z != pFrustrum->leftPlane * pCur->y &&
+                (pFrustrum->leftPlane * pPrev->y < pPrev->z || pFrustrum->leftPlane * pCur->y < pCur->z)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->z - pPrev->z;
+                denom = pFrustrum->leftPlane * dR - dC;
+                cross = pCur->y * pPrev->z - pPrev->y * pCur->z;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->leftPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->z) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = iC;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                pDstInt[numOut].w = (pCurInt->w - pPrevInt->w) * t + pPrevInt->w;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_C;
+            }
+            if (pCur->z <= pFrustrum->leftPlane * pCur->y) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 4: orthoBottomPlane, clip z, keep z >= plane * y ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (pFrustrum->orthoBottomPlane * pPrev->y <= pPrev->z || pFrustrum->orthoBottomPlane * pCur->y <= pCur->z) {
+            if (pPrev->z != pFrustrum->orthoBottomPlane * pPrev->y && pCur->z != pFrustrum->orthoBottomPlane * pCur->y &&
+                (pPrev->z < pFrustrum->orthoBottomPlane * pPrev->y || pCur->z < pFrustrum->orthoBottomPlane * pCur->y)) {
+                dR = pCur->y - pPrev->y;
+                dC = pCur->z - pPrev->z;
+                denom = pFrustrum->orthoBottomPlane * dR - dC;
+                cross = pCur->y * pPrev->z - pPrev->y * pCur->z;
+                if (denom != 0.0) {
+                    cross = cross / denom;
+                }
+                iC = pFrustrum->orthoBottomPlane * cross;
+                adR = dR < 0.0 ? -dR : dR;
+                adC = dC < 0.0 ? -dC : dC;
+                t = adR <= adC ? (iC - pPrev->z) / dC : (cross - pPrev->y) / dR;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDst[numOut].y = cross;
+                pDst[numOut].z = iC;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                pDstInt[numOut].w = (pCurInt->w - pPrevInt->w) * t + pPrevInt->w;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_PLANE_D;
+            }
+            if (pFrustrum->orthoBottomPlane * pCur->y <= pCur->z) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        return numOut;
+    }
+    pSwapV = rdClip_pSrcVerts;
+    rdClip_pSrcVerts = rdClip_pDstVerts;
+    rdClip_pDstVerts = pSwapV;
+    pSwapT = rdClip_pSrcTexVerts;
+    rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+    rdClip_pDstTexVerts = pSwapT;
+    pSwapI = rdClip_pSrcIntensities;
+    rdClip_pSrcIntensities = rdClip_pDstIntensities;
+    rdClip_pDstIntensities = pSwapI;
+
+    // ---- pass 5: zNear, clip y, keep y >= zNear ----
+    numIn = numOut;
+    numOut = 0;
+    pDst = rdClip_pDstVerts;
+    pDstTex = rdClip_pDstTexVerts;
+    pDstInt = rdClip_pDstIntensities;
+    pPrev = rdClip_pSrcVerts + numIn - 1;
+    pCur = rdClip_pSrcVerts;
+    pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+    pCurTex = rdClip_pSrcTexVerts;
+    pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+    pCurInt = rdClip_pSrcIntensities;
+    i = numIn;
+    do {
+        if (pFrustrum->zNear <= pPrev->y || pFrustrum->zNear <= pCur->y) {
+            if (pPrev->y != pFrustrum->zNear && pCur->y != pFrustrum->zNear && (pPrev->y < pFrustrum->zNear || pCur->y < pFrustrum->zNear)) {
+                t = (pFrustrum->zNear - pPrev->y) / (pCur->y - pPrev->y);
+                pDst[numOut].y = pFrustrum->zNear;
+                pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                pDstInt[numOut].w = (pCurInt->w - pPrevInt->w) * t + pPrevInt->w;
+                numOut++;
+                rdClip_faceStatus |= rdClip_FaceStatus_NEARZ;
+            }
+            if (pFrustrum->zNear <= pCur->y) {
+                pDst[numOut] = *pCur;
+                pDstTex[numOut] = *pCurTex;
+                pDstInt[numOut] = *pCurInt;
+                numOut++;
+            }
+        }
+        pPrev = pCur;
+        pCur++;
+        pPrevTex = pCurTex;
+        pCurTex++;
+        pPrevInt = pCurInt;
+        pCurInt++;
+        i--;
+    } while (i != 0);
+    if (numOut < 3) {
+        rdClip_faceStatus |= rdClip_FaceStatus_DEGENERATE;
+        return numOut;
+    }
+
+    // ---- pass 6: zFar, clip y, keep y <= zFar (only if far clip enabled) ----
+    if (pFrustrum->bFarClip != 0) {
+        pSwapV = rdClip_pSrcVerts;
+        rdClip_pSrcVerts = rdClip_pDstVerts;
+        rdClip_pDstVerts = pSwapV;
+        pSwapT = rdClip_pSrcTexVerts;
+        rdClip_pSrcTexVerts = rdClip_pDstTexVerts;
+        rdClip_pDstTexVerts = pSwapT;
+        pSwapI = rdClip_pSrcIntensities;
+        rdClip_pSrcIntensities = rdClip_pDstIntensities;
+        rdClip_pDstIntensities = pSwapI;
+
+        numIn = numOut;
+        numOut = 0;
+        pDst = rdClip_pDstVerts;
+        pDstTex = rdClip_pDstTexVerts;
+        pDstInt = rdClip_pDstIntensities;
+        pPrev = rdClip_pSrcVerts + numIn - 1;
+        pCur = rdClip_pSrcVerts;
+        pPrevTex = rdClip_pSrcTexVerts + numIn - 1;
+        pCurTex = rdClip_pSrcTexVerts;
+        pPrevInt = rdClip_pSrcIntensities + numIn - 1;
+        pCurInt = rdClip_pSrcIntensities;
+        i = numIn;
+        do {
+            if (pPrev->y <= pFrustrum->zFar || pCur->y <= pFrustrum->zFar) {
+                if (pPrev->y != pFrustrum->zFar && pCur->y != pFrustrum->zFar && (pFrustrum->zFar < pPrev->y || pFrustrum->zFar < pCur->y)) {
+                    t = (pFrustrum->zFar - pPrev->y) / (pCur->y - pPrev->y);
+                    pDst[numOut].y = pFrustrum->zFar;
+                    pDst[numOut].z = (pCur->z - pPrev->z) * t + pPrev->z;
+                    pDst[numOut].x = (pCur->x - pPrev->x) * t + pPrev->x;
+                    pDstTex[numOut].x = (pCurTex->x - pPrevTex->x) * t + pPrevTex->x;
+                    pDstTex[numOut].y = (pCurTex->y - pPrevTex->y) * t + pPrevTex->y;
+                    pDstInt[numOut].x = (pCurInt->x - pPrevInt->x) * t + pPrevInt->x;
+                    pDstInt[numOut].y = (pCurInt->y - pPrevInt->y) * t + pPrevInt->y;
+                    pDstInt[numOut].z = (pCurInt->z - pPrevInt->z) * t + pPrevInt->z;
+                    pDstInt[numOut].w = (pCurInt->w - pPrevInt->w) * t + pPrevInt->w;
+                    numOut++;
+                    rdClip_faceStatus |= rdClip_FaceStatus_FARZ;
+                }
+                if (pCur->y <= pFrustrum->zFar) {
+                    pDst[numOut] = *pCur;
+                    pDstTex[numOut] = *pCurTex;
+                    pDstInt[numOut] = *pCurInt;
+                    numOut++;
+                }
+            }
+            pPrev = pCur;
+            pCur++;
+            pPrevTex = pCurTex;
+            pCurTex++;
+            pPrevInt = pCurInt;
+            pCurInt++;
+            i--;
+        } while (i != 0);
+        if (numOut < 3) {
+            return numOut;
+        }
+    }
+
+    if (rdClip_pDstVerts != aVertices) {
+        for (i = 0; i < numOut; i++) {
+            aVertices[i] = rdClip_pDstVerts[i];
+            aTexVertices[i] = rdClip_pDstTexVerts[i];
+            aIntensities[i] = rdClip_pDstIntensities[i];
+        }
+    }
+    return numOut;
 }
 
 // Clips a textured, per-vertex-lit triangle against the orthographic view box


### PR DESCRIPTION
Four more of the `rdClip_Face3*` Sutherland-Hodgman clippers, reusing the shared `rdClip_workVerts` / `faceStatus` infra named in #244:

- `rdClip_Face3W` — position-only perspective (top / orthoRight side planes)
- `rdClip_Face3WOrtho` — position-only ortho (identical to `Face3SOrtho`; the game ships two matching routines)
- `rdClip_Face3SOrtho` — position-only ortho
- `rdClip_Face3T` — textured + per-vertex-lit perspective (same plane set as `Face3S`, perspective counterpart of `Face3TOrtho`; its zNear pass interpolates intensity correctly, unlike `Face3TOrtho`'s faithful quirk)

Each pass transcribed from its own decompile (plane sets differ per variant); status bits use the existing `rdClip_FaceStatus` enum. Remaining GS/GSOrtho/GT/GTOrtho left for a follow-up. Builds + links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)