### PR TITLE
reimpl(swrUI/swrSprite): widget setter family (sprite slots, checked state, values, colors)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -433,6 +433,7 @@ swrUI_caretX 0x004d79f0 int # text-input caret rect, set by swrUI_SetCaretRect
 swrUI_caretY 0x004d7c4c int
 swrUI_caretH 0x004d8780 int
 swrUI_caretW 0x004d8788 int
+swrUI_caretEnabled 0x004d87bc int # caret blink enabled, set by swrUI_SetCaretActive
 
 swrSpriteTexIsTGA 0x004d79f8 int[149]
 

--- a/scripts/GenerateHooks.py
+++ b/scripts/GenerateHooks.py
@@ -81,6 +81,9 @@ hooks_blacklist = [
     # stdConsole
     "stdConsole_GetCursorPos",
     "stdConsole_SetCursorPos",
+    # swrSprite (the resolution-independence deltas in renderer_hook.cpp own these hooks)
+    "swrSprite_GetUIScale",
+    "swrSprite_SetPosF",
     # stdDisplay
     "stdDisplay_Startup",
     "stdDisplay_Open",

--- a/src/Swr/swrSprite.c
+++ b/src/Swr/swrSprite.c
@@ -148,6 +148,20 @@ swrSpriteTexture* swrSprite_GetTextureFromId(int id)
     HANG("TODO");
 }
 
+// 0x00417040
+int swrSprite_FindFreeId(void)
+{
+    int id;
+
+    // the dynamic id range sits above the 251 named/static sprites
+    for (id = 251; id < 399; id++) {
+        if (swrSprite_array[id].texture == NULL) {
+            return id;
+        }
+    }
+    return 0;
+}
+
 // 0x00417120 TODO: crashes on release, works fine on debug
 void swrSprite_GetTextureDimFromId(swrSprite_NAME spriteId, int* out_width, int* out_height)
 {
@@ -460,6 +474,17 @@ void swrSprite_SetFlag(short id, unsigned int flag)
 void swrSprite_UnsetFlag(short id, unsigned int flag)
 {
     swrSprite_array[id].flags = swrSprite_array[id].flags & ~flag;
+}
+
+// 0x0042bb00
+void swrSprite_SetPosF(short id, short x, short y)
+{
+    short design_y;
+    short design_x;
+
+    design_y = (short)(int)(((float)y / (float)swrDisplay_screenHeight) * 240.0f);
+    design_x = (short)(int)(((float)x / (float)swrDisplay_screenWidth) * 320.0f);
+    swrSprite_SetPos(id, design_x, design_y);
 }
 
 // 0x0042D910
@@ -899,6 +924,13 @@ void swrSprite_ResetCurrentMaterial()
 void swrSprite_InitDrawing()
 {
     HANG("TODO");
+}
+
+// 0x0044F640
+void swrSprite_GetUIScale(float* out_xscale, float* out_yscale)
+{
+    *out_xscale = (float)swrDisplay_screenWidth * (float)swrUI_designWidthRecip;
+    *out_yscale = (float)swrDisplay_screenHeight * (float)swrUI_designHeightRecip;
 }
 
 // 0x0044FEF0

--- a/src/Swr/swrSprite.h
+++ b/src/Swr/swrSprite.h
@@ -155,7 +155,7 @@ void swrSprite_SetColor(short id, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 void swrSprite_SetFlag(short id, unsigned int flag);
 void swrSprite_UnsetFlag(short id, unsigned int flag);
 
-void swrSprite_SetPosF(short id, float x, float y);
+void swrSprite_SetPosF(short id, short x, short y); // converts real screen px -> 320x240 design space, then swrSprite_SetPos
 
 int16_t swrSprite_setCurrentTextPos(int16_t, int16_t);
 short swrSprite_getCurrentTextPos(int16_t*, int16_t*);

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -6,6 +6,7 @@
 #include "swrText.h"
 
 #include <General/stdMath.h>
+#include <General/utils.h>
 #include <Primitives/rdVector.h>
 
 #include <macros.h>
@@ -123,6 +124,12 @@ void swrUI_DisableElement(swrUI_unk* ui)
         ui->flags = ui->flags | swrUI_DISABLED;
 }
 
+// 0x00411730
+void swrUI_SetCaretActive(int active)
+{
+    swrUI_caretEnabled = active;
+}
+
 // 0x00411740
 void swrUI_SetCaretRect(int x, int y, int w, int h)
 {
@@ -190,6 +197,42 @@ void swrUI_PopMenuPage(void)
         swrUI_RunCallbacks((swrUI_unk*)(&swrUI_pageStack)[swrUI_pageStackDepth], 0x46, swrUI_pageStackDepth, 0);
 }
 
+// 0x00412fb0
+int swrUI_AddSprite(swrUI_unk* ui, int index, int spriteId, int* rect, int flag, int flag2)
+{
+    int i;
+
+    if (index == -1) {
+        if ((unsigned int)ui->sprite_count > 19) {
+            return -1; // vanilla leaves the return register untouched here
+        }
+        for (i = 0; i < 20; i++) {
+            if ((ui->ui_elements[i].flag & swrUI_SPRITE_SLOT_IN_USE) == 0) {
+                ui->sprite_count = ui->sprite_count + 1;
+                index = i;
+                break;
+            }
+        }
+        if (index == -1) {
+            return i; // no free slot found
+        }
+    }
+    ui->ui_elements[index].texture_id = spriteId;
+    ui->ui_elements[index].width = 1.0f;
+    ui->ui_elements[index].height = 1.0f;
+    ui->ui_elements[index].flag = flag2 | swrUI_SPRITE_SLOT_IN_USE;
+    swrUI_SetSpriteColor(ui, index, 0xff, 0xff, 0xff, 0xff);
+    swrUI_SetSpriteRect(ui, index, rect);
+    ui->sprite_count = 0;
+    for (i = 0; i < 20; i++) {
+        if ((ui->ui_elements[i].flag & swrUI_SPRITE_SLOT_IN_USE) != 0) {
+            ui->sprite_count = ui->sprite_count + 1;
+        }
+    }
+    swrUI_SetSpriteFlag(ui, index, flag);
+    return index;
+}
+
 // 0x00413090
 void swrUI_SetSpriteColor(swrUI_unk* ui, int slot, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
@@ -198,6 +241,16 @@ void swrUI_SetSpriteColor(swrUI_unk* ui, int slot, uint8_t r, uint8_t g, uint8_t
         ui->ui_elements[slot].g = g;
         ui->ui_elements[slot].b = b;
         ui->ui_elements[slot].a = a;
+    }
+}
+
+// 0x004130e0
+void swrUI_SetSpriteFlag(swrUI_unk* ui, int slot, int enabled)
+{
+    if (enabled != 0) {
+        ui->ui_elements[slot].flag = ui->ui_elements[slot].flag | swrUI_SPRITE_SLOT_ENABLED_UNK;
+    } else {
+        ui->ui_elements[slot].flag = ui->ui_elements[slot].flag & ~swrUI_SPRITE_SLOT_ENABLED_UNK;
     }
 }
 
@@ -250,17 +303,132 @@ int swrUI_CountSelectableItems(swrUI_unk* ui)
     return count;
 }
 
+// 0x004138b0
+void swrUI_SetListHighlightColor(swrUI_unk* list, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+    if (list != NULL) {
+        list->r2 = r;
+        list->g2 = g;
+        list->b2 = b;
+        list->a2 = a;
+        swrUI_ApplyListColors(list);
+    }
+}
+
+// 0x00413b10
+int swrUI_GetNumberValue(swrUI_unk* ui)
+{
+    if (ui != NULL) {
+        return *(int*)(ui->unk538 + 0x24); // number/slider value (+0x55c)
+    }
+    return 0;
+}
+
+// 0x00413b90
+swrUI_unk* swrUI_NewSpriteElement(swrUI_unk* parent, int id, int* rect, int spriteId, int spriteFlag, swrUI_unk_F2* f2, int sizeUnk)
+{
+    swrUI_unk* ui;
+
+    if (rect == NULL) {
+        return NULL;
+    }
+    ui = swrUI_New(parent, id, -1, NULL, 0, sizeUnk, 0, (swrUI_unk_F1)swrUI_DefaultElementProc, (swrUI_unk_F2)f2);
+    ui->flags = ui->flags | swrUI_STATIC;
+    swrUI_SetSize(ui, rect[2] - rect[0] + 1, rect[3] - rect[1] + 1);
+    swrUI_SetPos(ui, rect[0], rect[1]);
+    swrUI_AddSprite(ui, 0, spriteId, rect, 1, spriteFlag);
+    swrUI_SetSpriteColor(ui, 0, 0xff, 0xff, 0xff, 0xff);
+    swrUI_RunCallbacks2(ui, 1);
+    ui->widget_class = swrUI_CLASS_SPRITE;
+    return ui;
+}
+
 // 0x00413fa0
 int swrUI_GetValue(swrUI_unk* ui)
 {
-    HANG("TODO: members missing in type");
-#if 0
-    if (ui->value_available != 0)
-    {
-        return ui->value;
+    if (*(int*)(ui->unk538 + 4) != 0) { // value-available flag (+0x53c)
+        return *(int*)(ui->unk538 + 8); // stored value (+0x540)
     }
     return -1;
-#endif
+}
+
+// 0x00414420
+void swrUI_SetChecked(swrUI_unk* ui, unsigned int checked)
+{
+    unsigned int wasChecked;
+    swrSprite_NAME spriteId;
+    int texW;
+    int texH;
+    int rect[4];
+    swrUI_unk* spriteElem;
+
+    if (ui == NULL) {
+        return;
+    }
+    wasChecked = ui->flags & swrUI_CHECKED;
+    if (checked != 0) {
+        // enforce single selection within the radio group first
+        swrUI_ClearGroupChecked(ui);
+        ui->flags = ui->flags | swrUI_CHECKED;
+    } else {
+        ui->flags = ui->flags & ~swrUI_CHECKED;
+    }
+    if ((ui->flags & swrUI_CHECK_CIRCLE_UNK) != 0) {
+        spriteId = checked != 0 ? swrSprite_axis_check_circ_selected : swrSprite_axis_check_circ;
+    } else if ((ui->flags & swrUI_VERTICAL) != 0) {
+        spriteId = checked != 0 ? swrSprite_radio_checked : swrSprite_radio_unchecked;
+    } else {
+        spriteId = checked != 0 ? swrSprite_tiny_box_selected : swrSprite_tiny_box;
+    }
+    swrSprite_GetTextureDimFromId(spriteId, &texW, &texH);
+    if (spriteId == swrSprite_tiny_box_selected || spriteId == swrSprite_tiny_box) {
+        // boxes hug the right edge (width/height fields hold the right/bottom edge)
+        rect[0] = ui->width - texW - 3;
+        rect[2] = ui->width - 3;
+    } else {
+        rect[0] = ui->x + 3;
+        rect[2] = ui->x + 3 + texW - 1;
+    }
+    rect[1] = ui->y + (int)((unsigned int)(ui->height - ui->y - texH + 1) >> 1);
+    rect[3] = rect[1] + texH - 1;
+    if (ui->next == NULL) {
+        spriteElem = swrUI_NewSpriteElement(ui, 0, rect, spriteId, 0, NULL, 0);
+        spriteElem->flags = spriteElem->flags | swrUI_CHECK_SPRITE_UNK;
+    }
+    swrUI_AddSprite(ui->next, 0, spriteId, rect, 1, 0);
+    if (checked != wasChecked) {
+        swrUI_RunCallbacks(ui->prev, swrUI_MSG_CHECKED_CHANGED, ui->id, checked);
+    }
+}
+
+// 0x00414590
+void swrUI_ToggleChecked(swrUI_unk* ui)
+{
+    swrUI_SetChecked(ui, (ui->flags & swrUI_CHECKED) == 0);
+}
+
+// 0x00414ab0
+void swrUI_SetValueText(swrUI_unk* ui, char* text, int value)
+{
+    ui->value_text = swrUI_replaceAllocatedStr(ui->value_text, text);
+    ui->value = value;
+}
+
+// 0x00414ae0
+void swrUI_SetValue(swrUI_unk* ui, int value)
+{
+    ui->value = value;
+}
+
+// 0x00414af0
+char* swrUI_GetValueText(swrUI_unk* ui, char* out, int len)
+{
+    if (out != NULL && ui->value_text != NULL) {
+        strncpy(out, ui->value_text, len - 1);
+        out[len - 1] = '\0';
+        return out;
+    }
+    return ui->value_text;
 }
 
 // 0x00414b40
@@ -338,6 +506,22 @@ void swrUI_SetColorUnk2(swrUI_unk* ui, uint8_t r, uint8_t g, uint8_t b, uint8_t 
     ui->a2 = a;
 }
 
+// 0x00414cd0
+int swrUI_SetSlotValue(swrUI_unk* ui, int index, int value)
+{
+    int old;
+
+    old = *(int*)(ui->unk01_10 + index * 4);
+    *(int*)(ui->unk01_10 + index * 4) = value;
+    return old;
+}
+
+// 0x00414cf0
+int swrUI_GetSlotValue(swrUI_unk* ui, int index)
+{
+    return *(int*)(ui->unk01_10 + index * 4);
+}
+
 // 0x00414d90
 swrUI_unk* swrUI_GetById(swrUI_unk* ui, int id)
 {
@@ -399,6 +583,20 @@ int swrUI_IsElementVisible(swrUI_unk* ui)
         ui = ui->prev;
     } while (ui != NULL);
     return 1;
+}
+
+// 0x00414eb0
+void swrUI_SetUI4(swrUI_unk* ui)
+{
+    if (swrUI_unk4_ptr != NULL) {
+        swrUI_unk4_ptr->flags = swrUI_unk4_ptr->flags & ~swrUI_HOVERED;
+    }
+    swrUI_RunCallbacks(swrUI_unk4_ptr, swrUI_MSG_HOVER_CHANGED, 0, 0);
+    swrUI_unk4_ptr = ui;
+    if (ui != NULL) {
+        ui->flags = ui->flags | swrUI_HOVERED;
+    }
+    swrUI_RunCallbacks(ui, swrUI_MSG_HOVER_CHANGED, 1, 0);
 }
 
 // 0x00414f00
@@ -612,6 +810,35 @@ void swrUI_ClearAllSprites(swrUI_unk* ui)
     }
 }
 
+// 0x004171a0
+void swrUI_SetSpriteRect(swrUI_unk* ui, int slot, int* rect)
+{
+    int texW;
+    int texH;
+
+    if (ui == NULL) {
+        return;
+    }
+    swrSprite_GetTextureDimFromId(ui->ui_elements[slot].texture_id, &texW, &texH);
+    ui->ui_elements[slot].texture_w = texW;
+    ui->ui_elements[slot].texture_h = texH;
+    if (rect != NULL) {
+        // width/height become the UV scale of the dest rect over the texture
+        ui->ui_elements[slot].width = (float)(rect[2] - rect[0] + 1) / (float)texW;
+        ui->ui_elements[slot].height = (float)(rect[3] - rect[1] + 1) / (float)texH;
+        ui->ui_elements[slot].screen_x1 = rect[0];
+        ui->ui_elements[slot].screen_y1 = rect[1];
+        ui->ui_elements[slot].screen_x2 = rect[2];
+        ui->ui_elements[slot].screen_y2 = rect[3];
+    } else {
+        // no rect: span the texture from the element origin
+        ui->ui_elements[slot].screen_x1 = ui->x;
+        ui->ui_elements[slot].screen_y1 = ui->y;
+        ui->ui_elements[slot].screen_x2 = ui->x + texW - 1;
+        ui->ui_elements[slot].screen_y2 = ui->y + texH - 1;
+    }
+}
+
 // 0x004174e0 TODO: crashes on game startup
 char* swrUI_replaceAllocatedStr(char* str, char* mondo_text)
 {
@@ -631,6 +858,87 @@ char* swrUI_replaceAllocatedStr(char* str, char* mondo_text)
         res[len - 1] = '\0';
     }
     return res;
+}
+
+// 0x00418b70
+void swrUI_ClearGroupChecked(swrUI_unk* ui)
+{
+    int groupId;
+
+    if (ui == NULL) {
+        return;
+    }
+    groupId = ui->id;
+    // rewind to the first member of the radio group: a marked element whose
+    // preceding sibling belongs to a different group id
+    while (!((ui->flags & swrUI_RADIO_GROUP_UNK) != 0 && ui->prev2->id != groupId)) {
+        ui = ui->prev2;
+        if (ui == NULL) {
+            break;
+        }
+    }
+    // sweep forward, unchecking every checkable FramedText member of the group
+    while (ui != NULL && ui->widget_class == swrUI_CLASS_FRAMED_TEXT && ui->id == groupId) {
+        swrUI_SetChecked(ui, 0);
+        ui = ui->next2;
+    }
+}
+
+// 0x00418bc0
+void swrUI_ApplyListColors(swrUI_unk* list)
+{
+    swrUI_unk* item;
+
+    if (list == NULL) {
+        return;
+    }
+    for (item = list->next; item != NULL; item = item->next2) {
+        if (((uint8_t)item->widget_class & swrUI_CLASS_LIST_ITEM) == swrUI_CLASS_LIST_ITEM) {
+            swrUI_SetColorUnk(item, list->r, list->g, list->b, list->a);
+            swrUI_SetColorUnk2(item, list->r2, list->g2, list->b2, list->a2);
+            swrUI_SetColorUnk4(item, list->r4, list->g4, list->b4, list->a4);
+            swrUI_SetColorUnk3(item, list->r3, list->g3, list->b3, list->a3);
+            swrUI_SetColorUnk5(item, list->r5, list->g5, list->b5, list->a5);
+        }
+    }
+}
+
+// 0x00419030
+void swrUI_SetSpriteOffset(swrUI_unk* ui, int slot, int offsetX, int offsetY)
+{
+    if (ui != NULL && slot >= 0 && slot < 20) {
+        ui->ui_elements[slot].pos_x = offsetX;
+        ui->ui_elements[slot].pos_y = offsetY;
+    }
+}
+
+// 0x00419140
+void swrUI_RandomizeSpriteAlpha(swrUI_unk* element)
+{
+    unsigned int first;
+    int count;
+    int alpha;
+    unsigned int i;
+
+    if (element == NULL) {
+        return;
+    }
+    count = element->unk58;
+    first = element->unk54;
+    if (count == 0) {
+        count = 20;
+    }
+    if (first > (unsigned int)element->sprite_count) {
+        return;
+    }
+    if ((unsigned int)element->sprite_count < first + count) {
+        count = element->sprite_count - first;
+    }
+    // roll lands in (-156, 0], so the alpha lands in [100, 255]
+    alpha = 100 - (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * -156.0f);
+    for (i = first; i < first + count; i++) {
+        swrUI_SetSpriteColor(element, i, element->ui_elements[i].r, element->ui_elements[i].g, element->ui_elements[i].b, (uint8_t)alpha);
+    }
 }
 
 // 0x004197f0
@@ -678,6 +986,16 @@ swrUI_unk* swrUI_GetByValue(swrUI_unk* ui, int value)
         ui = ui->next2;
     }
     return ui;
+}
+
+// 0x0041b630
+void swrUI_ApplyFocusColor(swrUI_unk* ui)
+{
+    if ((ui->flags & swrUI_FOCUSED) != 0) {
+        swrUI_SetColorUnk(ui, ui->r5, ui->g5, ui->b5, ui->a5);
+    } else {
+        swrUI_SetColorUnk(ui, ui->r2, ui->g2, ui->b2, ui->a2);
+    }
 }
 
 // 0x00420930

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -319,7 +319,7 @@ void swrUI_SetListHighlightColor(swrUI_unk* list, uint8_t r, uint8_t g, uint8_t 
 int swrUI_GetNumberValue(swrUI_unk* ui)
 {
     if (ui != NULL) {
-        return *(int*)(ui->unk538 + 0x24); // number/slider value (+0x55c)
+        return ui->number_value;
     }
     return 0;
 }
@@ -346,8 +346,8 @@ swrUI_unk* swrUI_NewSpriteElement(swrUI_unk* parent, int id, int* rect, int spri
 // 0x00413fa0
 int swrUI_GetValue(swrUI_unk* ui)
 {
-    if (*(int*)(ui->unk538 + 4) != 0) { // value-available flag (+0x53c)
-        return *(int*)(ui->unk538 + 8); // stored value (+0x540)
+    if (ui->has_option_value != 0) {
+        return ui->option_value;
     }
     return -1;
 }
@@ -747,7 +747,7 @@ swrUI_unk* swrUI_New(swrUI_unk* ui, int id, int new_index, char* mondo_text, int
     elem->flags = flag;
     elem->size_unk2 = size_unk2;
     elem->size_unk1 = size_unk1;
-    elem->unk01_10 = elem->unk538 + size_unk1 * 4 + 0x38;
+    elem->unk01_10 = (char*)&elem->unk538 + size_unk1 * 4 + 0x38;
     elem->fun = f1;
     elem->fun2 = f2;
     elem->font_index = 0;
@@ -923,8 +923,8 @@ void swrUI_RandomizeSpriteAlpha(swrUI_unk* element)
     if (element == NULL) {
         return;
     }
-    count = element->unk58;
-    first = element->unk54;
+    count = element->rand_alpha_count;
+    first = element->rand_alpha_first;
     if (count == 0) {
         count = 20;
     }
@@ -994,7 +994,7 @@ swrUI_unk* swrUI_GetByValue(swrUI_unk* ui, int value)
         {
             return NULL;
         }
-        if (((ui->widget_class == 10) && (ui->id == *this_id)) && ((*(int*)(ui->unk538 + 8)) == value))
+        if (((ui->widget_class == 10) && (ui->id == *this_id)) && (ui->option_value == value))
             break;
         ui = ui->next2;
     }

--- a/src/types.h
+++ b/src/types.h
@@ -1194,7 +1194,7 @@ extern "C"
 
     typedef struct swrUI_unk2 // one sprite slot (swrUI_unk.ui_elements)
     {
-        int flag;            // 0x00 slot flags (bit 0x20000 via swrUI_SetSpriteFlag)
+        int flag; // 0x00 slot flags (swrUI_SPRITE_SLOT_FLAG)
         int texture_id;      // 0x04 source texture id (swrSprite_CreateFromTextureId)
         int sprite_ingameId; // 0x08 created sprite handle
         float width;         // 0x0c sprite dimensions (swrSprite_SetDim)
@@ -1203,8 +1203,8 @@ extern "C"
         int screen_y1; // 0x18
         int screen_x2; // 0x1c
         int screen_y2; // 0x20
-        void* unk35;         // 0x24
-        void* unk36;         // 0x28
+        int texture_w; // 0x24 texture dimensions (swrUI_SetSpriteRect)
+        int texture_h; // 0x28
         int pos_x;           // 0x2c base position (swrUI_SetSpriteOffset)
         int pos_y;           // 0x30
         char r;              // 0x34 color (swrUI_SetSpriteColor)
@@ -1234,8 +1234,8 @@ extern "C"
         int size_unk2;
         char* unk01_10;
         char unk01_11[12];
-        int unk54;
-        int unk58;
+        int unk54; // 0x54 first sprite slot of the alpha-randomize range (swrUI_RandomizeSpriteAlpha)
+        int unk58; // 0x58 slot count of that range (0 = all 20)
         int sprite_count;
         swrUI_unk2 ui_elements[20]; // 0x60
         char r;
@@ -1263,7 +1263,11 @@ extern "C"
         int font_index; // 0x4dc font-table index (set via swrUI_ReplaceIndex)
         swrSprite_BBox bbox;
         unsigned int unk0_flag;
-        char unk4f4[20]; // 0x4f4: value-text* @0x4f8, value @0x4fc, list first-visible idx @0x504
+        int unk4f4; // 0x4f4 (written by swrUI_SetValue2_Maybe)
+        char* value_text; // 0x4f8 secondary value-text (swrUI_SetValueText / swrUI_GetValueText)
+        int value; // 0x4fc element value (swrUI_SetValue)
+        int unk500;
+        int first_visible; // 0x504 list first-visible index
         swrUI_ITEM_FLAG item_flags; // 0x508 list-item state (swrUI_ITEM_SELECTED 0x80000)
         char unk50c[40]; // 0x50c scroll layout: left/top/right/bottom @0x50c-0x518, sel text/idx @0x51c/0x520, row spacing @0x524
         int max_length; // 0x534 text-entry max input length (swrUI_SetMaxLength)

--- a/src/types.h
+++ b/src/types.h
@@ -1234,8 +1234,8 @@ extern "C"
         int size_unk2;
         char* unk01_10;
         char unk01_11[12];
-        int unk54; // 0x54 first sprite slot of the alpha-randomize range (swrUI_RandomizeSpriteAlpha)
-        int unk58; // 0x58 slot count of that range (0 = all 20)
+        int rand_alpha_first; // 0x54 first sprite slot of the alpha-randomize range (swrUI_RandomizeSpriteAlpha)
+        int rand_alpha_count; // 0x58 slot count of that range (0 = all 20)
         int sprite_count;
         swrUI_unk2 ui_elements[20]; // 0x60
         char r;
@@ -1271,7 +1271,15 @@ extern "C"
         swrUI_ITEM_FLAG item_flags; // 0x508 list-item state (swrUI_ITEM_SELECTED 0x80000)
         char unk50c[40]; // 0x50c scroll layout: left/top/right/bottom @0x50c-0x518, sel text/idx @0x51c/0x520, row spacing @0x524
         int max_length; // 0x534 text-entry max input length (swrUI_SetMaxLength)
-        char unk538[4232];
+        // 0x538 per-widget-class payload. Radio buttons (widget_class 10) use the first two
+        // ints; number fields / sliders (widget_class 6) use the block from 0x544 on.
+        int unk538;
+        int has_option_value; // 0x53c set when option_value holds a real value (else swrUI_GetValue returns -1)
+        int option_value; // 0x540 radio-group option value (swrUI_GetValue, matched by swrUI_GetByValue)
+        char unk544[24]; // 0x544 number-field/slider block: style flags @0x544 (bit 0x1000000 draws the
+                         // number), track length @0x548, percent @0x54c and @0x550, step @0x558
+        int number_value; // 0x55c number-field / slider value (swrUI_GetNumberValue / swrUI_SetNumberValue)
+        char unk560[4192]; // 0x560 rest of the class payload; the swrUI_New slot array follows it
     } swrUI_unk; // sizeof(0x15c0 + unk size)
 
     // this could be some kind of viewport struct.

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -978,18 +978,56 @@ typedef enum swrUISprite
 
 typedef enum swrUI_FLAG
 {
+    swrUI_STATIC = 0x4, // non-interactive element (swrUI_NewSpriteElement)
+    swrUI_HOVERED = 0x10, // element under the cursor (swrUI_SetUI4)
     swrUI_FOCUSED = 0x20, // element currently has keyboard focus (swrUI_SetFocusedElement)
     swrUI_VISIBLE = 0x40, // element is visible (swrUI_IsElementVisible walks the parent chain)
+    swrUI_RADIO_GROUP_UNK = 0x80, // radio-group marker; swrUI_ClearGroupChecked rewinds to a flagged element whose predecessor leaves the group
     swrUI_DISABLED = 0x100, // grayed-out / non-interactive (swrUI_DisableElement)
+    swrUI_CHECK_SPRITE_UNK = 0x400, // set on the auto-created check-sprite child element (swrUI_SetChecked)
     swrUI_SELECTED = 0x800,
     swrUI_VERTICAL = 0x10000,
     swrUI_LEFT_RIGHT_UNK = 0x20000, // LEFT_TO_RIGHT or RIGHT_TO_LEFT ?
+    swrUI_CHECKED = 0x20000, // same bit: checked state on checkable class-0xa items (swrUI_SetChecked)
+    swrUI_CHECK_CIRCLE_UNK = 0x40000, // draw the check as the axis_check_circ art (swrUI_SetChecked)
 } swrUI_FLAG;
 
 typedef enum swrUI_ITEM_FLAG
 {
     swrUI_ITEM_SELECTED = 0x80000, // list item is the current selection (swrUI_GetSelectedItem)
 } swrUI_ITEM_FLAG;
+
+typedef enum swrUI_SPRITE_SLOT_FLAG // swrUI_unk2.flag, applied by swrUI_RenderElementSprites
+{
+    swrUI_SPRITE_SLOT_IN_USE = 0x10000, // slot allocated (swrUI_AddSprite)
+    swrUI_SPRITE_SLOT_ENABLED_UNK = 0x20000, // toggled by swrUI_SetSpriteFlag
+    swrUI_SPRITE_SLOT_CENTER_H = 0x40000, // center horizontally in the element rect
+    swrUI_SPRITE_SLOT_CENTER_V = 0x80000, // center vertically in the element rect
+    swrUI_SPRITE_SLOT_CENTER_BOTH = 0x100000, // center on both axes
+    swrUI_SPRITE_SLOT_MIRROR_V = 0x200000, // -> swrSprite flag 0x8 (mirror vertically)
+    swrUI_SPRITE_SLOT_MIRROR_H = 0x400000, // -> swrSprite flag 0x4 (mirror horizontally)
+    swrUI_SPRITE_SLOT_FLAG_8000_UNK = 0x800000, // -> swrSprite flag 0x8000
+    swrUI_SPRITE_SLOT_ADDITIVE = 0x1000000, // -> swrSprite flag 0x800 (additive blending)
+} swrUI_SPRITE_SLOT_FLAG;
+
+typedef enum swrUI_CLASS // swrUI_unk.widget_class, set by each swrUI_New* ctor
+{
+    swrUI_CLASS_SCREEN_TEXT = 3, // swrUI_NewScreenText
+    swrUI_CLASS_LIST = 5, // swrUI_NewList
+    swrUI_CLASS_NUMBER_FIELD = 6, // swrUI_NewNumberField (slider + value)
+    swrUI_CLASS_SPRITE = 7, // swrUI_NewSpriteElement
+    swrUI_CLASS_PANEL = 8, // swrUI_NewPanel (9-slice framed panel)
+    swrUI_CLASS_TEXT_ENTRY = 9, // swrUI_NewTextEntry
+    swrUI_CLASS_FRAMED_TEXT = 10, // swrUI_NewFramedText (checkable/radio item)
+    swrUI_CLASS_3PATCH_BOX = 11, // swrUI_New3PatchBox
+    swrUI_CLASS_LIST_ITEM = 12, // swrUI_AddListItem
+} swrUI_CLASS;
+
+typedef enum swrUI_MSG // element proc / swrUI_RunCallbacks message codes (partial)
+{
+    swrUI_MSG_HOVER_CHANGED = 1, // fired by swrUI_SetUI4; param 0 = left, 1 = entered
+    swrUI_MSG_CHECKED_CHANGED = 5000, // fired to the parent by swrUI_SetChecked; param = new state
+} swrUI_MSG;
 
 typedef enum swrConfig_DEVICE
 {


### PR DESCRIPTION
24 reverse-hook bodies covering the swrUI widget setter surface — everything that writes an element's position / color / value / checked state — plus the two 2D-scale seams on the swrSprite side.

**swrUI.c (21)**
- Sprite slots: `AddSprite`, `SetSpriteFlag`, `SetSpriteRect`, `SetSpriteOffset` — slot alloc, dest rect + UV scale, offsets
- Check/radio: `SetChecked`, `ToggleChecked`, `ClearGroupChecked`, `NewSpriteElement` — the full checkbox chain incl. the auto-created check-sprite child and the single-select group walk
- Colors: `SetListHighlightColor`, `ApplyListColors`, `ApplyFocusColor`
- Values: `SetValueText` / `SetValue` / `GetValueText`, `SetSlotValue` / `GetSlotValue`, `GetNumberValue`, and `GetValue` loses its HANG (the fields it needed are now named)
- Misc: `SetUI4` (hover pointer), `SetCaretActive`, `RandomizeSpriteAlpha`

**swrSprite.c (3)**
- `GetUIScale`, `SetPosF`, `FindFreeId`. `SetPosF`'s prototype was wrong — the binary takes **shorts** (MOVSX word loads) and converts real screen px into a **320x240** design space (consts at 0x4ac594/0x4ac598), not floats. Header fixed to match (the delta in `swrSprite_delta.cpp` already used the short signature). Since `SetPosF`/`GetUIScale` are forward-hooked by the res-independence deltas in `renderer_hook.cpp`, they join the GenerateHooks blacklist (same precedent as `stdConsole_GetCursorPos`).

**Supporting**
- `swrUI_SPRITE_SLOT_FLAG` enum — the slot bits decoded from `swrUI_RenderElementSprites` (in-use / center H,V,both / mirror / additive)
- `swrUI_CLASS` enum — the verified ctor class ids; `swrUI_MSG` (partial); `swrUI_FLAG` gains STATIC / HOVERED / CHECKED (same bit as LEFT_RIGHT — checked on checkable items) / the radio-group + check-circle bits
- `types.h`: `swrUI_unk2.texture_w/h` (were `unk35/36`), and the `value_text` / `value` / `first_visible` fields out of the `unk4f4` blob
- `data_symbols.syms`: `swrUI_caretEnabled` (0x4d87bc)

Deliberately left out (follow-ups): `BuildSliderSprites` + `BuildHighlightSprites` are the two remaining draw-side deps (they gate `SetNumberValue`/`SetSliderValue` and `UpdateElementColor`/`SetHighlightState`) — both are big sprite-layout functions that deserve their own PR. `swrSprite_CreateFromTextureId` waits on #268's `GetTextureFromId` body.

Builds + links clean (full dinput_hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)