### PR TITLE
reimpl(times): results + course-info menus (track-record commit and display)

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -358,6 +358,7 @@ swrRace_DeathSpeedDrop 0x004c7bbc float = 140.0
 swrRace_FireTimer 0x004c7bc0 float = -1.0
 
 swrSpline_trackLength 0x004c7be0 float
+swrSpline_finishNodeIdx 0x004c7be4 int # -1 closed-loop track, -2 open spline (CP0 has no prev; set by swrSpline_Build), >= 0 open-track finish: lap progress completes at 1.0 (swrRace_LapProgress / LapCompletion, GetCustomStartTransform)
 
 sithControl_secFPS 0x004c8174 float
 sithControl_msecFPS 0x004c8178 float
@@ -480,6 +481,8 @@ swrText_racerTab_array 0x004eb3c4 char**
 swrText_racerTab_buffer 0x004eb3c8 char*
 
 swrText_nbLinesRacerTab 0x004eb3cc int
+
+swrRace_playerName 0x004eb3d0 char[32] # display copy of the active profile name (sprintf'd by swrRace_LoadGameData / LoadProfileFromFile)
 
 ia3dSourceThreadId 0x004eb3f8 DWORD
 ia3dSourceEventHandle 0x004eb3fc HANDLE
@@ -623,6 +626,7 @@ DAT_0050c554 0x0050c554 int
 nb_AI_racers 0x0050c558 int # g_uNumRacers
 DAT_0050c55c 0x0050c55c char
 DAT_0050c560 0x0050c560 char
+swrRace_cheatUnlockAllDone 0x0050c568 int # one-shot latch for swrRace_CheatUnlockAll
 swrUI_menuArrowAlphaLeft 0x0050c584 float # front-end menu left selector-arrow glow alpha (swrUI_Front_MenuAxisHorizontal)
 swrUI_menuArrowAlphaRight 0x0050c588 float # front-end menu right selector-arrow glow alpha
 
@@ -632,6 +636,7 @@ pauseState 0x0050C5F0 int
 pauseDisabled 0x0050C5F4 int
 
 pauseEnabledFlag 0x0050c5f8 int # set to 1 by enablePause; write-only (no readers found)
+swrRace_saveDefaultsUnk 0x0050c75c int # zeroed by swrRace_InitDefaultGameData next to a stripped debug call; write-only (no readers found)
 
 assetBufferModelLoaded 0x0050C600 int
 assetBufferOverflow 0x0050c610 int
@@ -735,6 +740,7 @@ playerNumberInitiatingPause 0x0050CA4C int
 
 swrObjJdge_goAcknowledged 0x0050ca50 int
 swrObjJdge_postRaceDelay 0x0050ca54 float
+swrRace_hudTimeLabelShown 0x0050ca5c int # cleared when the 1P HUD falls back to the running TIME display; write-only (no reader found)
 
 swrObjJdge_musicFadedForPause 0x0050ca88 int
 
@@ -1185,7 +1191,12 @@ swrUI_pageStack 0x004d8110 void* # swrUI_unk* pageStack[21]
 swrUI_prevPage 0x004d8bd4 swrUI_unk* # page being left (checked by swrUI_IsPrevPage); set by push/pop
 swrUI_suppressBackPop 0x004d8be4 int # when nonzero, a back message (0x13) does not auto-pop the current page
 
-DAT_00e35a60 0x00e35a60 char[3]
+swrRace_profileLoaded 0x004b6c90 int # 0 = a profile name is loaded, -1 = none (swrRace_SaveProfile no-ops; set by LoadGameData/LoadProfileFromFile/ResetGameData)
+
+# Save / profile persistence (elfSaveLoad). swrRace_aProfiles are the live working profiles
+# (swrSaveProfile, 0x50 each); the individually named globals below alias slot 0's fields and
+# predate the struct.
+swrRace_aProfiles 0x00e35a60 swrSaveProfile[20] # [0] = active player, [1] = player 2
 
 swrRace_UnlockDataBase 0x00e35a84 char[6]
 # 0x00e35a85 -> aTracksSelectableTournament
@@ -1209,6 +1220,9 @@ swrRace_airbrake_upgrade_health 0x00e35aac char
 swrRace_cooling_upgrade_health 0x00e35aad char
 swrRace_repair_upgrade_health 0x00e35aae char
 
+swrRace_saveDataBackup 0x00e34a80 swrSaveData # snapshot taken by swrRace_BackupGameData (shop transaction rollback)
+swrRace_aCrc32Table 0x00e360a0 uint32_t[256] # lazily built by swrRace_InitCrc32Table (poly 0x04c11db7)
+swrRace_saveData 0x00e364a0 swrSaveData # in-memory tgfd.dat image: checksum, volumes, unlocks, 4 profile slots, track records
 sound_sfx_volume 0x00e364a5 uint8_t
 sound_music_volume 0x00e364a6 short
 g_aBeatTracksGlobal 0x00e364ac uint8_t[4]
@@ -1221,13 +1235,6 @@ airbrake_upgrade_level 0x00e364f9 char
 cooling_upgrade_level 0x00e364fa char
 repair_upgrade_level 0x00e364fb char
 
-DAT_00e365f4 0x00e365f4 float[1]
-
-DAT_00e366bc 0x00e366bc float[1]
-
-DAT_00e37404 0x00e37404 char[1]
-
-DAT_00e37436 0x00e37436 char[1]
 
 
 PrecomputedMVPMatrix 0x00e37480 rdMatrix44
@@ -1358,6 +1365,12 @@ multiplayer_racer20_id 0x00ea02ac int
 multiplayer_track_select 0x00ea02b0 swrRace_TRACK
 
 multiplayer_laps 0x00ea02b8 int
+
+# Remote racer race-progress state, indexed by the racer's net slot (score->time_unk read as int);
+# consumed by swrRace_LapCompletion for 'REMO' pods. Capacity matches the 20-racer roster.
+swrMultiplayer_aRemoteLapComp 0x00ea0360 float[20] # lap progress 0..1
+swrMultiplayer_aRemoteLapCompMax 0x00ea0420 float[20]
+swrMultiplayer_aRemoteLap 0x00ea0480 int[20] # remote score->results_P1_Lap (current lap counter)
 
 swrObjHang_someState 0x00ea05a0 swrObjHang_STATE
 

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -324,9 +324,12 @@ rdMatrix_unk6 0x004c3cf8 rdMatrix44 = {{-1.0, 3.0, -3.0, 1.0}, {3.0, -6.0, 3.0, 
 rdMatrix_unk4 0x004c3d38 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {-3.0, 9.0, -9.0, 3.0}, {6.0, -12.0, 6.0, 0.0}, {-3.0, 3.0, 0.0, 0.0}}
 rdMatrix_unk2 0x004c3d78 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {-6.0, 18.0, -18.0, 6.0}, {6.0, -12.0, 6.0, 0.0}}
 
+swrRace_resultsPlaceP1 0x004c022c char # player 1's finishing place on the results screen
+swrRace_resultsPlaceP2 0x004c0230 char # player 2's finishing place (-1 in single player)
+
 swrTextFmtString2 0x004c3e48 char[8] = "~f%d%s\0\0"
 
-DAT_004c4000 0x004c4000 int
+swrObjHang_menuJustEntered 0x004c4000 int # set by swrObjHang_SetMenuState; each menu update consumes it for first-frame init
 
 maybeUICameraPlacements 0x004C4010 swrUICameraPlacement[40]
 
@@ -399,7 +402,7 @@ stdControl_joystickDeviceIndex 0x004d6b3c int
 swrControl_acceptPressedEdge 0x004d6b40 int
 
 swrControl_cancelPressedEdge 0x004d6b44 int
-DAT_004d6b48 0x004d6b48 int
+swrControl_menuAcceptPressedEdge 0x004d6b48 int # accept edge for front-end menus (sibling of swrControl_acceptPressedEdge)
 swrControl_acceptReleasedEdge 0x004d6b4c int
 
 enableWindowInput 0x004D6B54 int
@@ -472,7 +475,7 @@ multiplayer_track_change_permission 0x004eb388 int
 stdComm_IPX_connectionIndex 0x004eb390 int
 stdComm_bInitted 0x004eb394 int
 swrMulti_Initialized 0x004eb398 int
-DAT_004eb39c 0x004eb39c  int
+swrMultiplayer_menuOverlayActive 0x004eb39c int # nonzero while the MP race-setup/join overlay owns input (hangar menus ignore accept/cancel)
 
 playerNumber 0x004eb3b4 int
 sithPlayer_g_numPlayers 0x004eb3b8 int # count of entries in sithPlayer_g_aPlayers (loop bound in sithMulti_GetPlayerNum)
@@ -610,22 +613,28 @@ DAT_0050c308 0x0050c308 char[12]
 g_objHang2 0x0050c454 swrObjHang*
 DAT_0050c458 0x0050c458 int
 
-DAT_0050c430 0x0050c430 char[1]
+swrObjHang_courseInfoItemKinds 0x0050c430 char[12] # course-info option rows top-to-bottom: 0 mirror, 1 winnings, 2 laps, 3 racers, 4 AI speed, 5 demo, 6 cutscene; -1 = unused
 
 DAT_0050c480 0x0050c480 int
 
 DAT_0050c524 0x0050c524 char
 rdroid_g_curRenderOptions2 0x0050c530 RdroidFlags
 
+swrRace_resultsScrollY 0x0050c114 float # results-list scroll offset (0 .. -(30*players-150))
+swrRace_resultsSortedScores 0x0050c180 swrScore*[20] # scores sorted by finishing position (rebuilt on results entry)
+swrRace_resultsFanfareDelay 0x0050c1f4 float # counts down from 2s after results entry, then plays the fanfare
+swrObjHang_trackInCircuitIdx 0x0050c228 uint8_t # selected track's index within its circuit (0..6)
 swrRace_TournamentTrugutGain 0x0050c53c int
+swrRace_resultsStateFlags 0x0050c540 int # swrRace_RESULTSFLAG one-shot latches, cleared when leaving the results screen
 
 DAT_0050c54c 0x0050c54c int
-DAT_0050c550 0x0050c550 int
-DAT_0050c554 0x0050c554 int
+swrObjHang_courseInfoSelectedRow 0x0050c550 int
+swrObjHang_courseInfoLeaving 0x0050c554 int # set once accept starts the race (stops drawing the option rows)
 
 nb_AI_racers 0x0050c558 int # g_uNumRacers
-DAT_0050c55c 0x0050c55c char
-DAT_0050c560 0x0050c560 char
+swrObjHang_splitscreenRacerCount 0x0050c55c char # racer count for 2-local-player races (2..6, step 2)
+swrObjHang_courseInfoItemCount 0x0050c560 char
+swrObjHang_camFocusIdx 0x0050c944 int # hangar camera focus target (-1 = none; read by swrObjHang_UpdateHoloCamera / StepCameraToward)
 swrRace_cheatUnlockAllDone 0x0050c568 int # one-shot latch for swrRace_CheatUnlockAll
 swrUI_menuArrowAlphaLeft 0x0050c584 float # front-end menu left selector-arrow glow alpha (swrUI_Front_MenuAxisHorizontal)
 swrUI_menuArrowAlphaRight 0x0050c588 float # front-end menu right selector-arrow glow alpha
@@ -701,7 +710,6 @@ swrUI_localPlayersInputPressedBitset 0x0050C918 int[4]
 
 DAT_0050c930 0x0050c930 int
 
-DAT_0050c944 0x0050c944 int
 
 someUI 0x0050c968 swrUI_unk*
 
@@ -1118,13 +1126,13 @@ swrRace_fireballTransform 0x00e289c0 rdMatrix44
 
 podHandlingData2 0x00e29bdc PodHandlingData
 
-DAT_00e295c0 0x00e295c0 uint32_t
+swrUI_menuScrolled 0x00e295c0 uint32_t # nonzero while a scrollable menu list is scrolled off its top (read by swrRace_DrawScrollbar)
 
 someUnkRootNode 0x00e2a660 swrModel_Node*
 
 uiUpgradeInfos2 0x00E2A6C0 swrUIUpgradeInfo[7] // size maybe wrong
 
-DAT_00e2a698 0x00e2a698 int
+swrObjHang_menuAcceptLock 0x00e2a698 int # blocks course-select/-info accept+cancel while nonzero; no writer found in the retail binary
 
 rdMatrix44_unk3 0x00e2ae80 rdMatrix44
 
@@ -1273,7 +1281,7 @@ texture_count 0x00e9823c unsigned int
 
 InRace_PauseMenu_ScrollInOut 0x00e9824c float
 
-DAT_00e98e80 0x00e98e80 float[1]
+swrControl_aPlayerAxisY 0x00e98e80 float[4] # per-local-player menu/steer stick Y (written by updateInRaceInputBitsets; scrolls the results list)
 
 inRaceLocalPlayerInputBitset3 0x00E98E90 int[4]
 DAT_00e98ea0 0x00e98ea0 float[1]

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -428,7 +428,7 @@ void swrRace_Init_capture(swrRace *player, float a2_spline, int a3_podModel, voi
 static void reset_score_for_restart(swrScore *score) {
     score->unk58 = 0;
     score->unk5a = 0;
-    score->results_P1_Lap = 0.0f;
+    score->results_P1_Lap = 0;
     *(short *) &score->results_P1_Position = -1;
     score->results_P1_total_time = 0.0f;
     score->results_P1_Lap1 = 0.0f;// SpawnRacer sets Lap1 to -1 then 0 -> 0
@@ -868,7 +868,7 @@ void swrObjJdge_F2_delta(swrObjJdge *jdge) {
 // summary in the same left-label / time-column style.
 void swrRace_InRaceEndStatistics_delta(void *jdge, void *score) {
     if (!g_lapScores) {
-        hook_call_original(swrRace_InRaceEndStatistics, jdge, score);
+        hook_call_original(swrRace_InRaceEndStatistics, (swrObjJdge *) jdge, (swrScore *) score);
         return;
     }
 
@@ -880,7 +880,7 @@ void swrRace_InRaceEndStatistics_delta(void *jdge, void *score) {
             for (int i = 0; i < numLaps && i < VANILLA_RESULTS_LAPS; i++)
                 *(float *) ((char *) score + SCORE_LAP1 + i * 4) = g_lapTimes[r][i];
         }
-        hook_call_original(swrRace_InRaceEndStatistics, jdge, score);
+        hook_call_original(swrRace_InRaceEndStatistics, (swrObjJdge *) jdge, (swrScore *) score);
         return;
     }
 

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -299,7 +299,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
                     }
 
                     DAT_0050c944 = 0xffffffff;
-                    iVar8 = FUN_004409d0(DAT_00e35a60, DAT_004c0948);
+                    iVar8 = FUN_004409d0(swrRace_aProfiles[0].name, DAT_004c0948);
                     if ((iVar8 != 0) && ((swrUI_localPlayersInputDownBitset[0] & 4) != 0)) {
                         FUN_00440c10(hang);
                     }
@@ -1126,9 +1126,9 @@ LAB_0043b9b4:
 
             // Record 3 Laps
             iVar6 = hang->bMirror + hang->track_index * 2;
-            if (hang->track_index < DEFAULT_NB_TRACKS && DAT_00e365f4[iVar6] < 3599.0f) {
+            if (hang->track_index < DEFAULT_NB_TRACKS && swrRace_saveData.record3LapTimes[iVar6] < 3599.0f) {
 
-                uint8_t PilotIdx = DAT_00e37404[iVar6];
+                uint8_t PilotIdx = swrRace_saveData.record3LapPilots[iVar6];
                 char *pNameFirst = swrText_Translate(swrRacer_PodData[PilotIdx].name);
                 char *pNameLast = swrText_Translate(swrRacer_PodData[PilotIdx].lastname);
 
@@ -1142,8 +1142,8 @@ LAB_0043b9b4:
 
             // Record Best Lap
             iVar6 = hang->bMirror + hang->track_index * 2;
-            if (hang->track_index < DEFAULT_NB_TRACKS && DAT_00e366bc[iVar6] < 3599.0f) {
-                uint8_t PilotIdx = DAT_00e37436[iVar6];
+            if (hang->track_index < DEFAULT_NB_TRACKS && swrRace_saveData.recordLapTimes[iVar6] < 3599.0f) {
+                uint8_t PilotIdx = swrRace_saveData.recordLapPilots[iVar6];
                 char *pNameFirst = swrText_Translate(swrRacer_PodData[PilotIdx].name);
                 char *pNameLast = swrText_Translate(swrRacer_PodData[PilotIdx].lastname);
                 sprintf(local_40, "~f4~c~s%s %s", pNameFirst, pNameLast);

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -112,8 +112,8 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
 
     iVar8 = -1;
     DAT_0050c480 = 0;
-    if (DAT_004c4000 != 0) {
-        DAT_004c4000 = 0;
+    if (swrObjHang_menuJustEntered != 0) {
+        swrObjHang_menuJustEntered = 0;
         if (hang->menuScreenPrev == swrObjHang_STATE_SELECT_TRACK) {
             hang->mainMenuSelection = 0;
         }
@@ -252,8 +252,8 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
                 bVar1 = true;
                 gamma_unk = gamma_unk - DAT_00e98ea0[iVar6] * swrRace_fdeltaTimeSecs * 105.0;
             }
-            if (DAT_00e98e80[i] > 0.1 || DAT_00e98e80[i] < -0.1) {
-                alpha_unk = alpha_unk - DAT_00e98e80[i] * swrRace_fdeltaTimeSecs * -67.5;
+            if (swrControl_aPlayerAxisY[i] > 0.1 || swrControl_aPlayerAxisY[i] < -0.1) {
+                alpha_unk = alpha_unk - swrControl_aPlayerAxisY[i] * swrRace_fdeltaTimeSecs * -67.5;
                 if (alpha_unk > 45.0) {
                     alpha_unk = 45.0;
                 }
@@ -279,7 +279,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             iVar8 = 3;
             swrObjHang_state2 = swrObjHang_STATE_SELECT_TRACK;
         }
-        if (DAT_004d6b48 != 0) {
+        if (swrControl_menuAcceptPressedEdge != 0) {
             FUN_00440550(84);
 
             // Start Race
@@ -298,7 +298,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
                         swrObjHang_state2 = 15;
                     }
 
-                    DAT_0050c944 = 0xffffffff;
+                    swrObjHang_camFocusIdx = 0xffffffff;
                     iVar8 = FUN_004409d0(swrRace_aProfiles[0].name, DAT_004c0948);
                     if ((iVar8 != 0) && ((swrUI_localPlayersInputDownBitset[0] & 4) != 0)) {
                         FUN_00440c10(hang);
@@ -361,7 +361,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             swrObjHang_SetMenuState(hang, swrObjHang_state2);
             return;
         }
-        DAT_0050c944 = 0xffffffff;
+        swrObjHang_camFocusIdx = 0xffffffff;
     }
 }
 
@@ -411,7 +411,7 @@ void HandleCircuits_delta(swrObjHang *hang) {
         swrRace_MenuSelectedItem = 0;
     }
     //END DELTA
-    DAT_00e295c0 = (uint32_t) (circuitId > 0);
+    swrUI_menuScrolled = (uint32_t) (circuitId > 0);
     g_bCircuitIdxInRange = (int) (circuitId < g_CircuitIdxMax);
     return;
 }
@@ -623,8 +623,8 @@ void swrRace_CourseSelectionMenu_delta(void) {
 
     swrObjHang *hang = g_objHang2;// == g_pMenuState
     const TrackInfo Track = GetTrackInfo(hang->track_index);
-    if (DAT_004c4000 != 0) {
-        DAT_004c4000 = 0;
+    if (swrObjHang_menuJustEntered != 0) {
+        swrObjHang_menuJustEntered = 0;
         FUN_0045bee0(hang, 0x25, 0xffffffff, 0);
         DAT_0050c54c = 0;
 
@@ -812,15 +812,15 @@ LAB_0043b5c4:
     if (DAT_0050c54c == 0) {
         FUN_00469c30(0, 1.0f, 1);
         uint32_t puVar2 = *swrUI_localPlayersInputPressedBitset;
-        if (DAT_004eb39c == 0) {
-            if (DAT_004d6b48 != 0 &&
+        if (swrMultiplayer_menuOverlayActive == 0) {
+            if (swrControl_menuAcceptPressedEdge != 0 &&
                 (swrMultiplayer_IsMultiplayerEnabled() == 0 || swrMultiplayer_IsHost() != 0) &&
                 hang->track_index >= 0) {
                 if (multiplayer_enabled != 0) {
                     FUN_004118b0();
                     return;
                 }
-                if (DAT_00e2a698 != 0) {
+                if (swrObjHang_menuAcceptLock != 0) {
                     return;
                 }
 
@@ -830,7 +830,7 @@ LAB_0043b5c4:
                 DAT_0050c54c = 1;
                 return;
             }
-            if ((swrControl_cancelPressedEdge != 0) && (DAT_00e2a698 == 0)) {
+            if ((swrControl_cancelPressedEdge != 0) && (swrObjHang_menuAcceptLock == 0)) {
                 if (multiplayer_enabled) {
                     FUN_004118b0();
                     return;
@@ -894,16 +894,16 @@ void swrRace_CourseInfoMenu_delta(swrObjHang *hang) {
     if (nb_AI_racers == 0) {
         nb_AI_racers = 12;
     }
-    if (DAT_0050c55c == 0) {
-        DAT_0050c55c = 2;
+    if (swrObjHang_splitscreenRacerCount == 0) {
+        swrObjHang_splitscreenRacerCount = 2;
     }
 
-    iVar3 = DAT_0050c560;
-    if (DAT_004c4000 != 0) {
-        DAT_004c4000 = 0;
+    iVar3 = swrObjHang_courseInfoItemCount;
+    if (swrObjHang_menuJustEntered != 0) {
+        swrObjHang_menuJustEntered = 0;
         FUN_0045bee0(hang, 0x25, -1, 0);
-        DAT_0050c550 = 0;
-        DAT_0050c554 = 0;
+        swrObjHang_courseInfoSelectedRow = 0;
+        swrObjHang_courseInfoLeaving = 0;
 
         if (hang->menuScreenPrev == swrObjHang_STATE_SELECT_PLANET) {
             swrRace_Transition = 1.0;
@@ -914,49 +914,49 @@ void swrRace_CourseInfoMenu_delta(swrObjHang *hang) {
             FUN_0043b1d0(hang);
         }
 
-        DAT_0050c430[0] = 0xff;
-        DAT_0050c430[1] = 0xff;
-        DAT_0050c430[2] = 0xff;
-        DAT_0050c430[3] = 0xff;
-        DAT_0050c430[4] = 0xff;
-        DAT_0050c430[5] = 0xff;
-        DAT_0050c430[6] = 0xff;
-        DAT_0050c430[7] = 0xff;
-        DAT_0050c430[8] = 0xff;
-        DAT_0050c430[9] = 0xff;
-        DAT_0050c430[10] = 0xff;
-        DAT_0050c430[11] = 0xff;
-        DAT_0050c560 = 0;
+        swrObjHang_courseInfoItemKinds[0] = 0xff;
+        swrObjHang_courseInfoItemKinds[1] = 0xff;
+        swrObjHang_courseInfoItemKinds[2] = 0xff;
+        swrObjHang_courseInfoItemKinds[3] = 0xff;
+        swrObjHang_courseInfoItemKinds[4] = 0xff;
+        swrObjHang_courseInfoItemKinds[5] = 0xff;
+        swrObjHang_courseInfoItemKinds[6] = 0xff;
+        swrObjHang_courseInfoItemKinds[7] = 0xff;
+        swrObjHang_courseInfoItemKinds[8] = 0xff;
+        swrObjHang_courseInfoItemKinds[9] = 0xff;
+        swrObjHang_courseInfoItemKinds[10] = 0xff;
+        swrObjHang_courseInfoItemKinds[11] = 0xff;
+        swrObjHang_courseInfoItemCount = 0;
 
         if (swrUI_Front_BeatEverything1stPlace(hang)) {
-            iVar6 = DAT_0050c560;
-            DAT_0050c560 = DAT_0050c560 + 1;
-            DAT_0050c430[iVar6] = 0;
+            iVar6 = swrObjHang_courseInfoItemCount;
+            swrObjHang_courseInfoItemCount = swrObjHang_courseInfoItemCount + 1;
+            swrObjHang_courseInfoItemKinds[iVar6] = 0;
         }
         if (!hang->isTournamentMode) {
-            iVar3 = DAT_0050c560 + 1;
-            DAT_0050c430[DAT_0050c560] = 2;
+            iVar3 = swrObjHang_courseInfoItemCount + 1;
+            swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoItemCount] = 2;
             if (hang->timeAttackMode != 0) {
                 goto LAB_0043b9b4;
             }
-            DAT_0050c560 = DAT_0050c560 + 2;
-            DAT_0050c430[iVar3] = 3;
-            DAT_0050c430[DAT_0050c560] = 4;
+            swrObjHang_courseInfoItemCount = swrObjHang_courseInfoItemCount + 2;
+            swrObjHang_courseInfoItemKinds[iVar3] = 3;
+            swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoItemCount] = 4;
         } else {
             int32_t NumUnlockedTracks = VerifySelectedTrack_delta(hang, swrRace_MenuSelectedItem);
             iVar6 = isTrackUnlocked(hang->circuitIdx, NumUnlockedTracks);
-            iVar3 = DAT_0050c560;
+            iVar3 = swrObjHang_courseInfoItemCount;
             if (iVar6 == 0) {
                 goto LAB_0043b9b4;
             }
-            DAT_0050c430[DAT_0050c560] = 1;
+            swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoItemCount] = 1;
         }
-        iVar3 = DAT_0050c560 + 1;
+        iVar3 = swrObjHang_courseInfoItemCount + 1;
     }
 
 LAB_0043b9b4:
 
-    DAT_0050c560 = iVar3;
+    swrObjHang_courseInfoItemCount = iVar3;
     const int32_t NumUnlockedTracks = VerifySelectedTrack_delta(hang, swrRace_MenuSelectedItem);
     const uint8_t ReqPlaceToProcceed =
         GetRequiredPlaceToProceed(hang->circuitIdx, NumUnlockedTracks);
@@ -965,21 +965,21 @@ LAB_0043b9b4:
     // so PosY must NOT be advanced per row -- doing so applied the offset twice and
     // double-spaced the race options. Multi-line entries still add explicit PosY+N offsets.
     int32_t PosY = 160;
-    if (DAT_0050c554 == 0 && DAT_0050c560 > 0) {
-        for (int8_t i = 0; i < DAT_0050c560; i++) {
-            if (DAT_0050c430[i] > 6) {
+    if (swrObjHang_courseInfoLeaving == 0 && swrObjHang_courseInfoItemCount > 0) {
+        for (int8_t i = 0; i < swrObjHang_courseInfoItemCount; i++) {
+            if (swrObjHang_courseInfoItemKinds[i] > 6) {
                 assert(false);
                 continue;
             }
 
             char *pText = NULL;
-            switch (DAT_0050c430[i]) {
+            switch (swrObjHang_courseInfoItemKinds[i]) {
                 case 0: {
                     pText = swrText_Translate(g_pTxtMirror);
-                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, swrObjHang_courseInfoSelectedRow, i, pText);
                     if (hang->bMirror != 0) {
                         pText = swrText_Translate(g_pTxtOn);
-                        uVar13 = (int8_t) DAT_0050c550;
+                        uVar13 = (int8_t) swrObjHang_courseInfoSelectedRow;
                         goto LAB_0043be29;
                     }
                     pText = swrText_Translate(g_pTxtOff);
@@ -998,18 +998,18 @@ LAB_0043b9b4:
                         pText = swrText_Translate(g_pTxtWinnerTakesAll);
                     }
 
-                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, swrObjHang_courseInfoSelectedRow, i,
                                          swrText_Translate(g_pTxtWinnings));
-                    swrUI_Front_TextMenu(hang, 85, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 85, PosY, 10, swrObjHang_courseInfoSelectedRow, i, pText);
 
-                    swrUI_Front_TextMenu(hang, 45, PosY + 10, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 45, PosY + 10, 10, swrObjHang_courseInfoSelectedRow, i,
                                          swrText_Translate(g_pTxt1st));
-                    swrUI_Front_TextMenu(hang, 45, PosY + 20, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 45, PosY + 20, 10, swrObjHang_courseInfoSelectedRow, i,
                                          swrText_Translate(g_pTxt2nd));
-                    swrUI_Front_TextMenu(hang, 45, PosY + 30, 10, DAT_0050c550, i,
+                    swrUI_Front_TextMenu(hang, 45, PosY + 30, 10, swrObjHang_courseInfoSelectedRow, i,
                                          swrText_Translate(g_pTxt3rd));
                     if (ReqPlaceToProcceed == 4) {
-                        swrUI_Front_TextMenu(hang, 45, PosY + 40, 10, DAT_0050c550, i,
+                        swrUI_Front_TextMenu(hang, 45, PosY + 40, 10, swrObjHang_courseInfoSelectedRow, i,
                                              swrText_Translate(g_pTxt4th));
                     }
 
@@ -1019,7 +1019,7 @@ LAB_0043b9b4:
                         fTruguts *= hang->winnings.truguts[hang->WinningsID - 1][j];
                         pText = swrText_Translate("~f0~r~s%d");
                         sprintf(local_40, pText, (int) fTruguts);
-                        swrUI_Front_TextMenu(hang, 105, PosYIt, 10, DAT_0050c550, i, local_40);
+                        swrUI_Front_TextMenu(hang, 105, PosYIt, 10, swrObjHang_courseInfoSelectedRow, i, local_40);
                         PosYIt = PosYIt + 10;
                     }
 
@@ -1036,7 +1036,7 @@ LAB_0043b9b4:
                     sprintf(local_40, pText, nb_AI_racers);
                     if (hang->num_local_players > 1) {
                         pText = swrText_Translate("~f0~s%d");
-                        sprintf(local_40, pText, DAT_0050c55c);
+                        sprintf(local_40, pText, swrObjHang_splitscreenRacerCount);
                     }
                     pText = g_pTxtRacers;
                     goto LAB_0043bd30;
@@ -1054,20 +1054,20 @@ LAB_0043b9b4:
 
                 LAB_0043bd30:
                     pText = swrText_Translate(pText);
-                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, swrObjHang_courseInfoSelectedRow, i, pText);
                     pText = local_40;
-                    uVar13 = DAT_0050c550;
+                    uVar13 = swrObjHang_courseInfoSelectedRow;
                     goto LAB_0043be29;
                 }
                 case 5: {
                     pText = swrText_Translate(g_pTxtDemoMode);
-                    swrUI_Front_TextMenu(hang, 30, PosY, 10, DAT_0050c550, i, pText);
+                    swrUI_Front_TextMenu(hang, 30, PosY, 10, swrObjHang_courseInfoSelectedRow, i, pText);
                     if (hang->demo_mode != 0) {
                         pText = swrText_Translate(g_pTxtOn);
                         goto LAB_0043be20;
                     }
                     pText = swrText_Translate(g_pTxtOff);
-                    uVar13 = DAT_0050c550;
+                    uVar13 = swrObjHang_courseInfoSelectedRow;
                     goto LAB_0043be29;
                 }
                 case 6: {
@@ -1082,18 +1082,18 @@ LAB_0043b9b4:
                 }
             }
             pText = swrText_Translate(pText);
-            swrUI_Front_TextMenu(hang, 30, PosY, 10, (char) DAT_0050c550, i, pText);
+            swrUI_Front_TextMenu(hang, 30, PosY, 10, (char) swrObjHang_courseInfoSelectedRow, i, pText);
             pText = local_40;
 
         LAB_0043be20:
-            uVar13 = DAT_0050c550;
+            uVar13 = swrObjHang_courseInfoSelectedRow;
 
         LAB_0043be29:
             swrUI_Front_TextMenu(hang, 85, PosY, 10, uVar13, i, pText);
         }
     }
 
-    if (DAT_0050c554 == 0) {
+    if (swrObjHang_courseInfoLeaving == 0) {
         uVar18 = 0x40533333;
     } else {
         uVar18 = 0xc0533333;
@@ -1106,7 +1106,7 @@ LAB_0043b9b4:
         DrawHoloPlanet(hang, trackInfo.PlanetIdx, swrRace_Transition * 0.5);
     }
 
-    if (DAT_0050c554 == 0 && DAT_0050c554 == 0) {
+    if (swrObjHang_courseInfoLeaving == 0 && swrObjHang_courseInfoLeaving == 0) {
         if (hang->track_index < DEFAULT_NB_TRACKS) {
             DrawTrackPreview(hang, hang->track_index, 0.5);
         }
@@ -1192,9 +1192,9 @@ LAB_0043b9b4:
             }
         }
 
-        if (DAT_0050c554 == 0 && swrRace_Transition >= 1.0) {
-            if (DAT_004eb39c == 0) {
-                if (DAT_004d6b48 != 0 && DAT_00e2a698 == 0) {
+        if (swrObjHang_courseInfoLeaving == 0 && swrRace_Transition >= 1.0) {
+            if (swrMultiplayer_menuOverlayActive == 0) {
+                if (swrControl_menuAcceptPressedEdge != 0 && swrObjHang_menuAcceptLock == 0) {
                     FUN_00440550(84);
                     if (!hang->isTournamentMode) {
                         if (hang->timeAttackMode == 0) {
@@ -1205,7 +1205,7 @@ LAB_0043b9b4:
                                     hang->num_players = 1;
                                 }
                             } else {
-                                hang->num_players = DAT_0050c55c;
+                                hang->num_players = swrObjHang_splitscreenRacerCount;
                             }
                         } else {
                             hang->num_players = 1;
@@ -1215,10 +1215,10 @@ LAB_0043b9b4:
                     }
                     swrObjHang_InitTrackSprites_delta(hang, false);
                     FUN_0045bee0(hang, 0x24, 3, 0);
-                    DAT_0050c554 = 1;
+                    swrObjHang_courseInfoLeaving = 1;
                     return;
                 }
-                if (swrControl_cancelPressedEdge != 0 && DAT_00e2a698 == 0) {
+                if (swrControl_cancelPressedEdge != 0 && swrObjHang_menuAcceptLock == 0) {
 
                     FUN_00440550(36);
                     swrObjHang_InitTrackSprites_delta(hang, false);
@@ -1226,25 +1226,25 @@ LAB_0043b9b4:
                     return;
                 }
             }
-            if (DAT_0050c560 > 1) {
+            if (swrObjHang_courseInfoItemCount > 1) {
                 if ((swrUI_localPlayersInputPressedBitset[0] & 0x4000) != 0) {
-                    DAT_0050c550--;
+                    swrObjHang_courseInfoSelectedRow--;
                     FUN_00440550(88);
                 }
                 if ((swrUI_localPlayersInputPressedBitset[0] & 0x8000) != 0) {
-                    DAT_0050c550++;
+                    swrObjHang_courseInfoSelectedRow++;
                     FUN_00440550(88);
                 }
-                if (DAT_0050c550 < 0) {
-                    DAT_0050c550 = DAT_0050c560 - 1;
+                if (swrObjHang_courseInfoSelectedRow < 0) {
+                    swrObjHang_courseInfoSelectedRow = swrObjHang_courseInfoItemCount - 1;
                 }
-                if ((DAT_0050c560 - 1) < DAT_0050c550) {
-                    DAT_0050c550 = 0;
+                if ((swrObjHang_courseInfoItemCount - 1) < swrObjHang_courseInfoSelectedRow) {
+                    swrObjHang_courseInfoSelectedRow = 0;
                 }
             }
-            if (DAT_0050c560 > 0) {
+            if (swrObjHang_courseInfoItemCount > 0) {
                 if ((swrUI_localPlayersInputPressedBitset[0] & 0x20000) != 0) {
-                    switch (DAT_0050c430[DAT_0050c550]) {
+                    switch (swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoSelectedRow]) {
                         case 0: {
                             hang->bMirror = hang->bMirror == 0;
                             break;
@@ -1273,10 +1273,10 @@ LAB_0043b9b4:
                                     nb_AI_racers += 2;
                                 }
                             } else {
-                                cVar4 = DAT_0050c55c + 2;
-                                DAT_0050c55c = cVar4;
+                                cVar4 = swrObjHang_splitscreenRacerCount + 2;
+                                swrObjHang_splitscreenRacerCount = cVar4;
                                 if (cVar4 == 8) {
-                                    DAT_0050c55c = 2;
+                                    swrObjHang_splitscreenRacerCount = 2;
                                 }
                             }
                             break;
@@ -1297,7 +1297,7 @@ LAB_0043b9b4:
                 }
                 if ((swrUI_localPlayersInputPressedBitset[0] & 0x10000) != 0) {
 
-                    switch (DAT_0050c430[DAT_0050c550]) {
+                    switch (swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoSelectedRow]) {
                         case 0: {
                             hang->bMirror = hang->bMirror == 0;
                             break;
@@ -1318,10 +1318,10 @@ LAB_0043b9b4:
                                     nb_AI_racers -= 2;
                                 }
                             } else {
-                                cVar4 = DAT_0050c55c - 2;
-                                DAT_0050c55c = cVar4;
+                                cVar4 = swrObjHang_splitscreenRacerCount - 2;
+                                swrObjHang_splitscreenRacerCount = cVar4;
                                 if (cVar4 == 0) {
-                                    DAT_0050c55c = 6;
+                                    swrObjHang_splitscreenRacerCount = 6;
                                 }
                             }
                             break;

--- a/src/Main/swrControl.c
+++ b/src/Main/swrControl.c
@@ -49,3 +49,9 @@ int swrControl_Startup(void)
     HANG("TODO");
     return 0;
 }
+
+// 0x0040a120
+void swrControl_StopAllForceEffects(int reInit)
+{
+    HANG("TODO");
+}

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -2299,3 +2299,9 @@ float swrModel_CollideRayWithMesh(swrModel_Mesh* mesh, float* ray, float* outPoi
         swrRace_collisionHitNode = swrModel_collisionResultNode;
     return swrModel_collisionResultDist;
 }
+
+// 0x0042c2d0
+void SetSunSpriteAlpha_Maybe(int index, unsigned char alpha)
+{
+    HANG("TODO");
+}

--- a/src/Swr/swrMultiplayer.c
+++ b/src/Swr/swrMultiplayer.c
@@ -90,6 +90,12 @@ void swrMultiplayer_SendEvent(int to, unsigned int flags, int eventMagic, int a4
     HANG("TODO");
 }
 
+// 0x0041e5a0
+void swrMultiplayer_BroadcastPlayerState(void)
+{
+    HANG("TODO");
+}
+
 // 0x0042830
 int swrMultiplayer_Initialize(void)
 {

--- a/src/Swr/swrMultiplayer.c
+++ b/src/Swr/swrMultiplayer.c
@@ -84,6 +84,12 @@ void swrMultiplayer_RacerPick(int a)
     HANG("TODO");
 }
 
+// 0x0041df10
+void swrMultiplayer_SendEvent(int to, unsigned int flags, int eventMagic, int a4, float a5, float a6, double a7, void* a8, void* a9, int a10)
+{
+    HANG("TODO");
+}
+
 // 0x0042830
 int swrMultiplayer_Initialize(void)
 {

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -12,9 +12,11 @@
 #include "swrViewport.h"
 #include "swrRace.h"
 #include "swrSpline.h"
+#include "swrWeather.h"
 #include "Primitives/rdVector.h"
 #include "Primitives/rdMatrix.h"
 #include "General/stdMath.h"
+#include "Main/swrControl.h"
 
 #include <macros.h>
 #include <General/utils.h>
@@ -304,7 +306,11 @@ int NumLocalPlayers()
 // 0x0045D390
 double swrRace_GetLapProgressIfAvailable()
 {
-    HANG("TODO");
+    if (swrEvent_GetItem('Test', 0) == NULL)
+        return -1.0;
+    if (firstLocalPlayer == NULL)
+        return -1.0;
+    return swrRace_LapProgress(&firstLocalPlayer->obj_test_ptr->splineCursor);
 }
 
 // 0x0045D3D0
@@ -332,7 +338,7 @@ float swrObjJdge_GetRacerProgress(swrScore* score)
         wrap = -wrap;
     if (0.5f < wrap)
         wrap = 1.0f - wrap;
-    float progress = ((float)(int)score->results_P1_Lap + lapCompMax) - wrap;
+    float progress = ((float)score->results_P1_Lap + lapCompMax) - wrap;
     if (progress < 0.0f)
         progress = 0.0f;
     return progress;
@@ -712,7 +718,7 @@ void swrObjJdge_F0(swrObjJdge* jdge)
         if (jdge->camSweepState == NULL) {
             advance = true;
         } else {
-            if (jdge->unk134_mat.vC.x == 0.0f)
+            if (jdge->postRaceCursor.endFlag == 0)
                 jdge->raceTimer_ms -= (float)swrRace_deltaTimeSecs;
             else if ((flags & 0x80) != 0)
                 jdge->raceTimer_ms += (float)swrRace_deltaTimeSecs;
@@ -720,7 +726,8 @@ void swrObjJdge_F0(swrObjJdge* jdge)
                 jdge->raceTimer_ms = 0.0f;
                 jdge->flag = flags | 0x80;
             }
-            if (jdge->unk134_mat.vC.x != 0.0f && 0.5f < jdge->raceTimer_ms)
+            // fly-by camera reached the end of its path: linger half a second, then results
+            if (jdge->postRaceCursor.endFlag != 0 && 0.5f < jdge->raceTimer_ms)
                 advance = true;
         }
         if (advance) {
@@ -793,8 +800,189 @@ void swrObjJdge_F0(swrObjJdge* jdge)
     }
 }
 
+// 0x0045e970
+void swrObjJdge_UpdateSplineGuideNodes(int nodeOwner, swrScore* score)
+{
+    HANG("TODO");
+}
+
+// Race-tick judge update. State 1 (racing): follows the camera spline, advances every racer's
+// progress, and accumulates race times with sub-frame precision: when a pod crosses the line,
+// swrRace_UpdateRaceProgress reports the portion of the frame delta spent before the crossing,
+// which closes out the finished lap; the remainder (raw, unclamped frame delta minus that) then
+// accrues to the new lap. Tracks the session-best lap (jdge->best_lap_time_ms), handles the
+// finish (racer hand-off to AI, FLAG1_FINISHED, 'fini' net event, announcer/fanfare SFX), and
+// re-arms state 1 while any local player still races; once none do, the state-2 pass zeroes the
+// race timer and extrapolates unfinished racers' totals from their progress. Also escalates the
+// Ando Prime blizzard per lap and drives the post-race fly-by camera while state 4 is active.
 // 0x0045ea30
 void swrObjJdge_F2(swrObjJdge* jdge)
+{
+    swrScore* score;
+    swrRace* pod;
+    float* lapTimes;
+    float crossTime;
+    float rank;
+    float frameRemainder;
+    int lap;
+    int crossed;
+    int i;
+
+    if ((jdge->flag & 0xf) == 4 && jdge->camSweepState != NULL)
+        swrSpline_EvaluateToMatrix(&jdge->postRaceCursor, &jdge->postRaceMat);
+
+    if ((jdge->flag & 0xf) == 1) {
+        swrSpline_EvaluateToMatrix(&jdge->cursor, &jdge->camBaseMat);
+        // provisionally advance to state 2 ("all local racers finished");
+        // re-armed back to state 1 below while a local player is still racing
+        jdge->flag = (jdge->flag & ~0xd) | 2;
+        for (i = 0; i < jdge->num_players; i++) {
+            score = &swrScoresPtr[i];
+            if ((score->flag & 1) == 0 || (score->flag & 2) != 0) {
+                if ((score->flag & 2) != 0)
+                    swrRace_UpdateRaceProgress(score->obj_test_ptr, &crossTime);
+                continue;
+            }
+            pod = score->obj_test_ptr;
+            crossed = swrRace_UpdateRaceProgress(pod, &crossTime);
+            if (debug_showSplineMarkers != 0)
+                swrObjJdge_UpdateSplineGuideNodes((int)jdge, score);
+            lapTimes = &score->results_P1_Lap1;
+            if (crossed) {
+                if (jdge->planetId == 1) {
+                    // Ando Prime: escalate the blizzard when the first lap completes
+                    if (jdge->planet_track_number == 0) {
+                        if (score->results_P1_Lap == 0) {
+                            swrWeather_SetVelocity(25.0f, 45.0f);
+                            swrWeather_SetParticleCap(20);
+                        } else {
+                            swrWeather_SetParticleCap(60);
+                            swrWeather_SetVelocity(20.0f, 60.0f);
+                            SetSunSpriteAlpha_Maybe(0, 0x80);
+                        }
+                    } else if (jdge->planet_track_number == 1) {
+                        if (score->results_P1_Lap == 0) {
+                            swrWeather_SetParticleCap(60);
+                            swrWeather_SetVelocity(20.0f, 60.0f);
+                            SetSunSpriteAlpha_Maybe(0, 0x80);
+                        } else {
+                            swrWeather_SetParticleCap(80);
+                            swrWeather_SetVelocity(10.0f, 90.0f);
+                            swrWeather_SetStretchFactor(1.0f);
+                            SetSunSpriteAlpha_Maybe(0, 0x14);
+                        }
+                    } else if (jdge->planet_track_number == 2) {
+                        if (score->results_P1_Lap == 0) {
+                            swrWeather_SetParticleCap(80);
+                            swrWeather_SetVelocity(10.0f, 60.0f);
+                            SetSunSpriteAlpha_Maybe(0, 0x40);
+                        } else {
+                            swrWeather_SetParticleCap(80);
+                            swrWeather_SetVelocity(10.0f, 90.0f);
+                            swrWeather_SetStretchFactor(1.0f);
+                            SetSunSpriteAlpha_Maybe(0, 0x14);
+                        }
+                    }
+                }
+                // close out the finished lap with the pre-crossing slice of this frame
+                score->results_P1_total_time += crossTime;
+                lap = score->results_P1_Lap;
+                lapTimes[lap] += crossTime;
+                if ((pod->flags0 & swrObjTest_FLAG0_LOCAL) != 0 && lapTimes[lap] < jdge->best_lap_time_ms)
+                    jdge->best_lap_time_ms = lapTimes[lap];
+                lap++;
+                score->results_P1_Lap = lap;
+                if (lap == jdge->num_laps) {
+                    if ((pod->flags0 & swrObjTest_FLAG0_LOCAL) != 0) {
+                        pod->flags1 |= swrObjTest_FLAG1_FORCE_GROUND;
+                        swrControl_StopAllForceEffects(0);
+                        swrRace_resultsScreenActive = 0;
+                        if (lapTimes[jdge->num_laps - 1] <= jdge->best_lap_time_ms) {
+                            // final lap tied/beat the session best: fanfare (0x27) once
+                            if (swrSound_TestSfxFlag((char)score->sfxChannel, swrSound_SFXFLAG_LAP_FANFARE) == 0) {
+                                if ((short)score->results_P1_Position == 1)
+                                    swrSound_PlaySfxThenDelayed(1, *(int*)score->unk18, 0xf, 6, 0, 0x27);
+                                else if ((short)score->results_P1_Position < 5)
+                                    swrSound_PlaySfxThrottled(6, 0, 0x27, NULL);
+                                else
+                                    swrSound_PlaySfxThenDelayed(1, *(int*)score->unk18, 0x10, 6, 0, 0x27);
+                                swrSound_SetSfxFlag((char)score->sfxChannel, swrSound_SFXFLAG_LAP_FANFARE);
+                            }
+                        } else {
+                            // announcer line by finishing position (0xf = won, 0x10 = trailing)
+                            if ((short)score->results_P1_Position == 1)
+                                swrSound_PlaySfxThrottled(1, *(int*)score->unk18, 0xf, NULL);
+                            else if (4 < (short)score->results_P1_Position)
+                                swrSound_PlaySfxThrottled(1, *(int*)score->unk18, 0x10, NULL);
+                        }
+                    }
+                    score->flag |= 2;
+                    swrMultiplayer_SendEvent(-1, 1, 'fini', 0, 0.0f, 0.0f, 0.0, NULL, NULL, 0);
+                    pod->flags0 &= ~swrObjTest_FLAG0_LOCAL;
+                    pod->flags0 &= ~(swrObjTest_FLAG0_CAN_CHARGE_BOOST | swrObjTest_FLAG0_BOOSTING);
+                    pod->flags0 |= swrObjTest_FLAG0_AI;
+                    pod->flags1 |= swrObjTest_FLAG1_FINISHED;
+                } else {
+                    lapTimes[lap] = 0.0f;
+                }
+            } else {
+                crossTime = 0.0f;
+            }
+            if ((score->flag & 2) == 0) {
+                // the rest of the frame delta accrues to the (possibly new) current lap;
+                // timing uses the raw, unclamped delta, capped at 3000s
+                frameRemainder = (float)swrRace_dt_raw_d - crossTime;
+                score->results_P1_total_time += frameRemainder;
+                if (3000.0f < score->results_P1_total_time)
+                    score->results_P1_total_time = 3000.0f;
+                lap = score->results_P1_Lap;
+                lapTimes[lap] += frameRemainder;
+                if (3000.0f < lapTimes[lap])
+                    lapTimes[lap] = 3000.0f;
+                if (firstLocalPlayer == NULL || score == firstLocalPlayer || score == secondLocalPlayer ||
+                    score == thirdLocalPlayer || score == fourthLocalPlayer)
+                    jdge->flag = (jdge->flag & ~0xe) | 1;
+            }
+        }
+        swrObjJdge_UpdateStandings(jdge);
+        swrObjJdge_UpdateOvertakeSounds(jdge);
+        if ((jdge->flag & 0xf) == 2) {
+            // every local racer just finished: freeze the race timer and extrapolate
+            // unfinished racers' totals from their lap progress
+            jdge->raceTimer_ms = 0.0f;
+            for (i = 0; i < jdge->num_players; i++) {
+                score = &swrScoresPtr[i];
+                rank = swrObjJdge_GetRacerRankValue(score);
+                if (rank < (float)jdge->num_laps) {
+                    score->results_P1_total_time = (score->results_P1_total_time / rank) * (float)jdge->num_laps;
+                    score->obj_test_ptr->flags0 &= ~(swrObjTest_FLAG0_CAN_CHARGE_BOOST | swrObjTest_FLAG0_BOOSTING);
+                    score->obj_test_ptr->flags1 |= swrObjTest_FLAG1_FINISHED;
+                }
+            }
+        }
+    } else if ((jdge->flag & 0xf) == 2) {
+        for (i = 0; i < jdge->num_players; i++)
+            swrRace_UpdateRaceProgress(swrScoresPtr[i].obj_test_ptr, &crossTime);
+    } else if ((jdge->flag & 0xf) != 6) {
+        for (i = 0; i < jdge->num_players; i++)
+            swrRace_UpdateRaceProgress(swrScoresPtr[i].obj_test_ptr, &crossTime);
+    }
+}
+
+// 0x0045ef70
+void swrObjJdge_UpdateOvertakeSounds(swrObjJdge* jdge)
+{
+    HANG("TODO");
+}
+
+// 0x0045fe70
+void swrObjJdge_DrawSpeedDialHud_Maybe(int racer, int score, short x, short y, int playerIdx)
+{
+    HANG("TODO");
+}
+
+// 0x004603f0
+void swrObjJdge_LayoutHudFrameSprites_Maybe(unsigned int mode)
 {
     HANG("TODO");
 }
@@ -1143,7 +1331,7 @@ void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score)
                 swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, 3, 0x10, 2);
             racer->flags0 |= 0x8000000; // flags0 bit 0x8000000 not named in swrObjTest_FLAG0
             rdMatrix44 guideMat;
-            swrSpline_EvaluateAtOffset(&racer->unk4_mat, &guideMat, 0.5f);
+            swrSpline_EvaluateAtOffset(&racer->splineCursor, &guideMat, 0.5f);
             rdVector_Copy3((rdVector3*)(racer->unk12 + 4), (rdVector3*)&guideMat.vD);
             *(swrModel_Node**)racer->unk12 = someRootNodeChildNodes[nodeIdx];
         }
@@ -1322,9 +1510,9 @@ void swrObjJdge_F3(swrObjJdge* jdge)
             if (state == 1 || state == 2) {
                 bool finalLap = false;
                 if (1 < jdge->num_laps) {
-                    if (firstLocalPlayer != NULL && jdge->num_laps <= (int)firstLocalPlayer->results_P1_Lap + 1)
+                    if (firstLocalPlayer != NULL && jdge->num_laps <= firstLocalPlayer->results_P1_Lap + 1)
                         finalLap = true;
-                    if (secondLocalPlayer != NULL && jdge->num_laps <= (int)secondLocalPlayer->results_P1_Lap + 1)
+                    if (secondLocalPlayer != NULL && jdge->num_laps <= secondLocalPlayer->results_P1_Lap + 1)
                         finalLap = true;
                 }
                 if (swrRace_music_enabled != 0) {
@@ -1529,22 +1717,22 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
         jdge->unk1d8 = 0;
         jdge->unk1dc = 0;
         jdge->camSweepState = NULL;
-        jdge->unk134_mat.vD.x = 1.0f;
-        jdge->unk134_mat.vD.y = 0.0f;
-        jdge->unk134_mat.vD.z = 0.0f;
-        jdge->unk134_mat.vD.w = 0.0f;
-        jdge->unk174[0] = 0.0f;
-        jdge->unk174[1] = 1.0f;
-        jdge->unk174[2] = 0.0f;
-        jdge->unk174[3] = 0.0f;
-        jdge->unk174[4] = 0.0f;
-        jdge->unk174[5] = 0.0f;
-        jdge->unk174[6] = 1.0f;
-        jdge->unk174[7] = 0.0f;
-        jdge->unk174[8] = 0.0f;
-        jdge->unk174[9] = 0.0f;
-        jdge->unk174[10] = 0.0f;
-        jdge->unk1a0 = 1.0f;
+        jdge->postRaceMat.vA.x = 1.0f;
+        jdge->postRaceMat.vA.y = 0.0f;
+        jdge->postRaceMat.vA.z = 0.0f;
+        jdge->postRaceMat.vA.w = 0.0f;
+        jdge->postRaceMat.vB.x = 0.0f;
+        jdge->postRaceMat.vB.y = 1.0f;
+        jdge->postRaceMat.vB.z = 0.0f;
+        jdge->postRaceMat.vB.w = 0.0f;
+        jdge->postRaceMat.vC.x = 0.0f;
+        jdge->postRaceMat.vC.y = 0.0f;
+        jdge->postRaceMat.vC.z = 1.0f;
+        jdge->postRaceMat.vC.w = 0.0f;
+        jdge->postRaceMat.vD.x = 0.0f;
+        jdge->postRaceMat.vD.y = 0.0f;
+        jdge->postRaceMat.vD.z = 0.0f;
+        jdge->postRaceMat.vD.w = 1.0f;
         jdge->cam_spline = NULL;
         jdge->unk1a8 = 0;
         jdge->unk1e0 = 0;
@@ -1831,7 +2019,7 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     swrTranslationRotation splineRot;
     rdMatrix44 splineMat;
 
-    swrSpline_EvaluateAtOffset(&racer->unk4_mat, &splineMat, t);
+    swrSpline_EvaluateAtOffset(&racer->splineCursor, &splineMat, t);
     rdMatrix_ExtractTransform(&splineMat, &splineRot);
     racer->spawn_pos_rot.translation.x = splineRot.translation.x;
     racer->spawn_pos_rot.translation.y = splineRot.translation.y;
@@ -1845,7 +2033,7 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->flags1 = racer->flags1 & ~(swrObjTest_FLAG1_FLAT_CACHE | swrObjTest_FLAG1_ON_FLAT);
     bool below = t < 0.0f;
     racer->flags0 = racer->flags0 & ~swrObjTest_FLAG0_ZOFF;
-    racer->unkdc = 0;
+    racer->splineSampleSpacing = 0.0f;
     racer->unkec_node = NULL;
     racer->unkf8 = 0;
     racer->unk100 = 0;

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -215,6 +215,18 @@ void DrawTrackPreview(void* unused, int TrackID, float param_3)
     HANG("TODO");
 }
 
+// 0x0045bee0
+void swrObjHang_FocusMenuItem(swrObjHang* hang, int itemIndex, swrObjHang_STATE nextState, int param_4)
+{
+    HANG("TODO");
+}
+
+// 0x00457140
+void swrObjHang_PositionHoloNode(int nodeIndex, float param_2, float param_3, float param_4)
+{
+    HANG("TODO");
+}
+
 // 0x00457620
 void swrObjHang_F0(swrObjHang* hang)
 {

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -519,7 +519,10 @@ void swrObjHang_PositionHoloNode(int nodeIndex, float param_2, float param_3, fl
 // Animate the holo screen-transition node (scaled by swrRace_Transition).
 void swrObjHang_AnimateTransitionNode(void);
 
-// Race start: build the roster (SP/MP) then fire the 'Begn' scene/judge events to spin up the race.
+// Race start: build the roster (SP/MP) then fire the 'Begn' scene/judge events to spin up the
+// race. The 'Begn' payload carries the selected track's saved records (swrRace_saveData
+// recordLapTimes / record3LapTimes / record3LapPilots at [track*2 + mirror]), which
+// swrObjJdge_F4 latches into jdge->best_lap_time_ms / recordLap3_ms for the session.
 void swrObjHang_StartRace(swrObjHang* hang, int* param_2, int param_3);
 void* swrObjHang_BuildRosterSinglePlayer(swrObjHang* hang, int* out);
 void* swrObjHang_BuildRosterMultiplayer(swrObjHang* hang, int* out);

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -7,6 +7,8 @@
 #include "swrText.h"
 #include "swrSound.h"
 #include "swrSprite.h"
+#include "swrUI.h"
+#include "swrMultiplayer.h"
 #include "macros.h"
 #include "engine_config.h"
 #include "globals.h"
@@ -317,10 +319,362 @@ void swrRace_DrawRecordText_Maybe(float x, float y, float alpha, char* recordNam
     swrText_CreateTextEntry1((int)x, (int)y, 0x32, -1, -1, (int)alpha, buffer);
 }
 
+// Post-race results screen. On entry (menuJustEntered) it sanitizes and sorts the race scores,
+// routes record-setting guest players through name entry, commits new 3-lap / best-lap records
+// into the save image (holder name + pilot from the live profile), and -- in tournament mode --
+// applies the whole progression step: prize truguts, next-track/circuit unlocks, beat-place
+// bits, the favorite-pilot unlock cutaway, and the podium hand-off; then autosaves. Every frame
+// it renders the scrollable standings list and handles input.
 // 0x00439ce0
 void swrRace_ResultsMenu(swrObjHang* hang)
 {
-    HANG("TODO");
+    swrScore* scores[20]; // race order: local players first
+    float bestLap[2];
+    swrScore* score;
+    char* text;
+    float rowYf;
+    float alphaF;
+    float lapTime;
+    int rowY;
+    int textY;
+    int alpha;
+    int spriteId;
+    int pilot;
+    int recordIdx;
+    int lap;
+    int i;
+    int k;
+    char effLaps;
+    char newCircuitIdx;
+    char minLocalPlace;
+    char required;
+    uint8_t favoritePilot;
+    int storedPlaceBits;
+    int gain;
+    swrObjHang_STATE state2;
+    char buffer[256];
+
+    newCircuitIdx = hang->circuitIdx;
+    bestLap[0] = ELFSAVE_RECORD_TIME_EMPTY;
+    bestLap[1] = ELFSAVE_RECORD_TIME_EMPTY;
+    g_CircuitIdxMax = (int)(150.0f - (float)hang->num_players * 30.0f); // scroll floor (see DrawScrollbar)
+    effLaps = hang->numLaps;
+    if (hang->isTournamentMode != 0)
+        effLaps = 3;
+    text = swrText_Translate("/SCREENTEXT_189/~c~sResults");
+    swrText_CreateColorlessEntry1(0xa0, 0x14, text);
+    for (i = 0; i < 20; i++)
+        scores[i] = NULL;
+
+    if (swrObjHang_menuJustEntered != 0) {
+        swrObjHang_menuJustEntered = 0;
+        swrRace_resultsFanfareDelay = 2.0f;
+        for (i = 0; i < g_aTracksInCircuits[(int)hang->circuitIdx]; i++) {
+            if ((int)hang->track_index == g_aTrackIDs[hang->circuitIdx * 7 + i]) {
+                swrObjHang_trackInCircuitIdx = (uint8_t)i;
+                break;
+            }
+        }
+        swrRace_resultsScrollY = 0.0f;
+        swrRace_TournamentTrugutGain = 0;
+        for (i = 0; i < 20; i++)
+            swrRace_resultsSortedScores[i] = NULL;
+        // collect + sanitize: out-of-range totals and lap times become the empty-record value
+        for (i = 0; i < hang->num_players; i++) {
+            score = &swrScores[i];
+            scores[i] = score;
+            if (score == NULL) {
+                hang->num_players = (char)i;
+                break;
+            }
+            if (ELFSAVE_RECORD_TIME_EMPTY < score->results_P1_total_time || score->results_P1_total_time < 0.0f)
+                score->results_P1_total_time = ELFSAVE_RECORD_TIME_EMPTY;
+            for (lap = 0; lap < effLaps; lap++) {
+                if (ELFSAVE_RECORD_TIME_EMPTY < (&score->results_P1_Lap1)[lap] || (&score->results_P1_Lap1)[lap] < 0.0f)
+                    (&score->results_P1_Lap1)[lap] = ELFSAVE_RECORD_TIME_EMPTY;
+            }
+            swrRace_resultsSortedScores[i] = score;
+        }
+        // sort by finishing position (bubble)
+        for (i = 1; i < hang->num_players; i++) {
+            for (k = 0; k < i; k++) {
+                if ((short)swrRace_resultsSortedScores[i]->results_P1_Position <
+                    (short)swrRace_resultsSortedScores[k]->results_P1_Position) {
+                    score = swrRace_resultsSortedScores[i];
+                    swrRace_resultsSortedScores[i] = swrRace_resultsSortedScores[k];
+                    swrRace_resultsSortedScores[k] = score;
+                }
+            }
+        }
+        // best single lap per local player (a non-positive lap time ends the scan)
+        for (k = 0; k < hang->num_local_players; k++) {
+            bestLap[k] = (&scores[k]->results_P1_Lap1)[0];
+            for (lap = 1; lap < effLaps; lap++) {
+                lapTime = (&scores[k]->results_P1_Lap1)[lap];
+                if (lapTime <= 0.0f)
+                    break;
+                if (lapTime < bestLap[k])
+                    bestLap[k] = lapTime;
+            }
+        }
+        // a record-setting guest profile (not linked to a save slot) gets sent to name entry
+        recordIdx = hang->bMirror + hang->track_index * 2;
+        if ((swrRace_resultsStateFlags & swrRace_RESULTSFLAG_NAME_ENTRY_P1) == 0 &&
+            swrRace_aProfiles[0].linkedToSave == 0 &&
+            ((effLaps == 3 && scores[0]->results_P1_total_time < swrRace_saveData.record3LapTimes[recordIdx] &&
+              (hang->num_local_players == 1 || scores[0]->results_P1_total_time < scores[1]->results_P1_total_time)) ||
+             (bestLap[0] < swrRace_saveData.recordLapTimes[recordIdx] &&
+              (hang->num_local_players == 1 || bestLap[0] < bestLap[1])))) {
+            swrRace_resultsStateFlags |= swrRace_RESULTSFLAG_NAME_ENTRY_P1;
+            hang->current_player_for_vehicle_selection = 0;
+            swrObjHang_SetMenuState(hang, swrObjHang_STATE_ENTER_NAME);
+            return;
+        }
+        if (1 < hang->num_local_players && (swrRace_resultsStateFlags & swrRace_RESULTSFLAG_NAME_ENTRY_P2) == 0 &&
+            swrRace_aProfiles[1].linkedToSave == 0 &&
+            ((effLaps == 3 && scores[1]->results_P1_total_time < swrRace_saveData.record3LapTimes[recordIdx] &&
+              scores[1]->results_P1_total_time < scores[0]->results_P1_total_time) ||
+             (bestLap[1] < swrRace_saveData.recordLapTimes[recordIdx] && bestLap[1] < bestLap[0]))) {
+            swrRace_resultsStateFlags |= swrRace_RESULTSFLAG_NAME_ENTRY_P2;
+            hang->current_player_for_vehicle_selection = 1;
+            swrObjHang_SetMenuState(hang, swrObjHang_STATE_ENTER_NAME);
+            return;
+        }
+        // commit new records: time + holder name + holder pilot from the live profile
+        if ((swrRace_resultsStateFlags & swrRace_RESULTSFLAG_RECORDS_COMMITTED) == 0) {
+            for (k = 0; k < hang->num_local_players; k++) {
+                recordIdx = hang->bMirror + hang->track_index * 2;
+                if (effLaps == 3 && scores[k]->results_P1_total_time < ELFSAVE_RECORD_TIME_EMPTY &&
+                    scores[k]->results_P1_total_time < swrRace_saveData.record3LapTimes[recordIdx]) {
+                    swrRace_saveData.record3LapTimes[recordIdx] = scores[k]->results_P1_total_time;
+                    for (i = 0; i < 32; i++)
+                        swrRace_saveData.record3LapNames[recordIdx][i] = swrRace_aProfiles[k].name[i];
+                    swrRace_saveData.record3LapPilots[recordIdx] = swrRace_aProfiles[k].pilotId;
+                }
+                if (bestLap[k] < ELFSAVE_RECORD_TIME_EMPTY &&
+                    bestLap[k] < swrRace_saveData.recordLapTimes[recordIdx]) {
+                    swrRace_saveData.recordLapTimes[recordIdx] = bestLap[k];
+                    for (i = 0; i < 32; i++)
+                        swrRace_saveData.recordLapNames[recordIdx][i] = swrRace_aProfiles[k].name[i];
+                    swrRace_saveData.recordLapPilots[recordIdx] = swrRace_aProfiles[k].pilotId;
+                }
+            }
+        }
+        swrRace_resultsStateFlags |= swrRace_RESULTSFLAG_RECORDS_COMMITTED;
+
+        swrRace_resultsPlaceP1 = *(char*)&scores[0]->results_P1_Position;
+        swrRace_resultsPlaceP2 = -1;
+        minLocalPlace = swrRace_resultsPlaceP1;
+        if (1 < hang->num_local_players) {
+            swrRace_resultsPlaceP2 = *(char*)&scores[1]->results_P1_Position;
+            if (swrRace_resultsPlaceP2 < swrRace_resultsPlaceP1)
+                minLocalPlace = swrRace_resultsPlaceP2;
+        }
+        if (3 < minLocalPlace) {
+            // start the list scrolled so the local player's row is visible
+            swrRace_resultsScrollY = (float)(minLocalPlace - 3) * -30.0f;
+            if (swrRace_resultsScrollY < 150.0f - (float)hang->num_players * 30.0f)
+                swrRace_resultsScrollY = 150.0f - (float)hang->num_players * 30.0f;
+        }
+        if (hang->num_local_players == 1 && hang->isTournamentMode != 0 && 3 < hang->num_players) {
+            // equal totals share a finishing position
+            for (i = 1; i < hang->num_players; i++) {
+                if (swrRace_resultsSortedScores[i]->results_P1_total_time ==
+                    swrRace_resultsSortedScores[i - 1]->results_P1_total_time)
+                    *(short*)&swrRace_resultsSortedScores[i]->results_P1_Position =
+                        *(short*)&swrRace_resultsSortedScores[i - 1]->results_P1_Position;
+            }
+            // winning a track can unlock its favorite pilot (cutaway state)
+            if (swrRace_resultsPlaceP1 == 1 && hang->isTournamentMode != 0 &&
+                (swrRace_resultsStateFlags & swrRace_RESULTSFLAG_PILOT_UNLOCK_SHOWN) == 0) {
+                favoritePilot = g_aTrackInfos[(int)hang->track_index].FavoritePilot;
+                if (favoritePilot == 2 && hang->track_index != 1)
+                    favoritePilot = 0;
+                if (0 < (char)favoritePilot &&
+                    (swrRace_aProfiles[0].pilotsUnlocked & (1u << (favoritePilot & 0x1f))) == 0) {
+                    swrRace_aProfiles[0].pilotsUnlocked |= 1u << (favoritePilot & 0x1f);
+                    swrRace_saveData.pilotsUnlockedGlobal |= swrRace_aProfiles[0].pilotsUnlocked;
+                    swrRace_SaveCurrentProfile();
+                    swrRace_resultsStateFlags |= swrRace_RESULTSFLAG_PILOT_UNLOCK_SHOWN;
+                    swrObjHang_SetMenuState(hang, swrObjHang_STATE_PILOT_UNLOCK);
+                    return;
+                }
+            }
+            required = GetRequiredPlaceToProceed(hang->circuitIdx, (char)swrObjHang_trackInCircuitIdx);
+            if (swrRace_resultsPlaceP1 <= required) {
+                storedPlaceBits = (swrRace_aProfiles[0].beatTrackPlace[(int)hang->circuitIdx] >>
+                                   ((swrObjHang_trackInCircuitIdx & 0xf) * 2)) &
+                                  3;
+                if (isTrackUnlocked(hang->circuitIdx, (char)swrObjHang_trackInCircuitIdx) != 0) {
+                    // prize scales with the circuit: x1.0 / x1.5 / x2.0 / x2.5
+                    gain = (int)hang->winnings.truguts[hang->WinningsID - 1][swrRace_resultsPlaceP1 - 1];
+                    gain = (int)((1.0 - (double)(int)hang->circuitIdx * -0.5) * (double)gain);
+                    swrRace_TournamentTrugutGain = gain;
+                    swrRace_truguts += gain;
+                    if (hang->circuitIdx < 3) {
+                        if ((int)swrObjHang_trackInCircuitIdx == g_aTracksInCircuits[(int)hang->circuitIdx] - 1 &&
+                            (swrRace_aProfiles[0].circuitsCompleted & (1 << (hang->circuitIdx & 0x1f))) == 0) {
+                            // circuit finished for the first time: jump to its invitational track
+                            newCircuitIdx = 3;
+                            swrRace_aProfiles[0].circuitsCompleted |= 1 << (hang->circuitIdx & 0x1f);
+                            hang->track_index = (char)g_aTrackIDs[hang->circuitIdx + 0x15];
+                        } else if ((int)swrObjHang_trackInCircuitIdx < g_aTracksInCircuits[(int)hang->circuitIdx] - 1 &&
+                                   (swrRace_aProfiles[0].tracksUnlocked[(int)hang->circuitIdx] &
+                                    (1 << ((swrObjHang_trackInCircuitIdx + 1) & 0x1f))) == 0) {
+                            hang->track_index =
+                                (char)g_aTrackIDs[hang->circuitIdx * 7 + swrObjHang_trackInCircuitIdx + 1];
+                        }
+                        swrRace_aProfiles[0].tracksUnlocked[(int)hang->circuitIdx] |=
+                            1 << ((swrObjHang_trackInCircuitIdx + 1) & 0x1f);
+                    }
+                    swrRace_UpdatePartsHealth();
+                }
+                if ((int)swrObjHang_trackInCircuitIdx == g_aTracksInCircuits[(int)hang->circuitIdx] - 1 &&
+                    hang->circuitIdx == 2)
+                    swrObjHang_SelectDemoTracks_Maybe(hang);
+                // best finishing place per track, 2 bits each (stored as 4 - place)
+                if (storedPlaceBits < 4 - swrRace_resultsPlaceP1) {
+                    swrRace_aProfiles[0].beatTrackPlace[(int)hang->circuitIdx] &=
+                        (uint16_t)~(3 << (swrObjHang_trackInCircuitIdx * 2));
+                    swrRace_aProfiles[0].beatTrackPlace[(int)hang->circuitIdx] |=
+                        (uint16_t)((4 - swrRace_resultsPlaceP1) << (swrObjHang_trackInCircuitIdx * 2));
+                    if (swrRace_aProfiles[0].beatTrackPlace[0] == 0x3fff &&
+                        swrRace_aProfiles[0].beatTrackPlace[1] == 0x3fff &&
+                        swrRace_aProfiles[0].beatTrackPlace[2] == 0x3fff) {
+                        if ((swrRace_aProfiles[0].circuitsCompleted & 8) == 0) {
+                            swrRace_aProfiles[0].circuitsCompleted |= 8;
+                            newCircuitIdx = 3;
+                            hang->track_index = (char)g_aTrackIDs[0x18];
+                        } else if (swrRace_aProfiles[0].beatTrackPlace[3] == 0xff &&
+                                   (swrRace_saveData.unlockFlags & swrSaveData_UNLOCK_BEAT_ALL_TRACKS_FIRST) == 0) {
+                            swrRace_saveData.unlockFlags |= swrSaveData_UNLOCK_BEAT_ALL_TRACKS_FIRST;
+                        }
+                    }
+                }
+            }
+            // fold the profile's unlock progress into the machine-global unlocks
+            // (UnlockDataBase[1..4] = tracksUnlocked[0..2] + circuitsCompleted)
+            for (i = 0; i < 4; i++) {
+                if (g_aBeatTracksGlobal[i] < (uint8_t)swrRace_UnlockDataBase[i + 1])
+                    g_aBeatTracksGlobal[i] = (uint8_t)swrRace_UnlockDataBase[i + 1];
+            }
+        }
+        hang->circuitIdx = newCircuitIdx;
+        swrRace_SaveCurrentProfile();
+    }
+
+    if (0.0f < swrRace_resultsFanfareDelay) {
+        swrRace_resultsFanfareDelay -= swrRace_fdeltaTimeSecs;
+        if (swrRace_resultsFanfareDelay <= 0.0f)
+            playASound(0xb6, 7, 0.25f, 1.0f, 0);
+    }
+
+    // standings rows (30px apart, faded near the top/bottom edges)
+    rowY = 0x1e;
+    for (i = 0; i < hang->num_players; i++) {
+        score = swrRace_resultsSortedScores[i];
+        rowYf = ((float)rowY + swrRace_resultsScrollY) + 15.0f;
+        alphaF = 255.0f;
+        if (rowYf < 45.0f)
+            alphaF = (float)(255.0 - (45.0 - (double)rowYf) * 8.0);
+        if (160.0f < rowYf)
+            alphaF = (float)(255.0 - ((double)rowYf - 160.0) * 8.0);
+        if (alphaF < 0.0f)
+            alphaF = 0.0f;
+        if (255.0f < alphaF)
+            alphaF = 255.0f;
+        alpha = (int)alphaF;
+        // duplicate pods use the mirrored sprite bank (+0x17 per prior appearance)
+        pilot = *(int*)score->unk18;
+        spriteId = pilot;
+        for (k = 0; k < i; k++) {
+            if (pilot == *(int*)swrRace_resultsSortedScores[k]->unk18)
+                spriteId += 0x17;
+        }
+        swrSprite_SetVisible((short)spriteId, 1);
+        swrSprite_SetPos((short)spriteId, 0x1e, (short)(int)rowYf);
+        swrSprite_SetDim((short)spriteId, 0.5f, 0.5f);
+        swrSprite_SetColor((short)spriteId, 0xff, 0xff, 0xff, (uint8_t)alpha);
+        rowYf += 10.0f;
+        textY = (int)rowYf;
+        if (i == swrRace_resultsPlaceP1 - 1 || i == swrRace_resultsPlaceP2 - 1) {
+            // local player's row: highlighted, with the profile name underneath
+            text = swrText_Translate("~r~s%d:");
+            sprintf(buffer, text, (int)(short)score->results_P1_Position);
+            swrText_CreateTextEntry1(0x58, textY, -0x5d, -0x42, 0x11, alpha, buffer);
+            text = swrText_Translate("~f4~s%s %s");
+            sprintf(buffer, text, swrText_Translate(swrRacer_PodData[pilot].name),
+                    swrText_Translate(swrRacer_PodData[pilot].lastname));
+            swrText_CreateTextEntry1(0x5c, (int)(rowYf + 1.0f), -0x5d, -0x42, 0x11, alpha, buffer);
+            swrText_CreateTimeEntryFormat(0x109, textY, score->results_P1_total_time, -0x5d, -0x42, 0x11, alpha, 1);
+            text = swrText_Translate("~f4~s%s");
+            sprintf(buffer, text,
+                    (i == swrRace_resultsPlaceP1 - 1) ? swrRace_aProfiles[0].name : swrRace_aProfiles[1].name);
+            swrText_CreateTextEntry1(100, (int)(rowYf + 9.0f), -0x5d, -0x42, 0x11, alpha, buffer);
+        } else {
+            text = swrText_Translate("~r~s%d:");
+            sprintf(buffer, text, (int)(short)score->results_P1_Position);
+            swrText_CreateTextEntry1(0x58, textY, 0x32, -1, -1, alpha, buffer);
+            text = swrText_Translate("~f4~s%s %s");
+            sprintf(buffer, text, swrText_Translate(swrRacer_PodData[pilot].name),
+                    swrText_Translate(swrRacer_PodData[pilot].lastname));
+            swrText_CreateTextEntry1(0x5c, (int)(rowYf + 1.0f), 0x32, -1, -1, alpha, buffer);
+            swrText_CreateTimeEntryFormat(0x109, textY, score->results_P1_total_time, 0x32, -1, -1, alpha, 1);
+        }
+        rowY += 0x1e;
+    }
+    if (4 < hang->num_players)
+        swrRace_DrawScrollbar(0x122, 0x1e, 0x90);
+    if (0 < swrRace_TournamentTrugutGain) {
+        text = swrText_Translate("/SCREENTEXT_575/~c~sYou won %d Truguts!");
+        sprintf(buffer, text, swrRace_TournamentTrugutGain);
+        swrText_CreateColorlessEntry1(0x87, 0xcd, buffer);
+        swrObjHang_PositionHoloNode(0, 7.0f, -7.0f, 1.0f);
+    }
+
+    state2 = swrObjHang_state2;
+    for (k = 0; k < hang->num_local_players; k++) {
+        if (swrControl_acceptPressedEdge != 0 || swrControl_cancelPressedEdge != 0) {
+            swrUI_RunCallbacks2(swrUI_GetUI1(), 1);
+            playUISound(0x54);
+            if (hang->isTournamentMode == 0) {
+                // multiplayer results return to the lobby flow (SELECT_PLANET - 11)
+                state2 = swrMultiplayer_IsMultiplayerEnabled() != 0
+                             ? (swrObjHang_STATE)(swrObjHang_STATE_SELECT_PLANET - 11)
+                             : swrObjHang_STATE_SELECT_PLANET;
+                swrObjHang_state2 = state2;
+            } else if (swrRace_resultsPlaceP1 < 4 && swrObjHang_trackInCircuitIdx == 6) {
+                // circuit final won: podium ceremony with the top three pilots
+                for (i = 0; i < 3; i++)
+                    hang->podiumCharacters[i] = *(char*)swrRace_resultsSortedScores[i]->unk18;
+                state2 = swrObjHang_STATE_PODIUM;
+                swrObjHang_state2 = state2;
+            } else {
+                state2 = swrObjHang_STATE_SELECT_PLANET;
+                swrObjHang_state2 = state2;
+            }
+        }
+        g_bCircuitIdxInRange = 0;
+        swrUI_menuScrolled = 0;
+        if (4 < hang->num_players) {
+            // analog scroll through the standings
+            if (swrControl_aPlayerAxisY[k] < -0.1f || 0.1f < swrControl_aPlayerAxisY[k]) {
+                swrRace_resultsScrollY -= swrControl_aPlayerAxisY[k] * swrRace_fdeltaTimeSecs * -300.0f;
+                if (0.0f < swrRace_resultsScrollY)
+                    swrRace_resultsScrollY = 0.0f;
+                if (swrRace_resultsScrollY < 150.0f - (float)hang->num_players * 30.0f)
+                    swrRace_resultsScrollY = 150.0f - (float)hang->num_players * 30.0f;
+            }
+            swrUI_menuScrolled = (uint32_t)(swrRace_resultsScrollY < 0.0f);
+            if ((float)g_CircuitIdxMax < swrRace_resultsScrollY)
+                g_bCircuitIdxInRange = 1;
+        }
+    }
+    if (state2 != ~swrObjHang_STATE_LEGAL) {
+        // a state transition is pending: reset the one-shot latches for the next results screen
+        swrRace_resultsStateFlags = 0;
+        swrObjHang_camFocusIdx = -1;
+    }
 }
 
 // 0x0043b240
@@ -329,10 +683,399 @@ void swrRace_CourseSelectionMenu(void)
     HANG("TODO");
 }
 
+// Course info screen (after track select): builds the option-row list on entry (mirror /
+// winnings / laps / racers / AI speed / demo / cutscene, depending on mode), draws the rows,
+// the planet hologram + track preview, the track name, both save-image records (3-lap + best
+// lap, with holder name + pod sprite), the track's favorite pilot, and the tournament
+// "must place N" hint; then handles option cycling and the start/back transitions.
 // 0x0043b880
 void swrRace_CourseInfoMenu(swrObjHang* hang)
 {
-    HANG("TODO");
+    char* text;
+    char* valueText;
+    int rowY;
+    int prizeY;
+    int recordIdx;
+    int trackInCircuit;
+    int prize;
+    int width;
+    int colR;
+    int colG;
+    int colB;
+    int i;
+    char itemCount;
+    char required;
+    char pilot;
+    uint8_t favoritePilot;
+    char buffer[64];
+
+    if ((uint8_t)nb_AI_racers == 0)
+        nb_AI_racers = (nb_AI_racers & ~0xff) | 0xc;
+    if (swrObjHang_splitscreenRacerCount == 0)
+        swrObjHang_splitscreenRacerCount = 2;
+
+    itemCount = swrObjHang_courseInfoItemCount;
+    if (swrObjHang_menuJustEntered != 0) {
+        swrObjHang_menuJustEntered = 0;
+        swrObjHang_FocusMenuItem(hang, 0x25, ~swrObjHang_STATE_LEGAL, 0);
+        swrObjHang_courseInfoSelectedRow = 0;
+        swrObjHang_courseInfoLeaving = 0;
+        if (hang->menuScreenPrev == swrObjHang_STATE_SELECT_PLANET)
+            swrRace_Transition = 1.0f;
+        swrUI_Front_HandleCircuits(hang);
+        if (hang->menuScreenPrev != swrObjHang_STATE_SELECT_PLANET)
+            swrUI_Front_SeekToCurrentTrack_Maybe(hang);
+        for (i = 0; i < 12; i++)
+            swrObjHang_courseInfoItemKinds[i] = -1;
+        swrObjHang_courseInfoItemCount = 0;
+        if (swrUI_Front_BeatEverything1stPlace(hang)) {
+            swrObjHang_courseInfoItemKinds[(int)swrObjHang_courseInfoItemCount] = 0; // mirror toggle
+            swrObjHang_courseInfoItemCount++;
+        }
+        if (hang->isTournamentMode == 0) {
+            itemCount = swrObjHang_courseInfoItemCount + 1;
+            swrObjHang_courseInfoItemKinds[(int)swrObjHang_courseInfoItemCount] = 2; // laps
+            if (hang->timeAttackMode == 0) {
+                swrObjHang_courseInfoItemCount += 2;
+                swrObjHang_courseInfoItemKinds[itemCount] = 3; // racers
+                swrObjHang_courseInfoItemKinds[(int)swrObjHang_courseInfoItemCount] = 4; // AI speed
+                itemCount = swrObjHang_courseInfoItemCount + 1;
+            }
+        } else {
+            trackInCircuit = VerifySelectedTrack(hang, swrRace_MenuSelectedItem);
+            if (isTrackUnlocked(hang->circuitIdx, (char)trackInCircuit) != 0) {
+                swrObjHang_courseInfoItemKinds[(int)swrObjHang_courseInfoItemCount] = 1; // winnings
+                itemCount = swrObjHang_courseInfoItemCount + 1;
+            } else {
+                itemCount = swrObjHang_courseInfoItemCount;
+            }
+        }
+    }
+    swrObjHang_courseInfoItemCount = itemCount;
+
+    trackInCircuit = VerifySelectedTrack(hang, swrRace_MenuSelectedItem);
+    required = GetRequiredPlaceToProceed(hang->circuitIdx, (char)trackInCircuit);
+
+    rowY = 0xa0;
+    if (swrObjHang_courseInfoLeaving == 0 && 0 < swrObjHang_courseInfoItemCount) {
+        for (i = 0; i < swrObjHang_courseInfoItemCount; i++) {
+            valueText = NULL;
+            switch (swrObjHang_courseInfoItemKinds[i]) {
+            case 0: // mirror
+                text = swrText_Translate(g_pTxtMirror);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                valueText = swrText_Translate(hang->bMirror == 0 ? g_pTxtOff : g_pTxtOn);
+                break;
+            case 1: // tournament winnings + prize table
+                if (hang->WinningsID == 1)
+                    text = swrText_Translate(g_pTxtFair);
+                else if (hang->WinningsID == 2)
+                    text = swrText_Translate(g_pTxtSkilled);
+                else
+                    text = swrText_Translate(g_pTxtWinnerTakesAll);
+                sprintf(buffer, text);
+                text = swrText_Translate(g_pTxtWinnings);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                swrUI_Front_TextMenu(hang, 0x55, rowY, 10, swrObjHang_courseInfoSelectedRow, i, buffer);
+                prizeY = rowY + 10;
+                text = swrText_Translate(g_pTxt1st);
+                swrUI_Front_TextMenu(hang, 0x2d, prizeY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                text = swrText_Translate(g_pTxt2nd);
+                swrUI_Front_TextMenu(hang, 0x2d, rowY + 0x14, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                text = swrText_Translate(g_pTxt3rd);
+                swrUI_Front_TextMenu(hang, 0x2d, rowY + 0x1e, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                if (required == 4) {
+                    text = swrText_Translate(g_pTxt4th);
+                    swrUI_Front_TextMenu(hang, 0x2d, rowY + 0x28, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                }
+                for (prize = 0; prize < required; prize++) {
+                    // prize scales with the circuit: x1.0 / x1.5 / x2.0 / x2.5
+                    int truguts = (int)((1.0 - (double)(int)hang->circuitIdx * -0.5) *
+                                        (double)(int)hang->winnings.truguts[hang->WinningsID - 1][prize]);
+                    text = swrText_Translate("~f0~r~s%d");
+                    sprintf(buffer, text, truguts);
+                    swrUI_Front_TextMenu(hang, 0x69, prizeY, 10, swrObjHang_courseInfoSelectedRow, i, buffer);
+                    prizeY += 10;
+                }
+                continue;
+            case 2: // laps
+                text = swrText_Translate("~f0~s%d");
+                sprintf(buffer, text, (int)hang->numLaps);
+                text = swrText_Translate(g_pTxtLaps);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                valueText = buffer;
+                break;
+            case 3: // racer count
+                text = swrText_Translate("~f0~s%d");
+                sprintf(buffer, text, (int)(uint8_t)nb_AI_racers);
+                if (1 < hang->num_local_players) {
+                    text = swrText_Translate("~f0~s%d");
+                    sprintf(buffer, text, (int)(uint8_t)swrObjHang_splitscreenRacerCount);
+                }
+                text = swrText_Translate(g_pTxtRacers);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                valueText = buffer;
+                break;
+            case 4: // AI speed
+                if (hang->AISpeed == 1)
+                    text = swrText_Translate(g_pTxtSlow);
+                else if (hang->AISpeed == 2)
+                    text = swrText_Translate(g_pTxtAverage);
+                else
+                    text = swrText_Translate(g_pTxtFast);
+                sprintf(buffer, text);
+                text = swrText_Translate(g_pTxtAISpeed);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                valueText = buffer;
+                break;
+            case 5: // demo mode
+                rowY += 10;
+                text = swrText_Translate(g_pTxtDemoMode);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                valueText = swrText_Translate(hang->demo_mode == 0 ? g_pTxtOff : g_pTxtOn);
+                break;
+            case 6: // cutscene selector
+                if (hang->unk68_type < 0) {
+                    text = swrText_Translate(g_pTxtOff2);
+                    sprintf(buffer, text);
+                } else {
+                    text = swrText_Translate("~s%d");
+                    sprintf(buffer, text, hang->unk68_type + 1);
+                }
+                text = swrText_Translate(g_pTxtCutscene);
+                swrUI_Front_TextMenu(hang, 0x1e, rowY, 10, swrObjHang_courseInfoSelectedRow, i, text);
+                valueText = buffer;
+                break;
+            default:
+                continue;
+            }
+            swrUI_Front_TextMenu(hang, 0x55, rowY, 10, swrObjHang_courseInfoSelectedRow, i, valueText);
+        }
+    }
+
+    swrObjHang_StepTransition(swrObjHang_courseInfoLeaving == 0 ? 3.3f : -3.3f);
+    if (0.0f < swrRace_Transition)
+        DrawHoloPlanet(hang, (int)(char)g_aTrackInfos[(int)hang->track_index].PlanetIdx,
+                       swrRace_Transition * 0.5f);
+    if (swrObjHang_courseInfoLeaving != 0)
+        return;
+    DrawTrackPreview(hang, (int)hang->track_index, 0.5f);
+    if (swrObjHang_courseInfoLeaving != 0)
+        return;
+
+    if (g_aTrackInfos[(int)hang->track_index].trackID == (INGAME_MODELID)~INGAME_MODELID_loc_watto_part ||
+        g_aTrackInfos[(int)hang->track_index].splineID == (SPLINEID)~SPLINEID_planetd_track) {
+        // no model/spline assigned: flashing "planet not loaded" warning
+        text = swrText_Translate(g_pTxtPlanetNotLoaded);
+        sprintf(buffer, text);
+        colB = (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 256.0f);
+        colG = (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 256.0f);
+        colR = (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 256.0f);
+        swrText_CreateTextEntry1(0xa0, 0xcd, colR, colG, colB, -1, buffer);
+    }
+    text = swrUI_Front_GetTrackNameFromId((int)hang->track_index);
+    valueText = swrText_Translate("~c~s%s");
+    sprintf(buffer, valueText, text);
+    swrText_CreateTextEntry1(0xa0, 0x25, 0, -1, 0, -1, buffer);
+    swrText_GetStringWidthByFont(buffer, 0); // result unused in the original too
+    width = swrText_GetStringWidthByFont(buffer, 0);
+    swrUI_Front_MenuAxisHorizontal((void*)(int)(160.0 - (double)width * 0.5), 0x26);
+
+    swrUI_Front_DrawRecord(hang, 100, 0x37, 255.0f, 0);
+    swrUI_Front_DrawRecord(hang, 0xdc, 0x37, 255.0f, 3);
+    // 3-lap record holder: pilot name + pod sprite
+    recordIdx = hang->bMirror + hang->track_index * 2;
+    if (swrRace_saveData.record3LapTimes[recordIdx] < ELFSAVE_RECORD_TIME_EMPTY) {
+        pilot = swrRace_saveData.record3LapPilots[recordIdx];
+        text = swrText_Translate("~f4~c~s%s %s");
+        sprintf(buffer, text, swrText_Translate(swrRacer_PodData[(int)pilot].name),
+                swrText_Translate(swrRacer_PodData[(int)pilot].lastname));
+        swrText_CreateTextEntry1(100, 0x4e, -0x5d, -0x42, 0x11, -1, buffer);
+        swrSprite_SetVisible((short)(pilot + 0x17), 1);
+        swrSprite_SetPos((short)(pilot + 0x17), 0x54, 0x55);
+        swrSprite_SetDim((short)(pilot + 0x17), 0.5f, 0.5f);
+        swrSprite_SetColor((short)(pilot + 0x17), 0xff, 0xff, 0xff, 0xff);
+    }
+    // best-lap record holder
+    if (swrRace_saveData.recordLapTimes[recordIdx] < ELFSAVE_RECORD_TIME_EMPTY) {
+        pilot = swrRace_saveData.recordLapPilots[recordIdx];
+        text = swrText_Translate("~f4~c~s%s %s");
+        sprintf(buffer, text, swrText_Translate(swrRacer_PodData[(int)pilot].name),
+                swrText_Translate(swrRacer_PodData[(int)pilot].lastname));
+        swrText_CreateTextEntry1(0xdc, 0x4e, -0x5d, -0x42, 0x11, -1, buffer);
+        swrSprite_SetVisible((short)(pilot + 0x2e), 1);
+        swrSprite_SetPos((short)(pilot + 0x2e), 0xcc, 0x55);
+        swrSprite_SetDim((short)(pilot + 0x2e), 0.5f, 0.5f);
+        swrSprite_SetColor((short)(pilot + 0x2e), 0xff, 0xff, 0xff, 0xff);
+    }
+    // track favorite
+    favoritePilot = g_aTrackInfos[(int)hang->track_index].FavoritePilot;
+    text = swrText_Translate(g_pTxtTrackFavorite);
+    swrText_CreateTextEntry1(0xf0, 0x82, 0x32, -1, -1, -1, text);
+    text = swrText_Translate("~f4~c~s%s %s");
+    sprintf(buffer, text, swrText_Translate(swrRacer_PodData[(char)favoritePilot].name),
+            swrText_Translate(swrRacer_PodData[(char)favoritePilot].lastname));
+    swrText_CreateTextEntry1(0xf0, 0x89, -0x5d, -0x42, 0x11, -1, buffer);
+    swrSprite_SetVisible((short)(char)favoritePilot, 1);
+    swrSprite_SetPos((short)(char)favoritePilot, 0xd0, 0x91);
+    swrSprite_SetDim((short)(char)favoritePilot, 1.0f, 1.0f);
+    swrSprite_SetColor((short)(char)favoritePilot, 0xff, 0xff, 0xff, 0xff);
+    if (hang->isTournamentMode != 0) {
+        trackInCircuit = VerifySelectedTrack(hang, swrRace_MenuSelectedItem);
+        if (isTrackUnlocked(hang->circuitIdx, (char)trackInCircuit) != 0) {
+            text = swrText_Translate(required == 3 ? g_pTxtMinPlace3rd : g_pTxtMinPlace4th);
+            swrText_CreateTextEntry1(0xa0, 0x73, -0x5d, -0x42, 0x11, -1, text);
+        }
+    }
+
+    if (swrObjHang_courseInfoLeaving == 0 && 1.0f <= swrRace_Transition) {
+        // the original iterates a single element: only player 1's pressed bitset
+        int* pressed = swrUI_localPlayersInputPressedBitset;
+        if (swrMultiplayer_menuOverlayActive == 0) {
+            if (swrControl_menuAcceptPressedEdge != 0 &&
+                (swrMultiplayer_IsMultiplayerEnabled() == 0 || swrMultiplayer_IsHost() != 0) &&
+                swrObjHang_menuAcceptLock == 0) {
+                playUISound(0x54);
+                if (hang->isTournamentMode == 0) {
+                    if (hang->timeAttackMode != 0) {
+                        hang->num_players = 1;
+                    } else if (hang->num_local_players < 2) {
+                        if (hang->demo_mode != 0 && (uint8_t)nb_AI_racers == 2)
+                            hang->num_players = 1;
+                        else
+                            hang->num_players = (uint8_t)nb_AI_racers;
+                    } else {
+                        hang->num_players = swrObjHang_splitscreenRacerCount;
+                    }
+                } else {
+                    hang->num_players = 12;
+                }
+                swrObjHang_InitTrackSprites(hang, 0);
+                swrObjHang_FocusMenuItem(hang, 0x24, swrObjHang_STATE_MAIN_MENU, 0);
+                swrObjHang_courseInfoLeaving = 1;
+                return;
+            }
+            if (swrControl_cancelPressedEdge != 0 && swrObjHang_menuAcceptLock == 0) {
+                playUISound(0x4d);
+                swrObjHang_InitTrackSprites(hang, 0);
+                swrObjHang_SetMenuState(hang, swrObjHang_STATE_SELECT_PLANET);
+                return;
+            }
+        }
+        if (1 < swrObjHang_courseInfoItemCount) {
+            if ((*pressed & swrUI_INPUT_MENU_UP) != 0) {
+                swrObjHang_courseInfoSelectedRow--;
+                playUISound(0x58);
+            }
+            if ((*pressed & swrUI_INPUT_MENU_DOWN) != 0) {
+                swrObjHang_courseInfoSelectedRow++;
+                playUISound(0x58);
+            }
+            if (swrObjHang_courseInfoSelectedRow < 0)
+                swrObjHang_courseInfoSelectedRow = swrObjHang_courseInfoItemCount - 1;
+            if (swrObjHang_courseInfoItemCount - 1 < swrObjHang_courseInfoSelectedRow)
+                swrObjHang_courseInfoSelectedRow = 0;
+        }
+        if (0 < swrObjHang_courseInfoItemCount) {
+            if ((*pressed & swrUI_INPUT_MENU_RIGHT) != 0) {
+                switch (swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoSelectedRow]) {
+                case 0:
+                    hang->bMirror = hang->bMirror == 0;
+                    break;
+                case 1:
+                    hang->WinningsID++;
+                    break;
+                case 2:
+                    hang->numLaps++;
+                    break;
+                case 3:
+                    if (hang->num_local_players < 2) {
+                        // 1 <-> 2 <-> 4 <-> 8 <-> 12 racers
+                        if ((uint8_t)nb_AI_racers == 8)
+                            nb_AI_racers = (nb_AI_racers & ~0xff) | 0xc;
+                        else if ((uint8_t)nb_AI_racers == 0xc)
+                            nb_AI_racers = (nb_AI_racers & ~0xff) | 1;
+                        else
+                            nb_AI_racers = (nb_AI_racers & ~0xff) | (uint8_t)((uint8_t)nb_AI_racers << 1);
+                    } else {
+                        swrObjHang_splitscreenRacerCount += 2;
+                        if (swrObjHang_splitscreenRacerCount == 8)
+                            swrObjHang_splitscreenRacerCount = 2;
+                    }
+                    break;
+                case 4:
+                    hang->AISpeed++;
+                    break;
+                case 5:
+                    hang->demo_mode = hang->demo_mode == 0;
+                    break;
+                case 6:
+                    hang->unk68_type++;
+                    break;
+                }
+                playUISound(0x58);
+            }
+            if ((*pressed & swrUI_INPUT_MENU_LEFT) != 0) {
+                switch (swrObjHang_courseInfoItemKinds[swrObjHang_courseInfoSelectedRow]) {
+                case 0:
+                    hang->bMirror = hang->bMirror == 0;
+                    break;
+                case 1:
+                    hang->WinningsID--;
+                    break;
+                case 2:
+                    hang->numLaps--;
+                    break;
+                case 3:
+                    if (hang->num_local_players < 2) {
+                        if ((uint8_t)nb_AI_racers == 0xc)
+                            nb_AI_racers = (nb_AI_racers & ~0xff) | 8;
+                        else if ((uint8_t)nb_AI_racers == 1)
+                            nb_AI_racers = (nb_AI_racers & ~0xff) | 0xc;
+                        else
+                            nb_AI_racers = (nb_AI_racers & ~0xff) | (uint8_t)((uint8_t)nb_AI_racers >> 1);
+                    } else {
+                        swrObjHang_splitscreenRacerCount -= 2;
+                        if (swrObjHang_splitscreenRacerCount == 0)
+                            swrObjHang_splitscreenRacerCount = 6;
+                    }
+                    break;
+                case 4:
+                    hang->AISpeed--;
+                    break;
+                case 5:
+                    hang->demo_mode = hang->demo_mode == 0;
+                    break;
+                case 6:
+                    hang->unk68_type--;
+                    break;
+                }
+                playUISound(0x58);
+            }
+        }
+        // wrap the cycling options
+        if (hang->numLaps < 1)
+            hang->numLaps = 5;
+        if (5 < hang->numLaps)
+            hang->numLaps = 1;
+        if (hang->AISpeed < 1)
+            hang->AISpeed = 3;
+        if (3 < hang->AISpeed)
+            hang->AISpeed = 1;
+        if (hang->WinningsID < 1)
+            hang->WinningsID = 3;
+        if (3 < hang->WinningsID)
+            hang->WinningsID = 1;
+        if (hang->unk68_type < -1)
+            hang->unk68_type = 0x14;
+        if (0x14 < hang->unk68_type)
+            hang->unk68_type = -1;
+
+        if (swrMultiplayer_IsMultiplayerEnabled() == 0 || swrMultiplayer_IsHost() != 0) {
+            g_LoadTrackModel = g_aTrackInfos[(int)hang->track_index].trackID;
+            swrMultiplayer_BroadcastPlayerState();
+        }
+    }
 }
 
 // 0x0043d720
@@ -392,16 +1135,16 @@ void swrRace_GenerateDefaultDataSAV(int user_tgfd, int slot)
     profile->pilotsUnlocked = ELFSAVE_DEFAULT_PILOTS;
     profile->unk3c = 0;
     profile->linkedToSave = 1;
-    profile->unlockData[0] = 0;
+    profile->pilotId = 0;
     profile->saveSlot = (uint8_t)slot;
     profile->beatTrackPlace[0] = 0;
     profile->beatTrackPlace[1] = 0;
     profile->beatTrackPlace[2] = 0;
     profile->beatTrackPlace[3] = 0;
-    profile->unlockData[1] = 1;
-    profile->unlockData[2] = 1;
-    profile->unlockData[3] = 1;
-    profile->unlockData[4] = 0;
+    profile->tracksUnlocked[0] = 1;
+    profile->tracksUnlocked[1] = 1;
+    profile->tracksUnlocked[2] = 1;
+    profile->circuitsCompleted = 0;
     for (i = 0; i < 7; i++) {
         profile->upgradeLevels[i] = 0;
         profile->upgradeHealths[i] = -1;
@@ -413,6 +1156,12 @@ void swrRace_GenerateDefaultDataSAV(int user_tgfd, int slot)
 
 // 0x0043f380
 void swrRace_BuyPitdroidsMenu(swrObjHang* hang)
+{
+    HANG("TODO");
+}
+
+// 0x0043fe90
+void swrRace_DrawScrollbar(short x, short y, int height)
 {
     HANG("TODO");
 }

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -4,14 +4,23 @@
 #include "swrModel.h"
 #include "swrSpline.h"
 #include "swrEvent.h"
+#include "swrText.h"
+#include "swrSound.h"
+#include "swrSprite.h"
 #include "macros.h"
+#include "engine_config.h"
 #include "globals.h"
 
 #include <General/stdMath.h>
 #include <General/utils.h>
+#include <General/stdFileUtil.h>
+#include <General/stdFnames.h>
 #include <Primitives/rdVector.h>
 #include <Primitives/rdMatrix.h>
 #include <Unknown/rdMatrixStack.h>
+
+#include <stdio.h>
+#include <string.h>
 
 // 0x00401340
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4)
@@ -41,6 +50,154 @@ int swrRace_SettingsMenu(void)
 swrRace_TRACK swrRace_GetSelectedTrack(void)
 {
     return multiplayer_track_select;
+}
+
+// 0x00421810
+void swrRace_InitGameData(void)
+{
+    if (!swrRace_LoadGameData()) {
+        swrRace_ResetGameData(1);
+        if (!swrRace_SaveGameData())
+            (*stdPlatform_hostServices_ptr->assert)("elfSaveLoad_SaveThisGameStruct()",
+                                                    "D:\\devel.QA5\\pc_gnome\\SpecPlat\\rdroid_gnome\\Source\\elfSaveLoad.c", 0x4f);
+    }
+    swrRace_CopyProfileFromSave(0, 0);
+}
+
+// 0x00421850
+bool swrRace_LoadProfileFromFile_Maybe(char* playerName)
+{
+    FILE* stream;
+    int failed;
+    int version;
+    swrSaveProfile profile;
+    char path[256];
+
+    version = 0;
+    failed = 0;
+    sprintf(path, "%s%s", ".\\data\\player\\", playerName);
+    stdFnames_ChangeExt(path, "sav");
+    stream = fopen(path, "rb");
+    if (stream == NULL) {
+        failed = 1;
+    } else {
+        if (fread(&version, 1, 4, stream) == 0 || version != ELFSAVE_VERSION_MAGIC ||
+            fread(&profile, 1, sizeof(swrSaveProfile), stream) == 0)
+            failed = 1;
+        fclose(stream);
+    }
+    if (failed == 0) {
+        swrRace_saveData.profiles[0] = profile;
+        swrRace_profileLoaded = 0;
+        swrRace_saveData.profiles[0].unk3c = 0;
+        sprintf(swrRace_playerName, "%s", profile.name);
+        swrRace_CopyProfileFromSave(0, 0);
+    }
+    return failed == 0;
+}
+
+// 0x004219d0
+bool swrRace_SaveProfile(char* playerName)
+{
+    FILE* stream;
+    size_t wroteMagic;
+    size_t wroteProfile;
+    int version;
+    swrSaveProfile profile;
+    char path[256];
+
+    version = ELFSAVE_VERSION_MAGIC;
+    profile = swrRace_saveData.profiles[0];
+    if (swrRace_profileLoaded < 0)
+        return false;
+    sprintf(path, "%s%s", ".\\data\\player\\", playerName);
+    stdFnames_ChangeExt(path, "sav");
+    stream = fopen(path, "wb");
+    if (stream == NULL)
+        return false;
+    wroteMagic = fwrite(&version, 1, 4, stream);
+    wroteProfile = fwrite(&profile, 1, sizeof(swrSaveProfile), stream);
+    fclose(stream);
+    return wroteProfile != 0 && wroteMagic != 0;
+}
+
+// 0x00421b20
+int swrRace_ResetGameData(int resetCurrentPlayer)
+{
+    swrSaveProfile profile;
+
+    profile = swrRace_saveData.profiles[0];
+    swrRace_InitDefaultGameData(&swrRace_saveData);
+    if (resetCurrentPlayer == 0) {
+        swrRace_saveData.profiles[0] = profile;
+        return 1;
+    }
+    swrRace_playerName[0] = wuRegistry_lpClass[0];
+    swrRace_profileLoaded = -1;
+    return 1;
+}
+
+// 0x00421b90
+bool swrRace_LoadGameData(void)
+{
+    FILE* stream;
+    int failed;
+    int version;
+    char path[256];
+
+    version = 0;
+    failed = 0;
+    sprintf(path, "%s%s", ".\\data\\player\\", "tgfd.dat");
+    stream = fopen(path, "rb");
+    if (stream == NULL) {
+        failed = 1;
+    } else {
+        if (fread(&version, 1, 4, stream) == 0 || version != ELFSAVE_VERSION_MAGIC ||
+            fread(&swrRace_saveData, 1, sizeof(swrSaveData), stream) == 0)
+            failed = 1;
+        fclose(stream);
+    }
+    if (failed == 0) {
+        sprintf(swrRace_playerName, "%s", swrRace_saveData.profiles[0].name);
+        swrRace_profileLoaded = (swrRace_playerName[0] != '\0') ? 0 : -1;
+        swrRace_saveData.profiles[0].unk3c = 0;
+        if (swrRace_IsGameDataUninitialized()) {
+            swrRace_CopyProfileToSave(0, 0);
+            swrRace_ResetGameData(0);
+        }
+    }
+    return failed == 0;
+}
+
+// 0x00421c90
+bool swrRace_SaveGameData(void)
+{
+    FILE* stream;
+    size_t wroteMagic;
+    size_t wroteImage;
+    int version;
+    char path[256];
+
+    version = ELFSAVE_VERSION_MAGIC;
+    if (swrRace_IsGameDataUninitialized()) {
+        swrRace_CopyProfileToSave(0, 0);
+        swrRace_ResetGameData(0);
+    }
+    stdFileUtil_MkDir(".\\data\\player\\");
+    sprintf(path, "%s%s", ".\\data\\player\\", "tgfd.dat");
+    stream = fopen(path, "wb");
+    if (stream == NULL)
+        return false;
+    wroteMagic = fwrite(&version, 1, 4, stream);
+    wroteImage = fwrite(&swrRace_saveData, 1, sizeof(swrSaveData), stream);
+    fclose(stream);
+    return wroteImage != 0 && wroteMagic != 0;
+}
+
+// 0x00421d80
+bool swrRace_IsGameDataUninitialized(void)
+{
+    return swrRace_saveData.pilotsUnlockedGlobal == 0;
 }
 
 // 0x0042a110
@@ -144,6 +301,22 @@ void swrRace_HangarMenu(swrObjHang* hang)
     HANG("TODO");
 }
 
+// Draws a track-record holder name below the record time (swrUI_Front_DrawRecord).
+// The stored name field is 32 chars with no guaranteed NUL (a fresh save holds 32 'A's);
+// the original sprintf's the raw copy and relies on whatever follows it on the stack,
+// so we terminate explicitly instead.
+// 0x00439c70
+void swrRace_DrawRecordText_Maybe(float x, float y, float alpha, char* recordName)
+{
+    char name[33];
+    char buffer[64];
+
+    memcpy(name, recordName, 32);
+    name[32] = '\0';
+    sprintf(buffer, "~f4~c~s%s", name);
+    swrText_CreateTextEntry1((int)x, (int)y, 0x32, -1, -1, (int)alpha, buffer);
+}
+
 // 0x00439ce0
 void swrRace_ResultsMenu(swrObjHang* hang)
 {
@@ -168,10 +341,74 @@ void swrRace_UpdatePartsHealth(void)
     HANG("TODO");
 }
 
+// 0x0043d970
+void swrRace_ResetAllProfiles(void)
+{
+    int i;
+
+    for (i = 0; i < 20; i++)
+        swrRace_GenerateDefaultDataSAV(0, i);
+    for (i = 0; i < 4; i++)
+        swrRace_GenerateDefaultDataSAV(1, i);
+}
+
+// 0x0043d9a0
+void swrRace_CheatUnlockAll(void)
+{
+    if (swrRace_cheatUnlockAllDone == 0) {
+        swrText_ShowTimedMessage("All Pods, tracks unlocked!!!", 3.0f);
+        if (swrRace_cheatUnlockAllDone == 0) {
+            swrRace_cheatUnlockAllDone = 1;
+            swrRace_saveData.unlockFlags |= swrSaveData_UNLOCK_BEAT_ALL_TRACKS_FIRST;
+            g_aBeatTracksGlobal[3] = 0xf;
+            swrRace_saveData.pilotsUnlockedGlobal = 0xfffffff;
+            swrRace_aProfiles[0].pilotsUnlocked = 0xfffffff;
+            swrRace_saveData.profiles[0].pilotsUnlocked = 0xfffffff;
+            g_aBeatTracksGlobal[0] = 0xff;
+            g_aBeatTracksGlobal[1] = 0xff;
+            g_aBeatTracksGlobal[2] = 0xff;
+            swrRace_SaveCurrentProfile();
+        }
+    }
+}
+
 // 0x0043ea00
 void swrRace_GenerateDefaultDataSAV(int user_tgfd, int slot)
 {
-    HANG("TODO");
+    swrSaveProfile* profile;
+    int i;
+
+    if (user_tgfd == 0)
+        profile = &swrRace_aProfiles[slot];
+    else if (user_tgfd == 1)
+        profile = &swrRace_saveData.profiles[slot];
+    else
+        return;
+
+    profile->unk20 = 0;
+    profile->truguts = ELFSAVE_DEFAULT_TRUGUTS;
+    profile->nbPitDroids = 1;
+    profile->unk23 = 0;
+    profile->pilotsUnlocked = ELFSAVE_DEFAULT_PILOTS;
+    profile->unk3c = 0;
+    profile->linkedToSave = 1;
+    profile->unlockData[0] = 0;
+    profile->saveSlot = (uint8_t)slot;
+    profile->beatTrackPlace[0] = 0;
+    profile->beatTrackPlace[1] = 0;
+    profile->beatTrackPlace[2] = 0;
+    profile->beatTrackPlace[3] = 0;
+    profile->unlockData[1] = 1;
+    profile->unlockData[2] = 1;
+    profile->unlockData[3] = 1;
+    profile->unlockData[4] = 0;
+    for (i = 0; i < 7; i++) {
+        profile->upgradeLevels[i] = 0;
+        profile->upgradeHealths[i] = -1;
+    }
+    memset(profile->name, 0, sizeof(profile->name));
+    if (user_tgfd == 1)
+        profile->unk4f = 0;
 }
 
 // 0x0043f380
@@ -889,16 +1126,302 @@ void swrRace_ReplaceBullseyeWithCyYunga(void)
     // TODO easy
 }
 
+// Rebuild the whole save image from scratch: header defaults, per-track record tables
+// (3599.99s times, all-'A' holder names, each track's favorite pilot as holder), the 4 saved
+// profile slots, and finally the checksum.
+// 0x0044e320
+void swrRace_InitDefaultGameData(void* saveImage)
+{
+    swrSaveData* save;
+    int track;
+    int mirror;
+    int idx;
+    int i;
+
+    save = (swrSaveData*)saveImage;
+    memset(save, 0, sizeof(swrSaveData));
+    save->unk4 = 1;
+    save->sfxVolume = 225;
+    save->musicVolume = 200;
+    save->unlockFlags = swrSaveData_UNLOCK_DEFAULT_Maybe;
+    swrRace_saveDefaultsUnk = 0;
+    swr_noop2();
+    save->pilotsUnlockedGlobal = ELFSAVE_DEFAULT_PILOTS;
+    save->beatTracksGlobal[0] = 7;
+    save->beatTracksGlobal[1] = 3;
+    save->beatTracksGlobal[2] = 1;
+    save->beatTracksGlobal[3] = 0;
+    for (track = 0; track < ELFSAVE_NB_TRACKS; track++) {
+        for (mirror = 0; mirror < 2; mirror++) {
+            idx = track * 2 + mirror;
+            save->record3LapTimes[idx] = ELFSAVE_RECORD_TIME_EMPTY;
+            save->recordLapTimes[idx] = ELFSAVE_RECORD_TIME_EMPTY;
+            for (i = 0; i < 32; i++) {
+                save->record3LapNames[idx][i] = 'A';
+                save->recordLapNames[idx][i] = 'A';
+            }
+            save->record3LapPilots[idx] = g_aTrackInfos[track].FavoritePilot;
+            save->recordLapPilots[idx] = g_aTrackInfos[track].FavoritePilot;
+        }
+    }
+    for (i = 0; i < 4; i++)
+        swrRace_GenerateDefaultDataSAV(1, i);
+    // the original hardcodes the global image here, ignoring saveImage
+    swrRace_saveData.checksum = swrRace_ComputeSaveChecksum(&swrRace_saveData);
+}
+
+// 0x0044e440
+unsigned int swrRace_ComputeSaveChecksum(void* saveImage)
+{
+    return swrRace_Crc32((char*)saveImage + 4, sizeof(swrSaveData) - 4);
+}
+
+// 0x0044e460
+unsigned int swrRace_Crc32(void* data, int length)
+{
+    unsigned char* bytes;
+    unsigned int crc;
+
+    if (swrRace_aCrc32Table[1] == 0)
+        swrRace_InitCrc32Table();
+    crc = 0xffffffff;
+    bytes = (unsigned char*)data;
+    for (; length > 0; length--) {
+        crc = (crc << 8) ^ swrRace_aCrc32Table[(crc >> 24) ^ *bytes];
+        bytes++;
+    }
+    return ~crc;
+}
+
+// 0x0044e4a0
+void swrRace_InitCrc32Table(void)
+{
+    unsigned int value;
+    int i;
+    int bit;
+
+    for (i = 0; i < 256; i++) {
+        value = i << 24;
+        for (bit = 8; bit != 0; bit--) {
+            if ((value & 0x80000000) == 0)
+                value = value << 1;
+            else
+                value = (value << 1) ^ 0x4c11db7;
+        }
+        swrRace_aCrc32Table[i] = value;
+    }
+}
+
+// 0x0044e4e0
+void swrRace_BackupGameData(void)
+{
+    swrRace_saveDataBackup = swrRace_saveData;
+}
+
+// 0x0044e500
+void swrRace_CopyProfileFromSave(int workingSlot, int savedSlot)
+{
+    swrRace_aProfiles[workingSlot] = swrRace_saveData.profiles[savedSlot];
+}
+
+// 0x0044e530
+void swrRace_CopyProfileToSave(int savedSlot, int workingSlot)
+{
+    swrRace_saveData.profiles[savedSlot] = swrRace_aProfiles[workingSlot];
+}
+
+// 0x0044e560
+void swrRace_SaveCurrentProfile(void)
+{
+    if (swrRace_aProfiles[0].linkedToSave == 1)
+        swrRace_CopyProfileToSave(swrRace_aProfiles[0].saveSlot, 0);
+    swrRace_CopyProfileToSave(0, 0);
+    swrRace_SaveGameData();
+    swrRace_SaveProfile(swrRace_saveData.profiles[0].name);
+}
+
+// 0x0044e5a0
+void swrRace_GetProfileRecordVec3_Maybe(int base, int index, float* out3)
+{
+    float* rec;
+
+    rec = (float*)(*(int*)(base + 0xc) + index * 0x54 + 0x10);
+    out3[0] = rec[0];
+    out3[1] = rec[1];
+    out3[2] = rec[2];
+}
+
 // 0x004550d0
 void swrRace_VehicleStatisticsSubMenu(void* param_1, float param_2, float param_3)
 {
     HANG("TODO");
 }
 
+// In-race HUD for one local racer: HUD frame sprites, speed readout, the lap-time popup shown
+// for ~4s after each lap (with flickering color, "New Record" blink vs the session-best lap, the
+// fanfare guard flag, and the FINAL LAP banner), the running TIME display when no lap popup is
+// up, the LAP x/y and POS counters, and the speed dial.
 // 0x00460950
-void swrRace_InRaceTimer(void* param_1, void* param_2)
+void swrRace_InRaceTimer(swrScore* score, swrObjJdge* jdge)
 {
-    HANG("TODO");
+    swrRace* pod;
+    char* text;
+    float x;
+    float y;
+    float speed;
+    float lastLapTime;
+    float fade;
+    float flicker;
+    int numLocal;
+    int isPlayer2;
+    int dialY;
+    int lap;
+    int lapShown;
+    int colR;
+    int colG;
+    int colB;
+    int alpha;
+    int lapTimeShown;
+    int blinkLapCounter;
+    char buffer[256];
+
+    dialY = 0xa4;
+    numLocal = NumLocalPlayers();
+    pod = score->obj_test_ptr;
+    isPlayer2 = (score == secondLocalPlayer) ? 1 : 0;
+    if (GetPauseState() == 0) {
+        pod->unk2b8_timer -= (float)swrRace_deltaTimeSecs;
+        if (pod->unk2b8_timer < 0.0f)
+            pod->unk2b8_timer = 0.0f;
+    }
+    swrObjJdge_LayoutHudFrameSprites_Maybe(jdge->hud_mode == 1 ? 5 : (jdge->hud_mode == 0 ? 2 : 0));
+
+    // speed readout
+    x = 254.0f;
+    y = 190.0f;
+    if (numLocal == 2) {
+        x = 277.0f;
+        y = (float)(isPlayer2 * 0x6e + 0x60);
+    }
+    speed = pod->speedValue;
+    if (speed <= 0.0f)
+        speed = 0.0f;
+    text = swrText_Translate("~f2~c~s%.0f");
+    sprintf(buffer, text, (double)speed);
+    swrText_CreateTextEntry1((int)x, (int)y, 0, -0x3d, -2, -2, buffer);
+
+    // lap-time popup panel position
+    if (jdge->hud_mode == 1) {
+        x = 240.0f;
+        y = 30.0f;
+    } else {
+        x = 160.0f;
+        y = 23.0f;
+        if (numLocal == 2)
+            y = (float)(isPlayer2 * 0x6e + 0x14);
+    }
+    lap = score->results_P1_Lap;
+    lapTimeShown = 0;
+    blinkLapCounter = 0;
+    if (0 < lap) {
+        lastLapTime = (&score->results_P1_Lap1)[lap - 1];
+        // the popup fades out over the first 4 seconds of the new lap
+        fade = 1.0f - (&score->results_P1_Lap1)[lap] * 0.25f;
+        if (fade <= 0.0f || 1.0f <= fade) {
+            // popup window over: release the fanfare guard once the sfx cooldown lapses
+            if (swrSound_TestSfxFlag((char)score->sfxChannel, swrSound_SFXFLAG_LAP_FANFARE) != 0 &&
+                swrSound_IsSfxOnCooldown(6, 0) == 0)
+                swrSound_ClearSfxFlag((char)score->sfxChannel, swrSound_SFXFLAG_LAP_FANFARE);
+        } else {
+            flicker = 223.25f;
+            if (pauseState == 0)
+                flicker = (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f;
+            colR = (int)flicker;
+            colG = (int)((float)colR * 0.5f);
+            alpha = (int)(fade * 255.0f) * 8;
+            if (255 < alpha)
+                alpha = 255;
+            text = swrText_Translate("~f3~c~s");
+            swrText_CreateTimeEntry((int)x, (int)y, lastLapTime, colR, colG, 0x40, alpha, text);
+            text = swrText_Translate("/SCREENTEXT_420/~c~sLAP TIME");
+            swrText_CreateTextEntry1((int)x, (int)y + 17, colR, colG, 0x40, alpha, text);
+            if (lastLapTime <= jdge->best_lap_time_ms && ((int)(fade * 16.0f) & 1) != 0) {
+                // this lap tied/beat the session best: blinking "New Record" + one fanfare
+                text = swrText_Translate("/SCREENTEXT_538/~s~cNew Record");
+                swrText_CreateTextEntry1((int)x, (int)y + 25, -0x38, -1, 0, alpha, text);
+                if (swrSound_TestSfxFlag((char)score->sfxChannel, swrSound_SFXFLAG_LAP_FANFARE) == 0) {
+                    swrSound_PlaySfxThrottled(6, 0, 0x27, NULL);
+                    swrSound_SetSfxFlag((char)score->sfxChannel, swrSound_SFXFLAG_LAP_FANFARE);
+                }
+            }
+            lapTimeShown = 1;
+            if (lap + 1 == jdge->num_laps) {
+                if (numLocalPlayers < 2) {
+                    // FINAL LAP banner, fading in over the second half of the popup window
+                    fade = (fade - 0.5f) * 2.0f;
+                    if (0.0f < fade) {
+                        alpha = (int)(fade * 255.0f) * 4;
+                        if (255 < alpha)
+                            alpha = 255;
+                        colR = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 255.0f : 191.25f);
+                        colG = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 255.0f : 191.25f);
+                        colB = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 255.0f : 191.25f);
+                        text = swrText_Translate("/SCREENTEXT_526/~f6~s~cFINAL LAP");
+                        swrText_CreateTextEntry1(0xa0, 0x46, colR, colG, colB, alpha, text);
+                    }
+                } else {
+                    // splitscreen has no room for the banner: blink the LAP counter instead
+                    blinkLapCounter = ((int)(fade * 36.0f) & 1) != 0;
+                }
+            }
+        }
+    }
+    if (lapTimeShown == 0 && numLocal < 2) {
+        // no lap popup: show the running total race time
+        swrRace_hudTimeLabelShown = 0;
+        text = swrText_Translate("~f3~c~s");
+        swrText_CreateTimeEntry((int)x, (int)y, score->results_P1_total_time, -1, -1, -1, -0x42, text);
+        text = swrText_Translate("/SCREENTEXT_422/~c~sTIME");
+        swrText_CreateTextEntry1((int)x, (int)y + 17, -1, -1, -1, -0x42, text);
+    }
+    if (jdge->hud_mode == 6 || jdge->hud_mode == 7)
+        swrText_CreateTimeEntry(0x121, (int)y, score->results_P1_total_time, -1, -1, -1, -0x42, "~f3~r~s");
+
+    // LAP x/y counter
+    x = 62.0f;
+    if (jdge->hud_mode != 1)
+        x = 42.0f;
+    lapShown = lap + 1;
+    if (jdge->num_laps < lapShown)
+        lapShown = jdge->num_laps;
+    text = swrText_Translate("~f3~c~s%d/%d");
+    sprintf(buffer, text, lapShown, jdge->num_laps);
+    if (numLocalPlayers < 2 || blinkLapCounter == 0) {
+        swrText_CreateTextEntry1((int)x, (int)y, -1, -1, -1, -0x42, buffer);
+        text = swrText_Translate("/SCREENTEXT_424/~c~sLAP");
+        swrText_CreateTextEntry1((int)x, (int)y + 17, -1, -1, -1, -0x42, text);
+    } else {
+        swrText_CreateTextEntry1((int)x, (int)y, -1, 0x3f, 0x3f, -1, buffer);
+        text = swrText_Translate("/SCREENTEXT_424/~c~sLAP");
+        swrText_CreateTextEntry1((int)x, (int)y + 17, -1, 0x3f, 0x3f, -1, text);
+    }
+
+    // POS x/y counter (hidden in hud modes 1/6/7)
+    if (jdge->hud_mode != 1 && jdge->hud_mode != 6 && jdge->hud_mode != 7) {
+        if (0 < (short)score->results_P1_Position) {
+            text = swrText_Translate("~f3~c~s%d/%d");
+            sprintf(buffer, text, (int)(short)score->results_P1_Position, jdge->num_players);
+            swrText_CreateTextEntry1(0x116, (int)y, -1, -1, -1, -0x42, buffer);
+        }
+        text = swrText_Translate("/SCREENTEXT_426/~c~sPOS");
+        swrText_CreateTextEntry1(0x116, (int)y + 17, -1, -1, -1, -0x42, text);
+    }
+
+    if (1 < numLocalPlayers && isPlayer2 == 0)
+        dialY = 0x36;
+    swrObjJdge_DrawSpeedDialHud_Maybe((int)jdge, (int)pod, 0xe1, (short)dialY, isPlayer2);
+    if (swrRace_DebugLevel != 0 && assetBufferOverflow != 0)
+        swrText_CreateTextEntry1(0xa0, 0x14, -1, 0, 0, -1, "~c~oZOT");
 }
 
 // 0x004611f0
@@ -907,10 +1430,177 @@ void swrRace_InRaceEngineUI(void* param_1, int param_2)
     HANG("TODO");
 }
 
+// Post-race statistics panel for one local racer: per-lap time rows (the session-best lap
+// flickers), the Total row, and the finishing-place text with the 1st/2nd/3rd medal sprite
+// sliding in against jdge->raceTimer_ms. Also the only writer of jdge->recordLap3_ms: the
+// session-best race total is latched here, in the draw pass, when the shown total beats it.
 // 0x00462320
-void swrRace_InRaceEndStatistics(void* param_1, void* param_2)
+void swrRace_InRaceEndStatistics(swrObjJdge* jdge, swrScore* score)
 {
-    HANG("TODO");
+    char* text;
+    float total;
+    float lapTime;
+    int numLocal;
+    int x;
+    int rowY;
+    int placeY;
+    int textY;
+    int colR;
+    int colG;
+    int colB;
+    int i;
+    short pos;
+    short spriteX;
+    char buf[32];
+
+    numLocal = NumLocalPlayers();
+    if (numLocal == 2) {
+        if (score == firstLocalPlayer) {
+            rowY = 0x69;
+            placeY = 0x1e;
+            for (i = 0xf; i < 0x13; i++)
+                swrSprite_SetVisible((short)i, 0);
+        } else {
+            rowY = 0xd7;
+            placeY = 0x8c;
+            for (i = 0x13; i < 0x17; i++)
+                swrSprite_SetVisible((short)i, 0);
+        }
+    } else {
+        for (i = 0; i < 0x13; i++)
+            swrSprite_SetVisible((short)i, 0);
+        rowY = 0xd7;
+        placeY = 0x37;
+    }
+    rowY -= jdge->num_laps * 0xe;
+
+    // time-column x scales with the total's digit count
+    total = score->results_P1_total_time;
+    if (total < 60.0f)
+        x = 0x5b;
+    else if (total < 600.0f)
+        x = 0x69;
+    else if (total < 6000.0f)
+        x = 0x73;
+    else if (total < 60000.0f)
+        x = 0x7d;
+    else
+        x = 0x87;
+
+    for (i = 0; i < jdge->num_laps; i++) {
+        lapTime = (&score->results_P1_Lap1)[i];
+        text = swrText_Translate("/SCREENTEXT_211/~sLap");
+        sprintf(buf, "~f4%s", text);
+        swrText_CreateTextEntry1(0x19, rowY + 1, -1, -1, 0, -1, buf);
+        sprintf(buf, "~s%d", i + 1);
+        swrText_CreateTextEntry1(0x2d, rowY, -1, -1, 0, -1, buf);
+        if (jdge->best_lap_time_ms < lapTime) {
+            colR = 0xff;
+            colG = 0x80;
+        } else {
+            // this row is the session-best lap: flicker it
+            if (pauseState == 0)
+                colR = (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f);
+            else
+                colR = (int)223.25f;
+            colG = colR - 0x14;
+        }
+        swrText_CreateTimeEntry(x, rowY - 3, lapTime, colR, colG, 0, -1, "~f1~r~s");
+        rowY += 0xe;
+    }
+
+    if (jdge->recordLap3_ms < total) {
+        colR = 0x32;
+        colG = 0xff;
+        colB = 5;
+    } else {
+        // new session-best race total: latch it and flicker the row
+        jdge->recordLap3_ms = total;
+        if (pauseState == 0)
+            colR = (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 26.0f + 24.0f);
+        else
+            colR = (int)43.5f;
+        if (pauseState == 0)
+            colG = (int)((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f);
+        else
+            colG = (int)223.25f;
+        colB = 0;
+    }
+    text = swrText_Translate("/SCREENTEXT_534/~sTotal: ");
+    sprintf(buf, "~f4%s", text);
+    swrText_CreateTextEntry1(0x19, rowY + 1, -0x10, -1, 0, -1, buf);
+    swrText_CreateTimeEntry(x, rowY - 3, total, colR, colG, colB, -1, "~f1~r~s");
+
+    if (numLocalPlayers < 2) {
+        if (jdge->num_players < 2)
+            return;
+        if (8.0f < jdge->raceTimer_ms) {
+            swrSprite_SetVisible(0xa4, 0);
+            swrSprite_SetVisible(0xa5, 0);
+            swrSprite_SetVisible(0xa6, 0);
+            return;
+        }
+        // finishing-place banner slides in over the first half second and back out after 7.5s
+        x = 0xa0;
+        if (jdge->raceTimer_ms < 0.5f)
+            x = (int)(160.0f - (0.5f - jdge->raceTimer_ms) * 380.0f);
+        if (7.5f < jdge->raceTimer_ms)
+            x = (int)((float)x + (jdge->raceTimer_ms - 7.5f) * 380.0f);
+        textY = placeY;
+        pos = (short)score->results_P1_Position;
+        if (pos < 4) {
+            x -= 0x14;
+            textY = placeY + 0x14;
+            swrSprite_AddDirtyRect(-x + 0x12f, placeY - 0xd, -x + 0x151, placeY + 0x35);
+            spriteX = (short)(0x140 - x);
+            if (pos == 1) {
+                swrSprite_SetVisible(0xa4, 1);
+                swrSprite_SetPos(0xa4, spriteX, (short)placeY);
+            }
+            if (pos == 2) {
+                swrSprite_SetVisible(0xa5, 1);
+                swrSprite_SetPos(0xa5, spriteX, (short)placeY);
+            }
+            if (pos == 3) {
+                swrSprite_SetVisible(0xa6, 1);
+                swrSprite_SetPos(0xa6, spriteX, (short)placeY);
+            }
+        }
+        if (pos == 1)
+            text = "/SCREENTEXT_427/~sst";
+        else if (pos == 2)
+            text = "/SCREENTEXT_428/~snd";
+        else if (pos == 3)
+            text = "/SCREENTEXT_429/~srd";
+        else
+            text = "/SCREENTEXT_430/~sth";
+        text = swrText_Translate(text);
+        colR = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f : 223.25f);
+        colG = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f : 223.25f);
+        colB = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f : 223.25f);
+        sprintf(buf, "~f2~r~s%d", (int)pos);
+        swrText_CreateTextEntry1(x, textY, colR, colG, colB, -2, buf);
+        swrText_CreateTextEntry1(x + 1, textY, colR, colG, colB, -2, text);
+        return;
+    }
+
+    // splitscreen: fixed-position place text, no medal sprite
+    pos = (short)score->results_P1_Position;
+    if (pos == 1)
+        text = "/SCREENTEXT_427/~sst";
+    else if (pos == 2)
+        text = "/SCREENTEXT_428/~snd";
+    else if (pos == 3)
+        text = "/SCREENTEXT_429/~srd";
+    else
+        text = "/SCREENTEXT_430/~sth";
+    text = swrText_Translate(text);
+    colR = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f : 223.25f);
+    colG = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f : 223.25f);
+    colB = (int)(pauseState == 0 ? (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 127.0f + 128.0f : 223.25f);
+    sprintf(buf, "~f2~r~s%d", (int)pos);
+    swrText_CreateTextEntry1(0xa0, placeY, colR, colG, colB, -2, buf);
+    swrText_CreateTextEntry1(0xa1, placeY, colR, colG, colB, -2, text);
 }
 
 // Bitmask of which engine sides have damaged/disabled parts (status bits 0x14):
@@ -1687,7 +2377,7 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
 
         if ((((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) && ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0) &&
             (0.0f <= progress && progress <= 1.0f)) {
-            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0);
             velocity[2] = progress * (splineMat.vD.z - velocity[2]) + velocity[2];
         }
 
@@ -1722,7 +2412,7 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
         player->terrainModel = player->unkec_node;
         player->flags1 = player->flags1 | swrObjTest_FLAG1_GROUND_CACHED;
         if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) {
-            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0);
             velocity[2] = splineMat.vD.z;
         }
         groundDist = 2.0f;
@@ -2529,18 +3219,147 @@ void swrRace_InitFireEffects(int racer, float reset)
     HANG("TODO");
 }
 
+// Overall lap progress in [0..1) for a pod's spline cursor: the current control point's baked
+// progress base plus segmentT scaled by the segment's progress span (spline_progress_values).
+// Closed tracks clamp to just under 1.0 (the wrap is what swrRace_LapCompletion detects);
+// open tracks (swrSpline_finishNodeIdx >= 0) clamp to exactly 1.0 = finished.
 // 0x0047f810
-float swrRace_LapProgress(int a)
+float swrRace_LapProgress(swrSplineCursor* cursor)
 {
-    // TODO
-    return 0.0;
+    int cp;
+    float progress;
+
+    cp = swrSpline_getControlPoint(cursor, 0);
+    progress = cursor->segmentT * spline_progress_values[cp].y + spline_progress_values[cp].x;
+    if (swrSpline_finishNodeIdx < 0) {
+        if (1.0f <= progress)
+            progress = 0.9999f;
+    } else if (1.0f < progress) {
+        progress = 1.0f;
+    }
+    return progress;
 }
 
+// Per-frame lap-progress bookkeeping for one pod; returns true when it crossed the start/finish
+// line this frame. lapCompMax tracks the furthest progress reached; near the line (lapComp < 0.1)
+// it is unwrapped by -1.0 so a crossing shows up as progress overtaking a negative lapCompMax.
+// Remote ('REMO') pods take their progress from the swrMultiplayer_aRemote* arrays instead of
+// the local spline cursor. checkCrossing gates the crossing test (forced on for dead pods).
 // 0x0047fdd0
-bool swrRace_LapCompletion(void* engineData, int param_2)
+bool swrRace_LapCompletion(swrRace* player, int checkCrossing)
 {
-    // See swe1r-decomp
+    swrScore* score;
+    int netSlot;
+    float maxComp;
+    bool crossed;
+
+    if ((player->flags0 & swrObjTest_FLAG0_DEAD) != 0)
+        checkCrossing = 1;
+    player->lapCompPrev = player->lapComp;
+    if (multiplayer_enabled != 0 && (player->flags0 & swrObjTest_FLAG0_REMOTE) != 0) {
+        score = player->score_ptr;
+        netSlot = *(int*)&score->time_unk;
+        player->lapCompMax = swrMultiplayer_aRemoteLapCompMax[netSlot];
+        score->results_P1_Lap = swrMultiplayer_aRemoteLap[netSlot];
+    }
+    if (multiplayer_enabled == 0 || (player->flags0 & swrObjTest_FLAG0_REMOTE) == 0)
+        player->lapComp = swrRace_LapProgress(&player->splineCursor);
+    else
+        player->lapComp = swrMultiplayer_aRemoteLapComp[*(int*)&player->score_ptr->time_unk];
+
+    if (player->moveTick < 9)
+        player->idleTick += (float)swrRace_deltaTimeSecs;
+    else
+        player->idleTick = 0.0f;
+
+    // skip the crossing test when the pod just jumped backward over the line
+    // (progress snapped high while the previous frame was just past it)
+    if (checkCrossing != 0 && (player->lapComp <= 0.8f || 0.1f <= player->lapCompPrev)) {
+        maxComp = player->lapCompMax;
+        if (player->lapComp < 0.1f) {
+            if (0.8f < maxComp)
+                maxComp -= 1.0f;
+            if (0.8f < player->lapCompPrev)
+                player->lapCompPrev -= 1.0f;
+        }
+        if (swrSpline_finishNodeIdx >= 0) {
+            // open (point-to-point) track: done once progress reaches 1.0
+            crossed = 1.0f <= player->lapComp;
+            player->idleTick = 0.0f;
+            player->lapCompMax = player->lapComp;
+            return crossed;
+        }
+        if (maxComp < player->lapComp && player->lapCompPrev - 0.01f <= maxComp) {
+            // a negative (unwrapped) high-water mark being overtaken == line crossed
+            crossed = maxComp < 0.0f;
+            player->idleTick = 0.0f;
+            player->lapCompMax = player->lapComp;
+            return crossed;
+        }
+    }
+    return false;
+}
+
+// 0x0047f890
+swrModel_Node* swrRace_GetTrackMeshAtCursor(swrSplineCursor* cursor)
+{
     HANG("TODO");
+}
+
+// 0x0047f8e0
+void swrRace_AdvanceSplineCursor(swrRace* player, float* outCrossTime, int* outForward, int* outBackward)
+{
+    HANG("TODO");
+}
+
+// 0x0047fbb0
+int swrRace_UpdateSplineBinding(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// 0x0047fca0
+void swrRace_ComputeTrackOffset(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// Per-racer race-progress update (called per racer from swrObjJdge_F2): advances the spline
+// cursor, refreshes the cursor-derived state (track mesh, sample spacing, projections), runs
+// swrRace_LapCompletion, and ticks the forward/backward movement counters. Returns nonzero when
+// the pod completed a lap this frame; *outCrossTime then holds the portion of the frame delta
+// spent before the line crossing (F2 uses it to time laps with sub-frame precision).
+// 0x0047ffb0
+int swrRace_UpdateRaceProgress(swrRace* player, float* outCrossTime)
+{
+    int movedForward;
+    int wentBackward;
+    int binding;
+    int completedLap;
+
+    swrRace_AdvanceSplineCursor(player, outCrossTime, &movedForward, &wentBackward);
+    player->unkf0 = (int)player->unkec_node;
+    player->unkec_node = swrRace_GetTrackMeshAtCursor(&player->splineCursor);
+    // the original passes the cursor, but the retail GetSampleSpacing stub ignores it
+    player->splineSampleSpacing = swrSpline_GetSampleSpacing_Maybe();
+    player->unkf8 = swrSpline_ProjectPointStub_Maybe(&player->splineCursor, &player->unkf4);
+    player->unk100 = swrSpline_ProjectPointStub_Maybe(&player->splineCursor, &player->unkfc);
+    if (player->unkf0 != (int)player->unkec_node)
+        player->unk1f24 = 0;
+    binding = swrRace_UpdateSplineBinding(player);
+    swrRace_ComputeTrackOffset(player);
+    completedLap = swrRace_LapCompletion(player, (movedForward != 0 || binding == 1) ? 1 : 0);
+    if (wentBackward != 0) {
+        player->unk10c++;
+        player->moveTick = 0;
+    }
+    if (movedForward != 0) {
+        player->unk10c = 0;
+        if (wentBackward == 0 && player->moveTick < 200)
+            player->moveTick++;
+    }
+    player->unk10e = (short)binding;
+    return completedLap;
 }
 
 // 0x004804c0

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -244,7 +244,7 @@
 #define swrRace_HandleWallScrapeHit_Maybe_ADDR (0x00479d40)
 #define swrRace_UpdateScrapeContact_Maybe_ADDR (0x0047a3a0)
 #define swrRace_UpdateSplineOrientation_Maybe_ADDR (0x0047a610)
-#define swrRace_GetSplineProgressValue_Maybe_ADDR (0x0047f890)
+#define swrRace_GetTrackMeshAtCursor_ADDR (0x0047f890)
 
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4);
 
@@ -298,8 +298,8 @@ int swrRace_GetLensFlareEnabled(void);
 
 void swrRace_HangarMenu(swrObjHang* hang);
 
-// Formats a record entry and creates the text entry that displays it (best guess).
-void swrRace_DrawRecordText_Maybe(int x, int y, void* recordFields);
+// Draws a record-holder name (32-char field, not NUL-terminated) at x/y with the given alpha.
+void swrRace_DrawRecordText_Maybe(float x, float y, float alpha, char* recordName);
 
 void swrRace_ResultsMenu(swrObjHang* hang);
 
@@ -358,11 +358,11 @@ void swrRace_ReplaceBullseyeWithCyYunga(void);
 
 void swrRace_VehicleStatisticsSubMenu(void* param_1, float param_2, float param_3);
 
-void swrRace_InRaceTimer(void* param_1, void* param_2);
+void swrRace_InRaceTimer(swrScore* score, swrObjJdge* jdge);
 
 void swrRace_InRaceEngineUI(void* param_1, int param_2);
 
-void swrRace_InRaceEndStatistics(void* param_1, void* param_2);
+void swrRace_InRaceEndStatistics(swrObjJdge* jdge, swrScore* score);
 
 void swrRace_Repair(swrRace* player);
 
@@ -556,17 +556,19 @@ void swrRace_ResolvePodCollision(swrRace* player);
 
 void swrRace_TriggerHandler(int player, int a, char b);
 
-float swrRace_LapProgress(int a);
+float swrRace_LapProgress(swrSplineCursor* cursor);
 
-// Returns a component of the spline progress values for a spline cursor (best guess).
-float swrRace_GetSplineProgressValue_Maybe(void* splineCursor);
+// Track mesh (collision model node) under the cursor's current position; cached into
+// player->unkec_node and promoted to player->terrainModel while the ground cache is valid.
+swrModel_Node* swrRace_GetTrackMeshAtCursor(swrSplineCursor* cursor);
 
-bool swrRace_LapCompletion(void* engineData, int param_2);
+bool swrRace_LapCompletion(swrRace* player, int checkCrossing);
 
 // Per-racer race-progress update (called per racer from swrObjJdge_F2): advances the spline
-// cursor, recomputes the current checkpoint segment, runs swrRace_LapCompletion, and ticks the
-// lap counter / off-track recovery timer.
-void swrRace_UpdateRaceProgress(void* engineData, int param_2, int incrementLap, int offTrackTick);
+// cursor, refreshes cursor-derived state, runs swrRace_LapCompletion, and ticks the
+// forward/backward movement counters. Returns nonzero when the pod completed a lap this frame
+// (*outCrossTime = frame-delta portion spent before the crossing, for sub-frame lap timing).
+int swrRace_UpdateRaceProgress(swrRace* player, float* outCrossTime);
 
 void swrRace_IncrementFrameTimer(void);
 
@@ -577,7 +579,7 @@ void swrRace_InitFrameTimer(void);
 // engine-fire FX + spline-cursor track following (per-pod, run during the race tick):
 void swrRace_UpdateFireEffects(swrRace* player);
 void swrRace_InitFireEffects(int racer, float reset);
-void swrRace_AdvanceSplineCursor(swrRace* player, float* outProgress, int* outForward, int* outBackward);
+void swrRace_AdvanceSplineCursor(swrRace* player, float* outCrossTime, int* outForward, int* outBackward);
 int swrRace_UpdateSplineBinding(swrRace* player);
 void swrRace_ComputeTrackOffset(swrRace* player);
 
@@ -585,8 +587,9 @@ void swrRace_ComputeTrackOffset(swrRace* player);
 // Boot entry: load tgfd.dat; on failure rebuild defaults and write a fresh file.
 void swrRace_InitGameData(void);
 
-// Loads a player profile file, validates its magic, reads the profile blob, and copies it into the save image (best guess).
-bool swrRace_LoadProfileFromFile_Maybe(int playerId);
+// Loads .\data\player\<playerName>.sav, validates its magic, and installs the profile blob as
+// saved profile slot 0 + the live working profile.
+bool swrRace_LoadProfileFromFile_Maybe(char* playerName);
 // Read .\data\player\tgfd.dat, verify the 0x10003 version magic, load the 0xfd4-byte image.
 bool swrRace_LoadGameData(void);
 // Create .\data\player\ and write the version magic + 0xfd4-byte image to tgfd.dat.

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -517,6 +517,12 @@ void swrSpline_ResetNodeProgress(int nodeIndex)
     spline_progress_values[nodeIndex].y = 0.0f;
 }
 
+// 0x0047eb50
+int swrSpline_ProjectPointStub_Maybe(void* cursor, int* out)
+{
+    HANG("TODO");
+}
+
 // Returns the .rdata sample-spacing constant at 0x004adf40 (0.0f in retail).
 // 0x0047f800
 float swrSpline_GetSampleSpacing_Maybe(void)

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -776,6 +776,24 @@ void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY)
     }
 }
 
+// 0x0043b1d0
+void swrUI_Front_SeekToCurrentTrack_Maybe(swrObjHang* hang)
+{
+    HANG("TODO");
+}
+
+// 0x00440550
+void playUISound(int soundId)
+{
+    HANG("TODO");
+}
+
+// 0x00440c10
+void swrObjHang_SelectDemoTracks_Maybe(swrObjHang* hang)
+{
+    HANG("TODO");
+}
+
 // Draws one track-record entry on the front-end course screens: heading ("3-Lap Record" /
 // "Best Lap"), the record time from the save image (or a "--:--.--- ---" placeholder while
 // the 3599.99s default is still in place), and the record holder's name. recordKind selects

--- a/src/Swr/swrUI.c
+++ b/src/Swr/swrUI.c
@@ -2,6 +2,7 @@
 
 #include "globals.h"
 #include "swrModel.h"
+#include "swrRace.h"
 #include "swrSprite.h"
 #include "swrText.h"
 
@@ -9,6 +10,7 @@
 #include <Primitives/rdVector.h>
 
 #include <macros.h>
+#include <engine_config.h>
 
 // 0x00408640
 void swrUI_UpdateProgressBar(int progressPercent)
@@ -774,10 +776,39 @@ void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY)
     }
 }
 
+// Draws one track-record entry on the front-end course screens: heading ("3-Lap Record" /
+// "Best Lap"), the record time from the save image (or a "--:--.--- ---" placeholder while
+// the 3599.99s default is still in place), and the record holder's name. recordKind selects
+// the table: 0 = 3-lap record, 3 = best single lap. Records are per track + mirror.
 // 0x004403e0
-void swrUI_Front_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5)
+void swrUI_Front_DrawRecord(swrObjHang* hang, int x, int y, float alpha, char recordKind)
 {
-    HANG("TODO");
+    char* text;
+    char* holderName;
+    float recordTime;
+    int idx;
+
+    if (recordKind == 0) {
+        text = swrText_Translate("/SCREENTEXT_545/~f4~c~s3-Lap Record");
+        swrText_CreateTextEntry1(x, y, 0x32, -1, -1, (int)alpha, text);
+    } else if (recordKind == 3) {
+        text = swrText_Translate("/SCREENTEXT_546/~f4~c~sBest Lap");
+        swrText_CreateTextEntry1(x, y, 0x32, -1, -1, (int)alpha, text);
+    }
+    idx = hang->bMirror + hang->track_index * 2;
+    if (recordKind == 3) {
+        recordTime = swrRace_saveData.recordLapTimes[idx];
+        holderName = swrRace_saveData.recordLapNames[idx];
+    } else {
+        recordTime = swrRace_saveData.record3LapTimes[idx];
+        holderName = swrRace_saveData.record3LapNames[idx];
+    }
+    if (ELFSAVE_RECORD_TIME_EMPTY <= recordTime) {
+        swrText_CreateTextEntry1(x, y + 7, 0x32, -1, -1, (int)alpha, "~c~s--:--.--- ---");
+        return;
+    }
+    swrText_CreateTimeEntryFormat(x + 0x1e, y + 7, recordTime, 0x32, -1, -1, (int)alpha, 1);
+    swrRace_DrawRecordText_Maybe((float)x, (float)(y + 0xf), alpha, holderName);
 }
 
 // 0x00440620

--- a/src/Swr/swrUI.h
+++ b/src/Swr/swrUI.h
@@ -459,7 +459,9 @@ void swrUI_Front_TextMenu(swrObjHang* hang, int posX, int posY, int rowSpacing, 
 
 void swrUI_Front_MenuAxisHorizontal(void* pUnused, short posY);
 
-void swrUI_Front_DrawRecord(swrObjHang* hang, int param_2, int param_3, float param_4, char param_5);
+// Draw one track-record entry (heading, time, holder) on the front-end course screens;
+// recordKind 0 = 3-lap record, 3 = best single lap.
+void swrUI_Front_DrawRecord(swrObjHang* hang, int x, int y, float alpha, char recordKind);
 
 // Selects per-sound volume, pitch, and loop parameters by id and plays the UI sound.
 void playUISound(int soundId);

--- a/src/Swr/swrWeather.c
+++ b/src/Swr/swrWeather.c
@@ -1,0 +1,22 @@
+#include "swrWeather.h"
+
+#include "macros.h"
+#include "globals.h"
+
+// 0x0042d3c0
+void swrWeather_SetVelocity(float vx, float vy)
+{
+    HANG("TODO");
+}
+
+// 0x0042d410
+void swrWeather_SetParticleCap(int max)
+{
+    HANG("TODO");
+}
+
+// 0x0042d430
+void swrWeather_SetStretchFactor(float factor)
+{
+    HANG("TODO");
+}

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -12,4 +12,11 @@
 #define DAALLOC_ARENA_COUNT (0x421)      // number of daAlloc_struct arena slots (1057)
 #define DAALLOC_SMALL_ALLOC_MAX (0x1000) // requests larger than this bypass the arena (daSmallAlloc)
 
+// Save / profile persistence (elfSaveLoad, swrRace.c).
+#define ELFSAVE_VERSION_MAGIC (0x10003)      // 4-byte magic prefixed to tgfd.dat and .sav profile exports
+#define ELFSAVE_NB_TRACKS (25)               // tracks in the record tables (x2 slots each: normal + mirror)
+#define ELFSAVE_RECORD_TIME_EMPTY (3599.99f) // record-slot default; at/above this the UI shows "--:--.---"
+#define ELFSAVE_DEFAULT_PILOTS (0x22e01)     // pilot-unlock bitfield of a fresh profile
+#define ELFSAVE_DEFAULT_TRUGUTS (400)        // starting currency of a fresh profile
+
 #endif // ENGINE_CONFIG_H

--- a/src/types.h
+++ b/src/types.h
@@ -433,6 +433,22 @@ extern "C"
         short flags; // 0x6
     } swrObj; // sizeof(0x8)
 
+    // Runtime cursor walking a spline graph (0x30 bytes). swrObjJdge embeds two
+    // (+0x34 camera follow, +0x134 post-race fly-by), swrRace one at +0xac (lap
+    // progress). See swrSpline_CursorInit / CursorSeek / CursorEvaluate.
+    typedef struct swrSplineCursor
+    {
+        struct swrSpline* spline; // 0x00
+        float velocity; // 0x04 signed; sign selects step direction
+        float segmentT; // 0x08 parameter along the current segment, clamped 0..1
+        float tangentLength; // 0x0c length of the evaluated path tangent
+        int nodeLookahead[4]; // 0x10 current node + 3-level lookahead window
+        int endFlag; // 0x20 set when the forward end of the path is reached
+        int startFlag; // 0x24 set when the backward start of the path is reached
+        int branchSelector; // 0x28
+        int branchFlags; // 0x2c
+    } swrSplineCursor; // sizeof(0x30)
+
     // TODO 0x00475ad0
 
     typedef struct swrRace // swrObjTest
@@ -445,8 +461,8 @@ extern "C"
         char unk1_1[2];
         PodHandlingData podStats;
         char unk4[4];
-        rdMatrix34 unk4_mat; // 0xac. Not a matrix ? LapCompStruct
-        int unkdc;
+        swrSplineCursor splineCursor; // 0xac. lap-progress cursor along the track spline
+        float splineSampleSpacing; // 0xdc. swrSpline_GetSampleSpacing_Maybe at the cursor (refreshed by swrRace_UpdateRaceProgress)
         float lapComp;
         float lapCompPrev;
         float lapCompMax;
@@ -526,7 +542,7 @@ extern "C"
         float engineHealthMin[6]; // engine health related
         float engineHealth[6]; // 0x288 left top-mid-bot, right top-mid-bot
         unsigned int engineStatus[6];
-        char unk2b8[4];
+        float unk2b8_timer; // 0x2b8. ticked down to 0 by swrRace_InRaceTimer while unpaused; setter not yet identified
         float repairTimer; // 0x2bc
         float damageWarningTimer; // 0x2c0
         float totalDamage; // 0x2c4
@@ -598,7 +614,8 @@ extern "C"
         char unk1e74[64];
         int unk1eb4;
         char unk1eb8[64];
-        float unk1ebc;
+        float unk1ef8;
+        int unk1efc;
         float unk1f00;
         int unk1f04;
         int unk1f08;
@@ -608,7 +625,7 @@ extern "C"
         int unk1f1c;
         int unk1f20;
         int unk1f24;
-    } swrRace; // at 0x00e29c44 sizeof(0x1f28)
+    } swrRace; // at 0x00e29c44 sizeof(0x1f28) (tail hole at 0x1ef8 restored 2026-07: unk1f00..unk1f24 sit at their true offsets again)
 
     typedef struct swrObjToss
     {
@@ -731,20 +748,51 @@ extern "C"
         char unkcf;
     } swrObjHang; // sizeof(0xd0)
 
-    // Runtime cursor walking a spline graph (0x30 bytes). swrObjJdge embeds one
-    // at +0x34. See swrSpline_CursorInit / CursorSeek / CursorEvaluate.
-    typedef struct swrSplineCursor
+    // One player profile (0x50 bytes). The live working copies sit in swrRace_aProfiles
+    // (20 slots; [0] = active player, [1] = player 2) and the save image embeds 4 more
+    // (swrSaveData.profiles). swrRace_CopyProfileFromSave / swrRace_CopyProfileToSave move
+    // whole slots between the two.
+    typedef struct swrSaveProfile
     {
-        struct swrSpline* spline; // 0x00
-        float velocity; // 0x04 signed; sign selects step direction
-        float segmentT; // 0x08 parameter along the current segment, clamped 0..1
-        float tangentLength; // 0x0c length of the evaluated path tangent
-        int nodeLookahead[4]; // 0x10 current node + 3-level lookahead window
-        int endFlag; // 0x20 set when the forward end of the path is reached
-        int startFlag; // 0x24 set when the backward start of the path is reached
-        int branchSelector; // 0x28
-        int branchFlags; // 0x2c
-    } swrSplineCursor; // sizeof(0x30)
+        char name[32]; // 0x00. player name, NUL-padded
+        uint8_t unk20; // 0x20
+        uint8_t linkedToSave; // 0x21. 1 = swrRace_SaveCurrentProfile mirrors this profile into save slot `saveSlot`
+        uint8_t saveSlot; // 0x22. save-image profile slot this profile syncs with (defaults to its own index)
+        uint8_t unk23; // 0x23
+        uint8_t unlockData[6]; // 0x24. [1..3] = per-circuit track-unlocked bitmask; [4] = circuit-completion bits (see swrRace_ResultsMenu)
+        uint16_t beatTrackPlace[4]; // 0x2a. per-circuit best finishing place, 2 bits per track
+        char unk32[2]; // 0x32
+        uint32_t pilotsUnlocked; // 0x34. pilot unlock bitfield (default 0x22e01)
+        int truguts; // 0x38. currency (default 400)
+        uint32_t unk3c; // 0x3c. cleared by swrRace_LoadGameData and the profile defaults
+        char nbPitDroids; // 0x40. default 1
+        char upgradeLevels[7]; // 0x41. traction/turning/accel/topspeed/airbrake/cooling/repair
+        char upgradeHealths[7]; // 0x48. 0xff = full health
+        char unk4f; // 0x4f
+    } swrSaveProfile; // sizeof(0x50)
+
+    // In-memory image of .\data\player\tgfd.dat (swrRace_saveData; written to disk verbatim
+    // after a 4-byte 0x10003 version magic). `checksum` covers everything after itself
+    // (swrRace_ComputeSaveChecksum). Record tables are indexed [trackId * 2 + mirrored]
+    // (25 tracks x normal/mirror). Original engine module name: "elfSaveLoad".
+    typedef struct swrSaveData
+    {
+        uint32_t checksum; // 0x000. CRC32 of the 0xfd0 bytes after this field
+        uint8_t unk4; // 0x004. set to 1 by swrRace_InitDefaultGameData
+        uint8_t sfxVolume; // 0x005. default 225 (= sound_sfx_volume)
+        int16_t musicVolume; // 0x006. default 200 (= sound_music_volume)
+        uint32_t unlockFlags; // 0x008. default 3; |= 0x20 once every track is beaten 1st place (swrRace_ResultsMenu, swrRace_CheatUnlockAll)
+        uint8_t beatTracksGlobal[4]; // 0x00c. = g_aBeatTracksGlobal, defaults {7,3,1,0}
+        uint32_t pilotsUnlockedGlobal; // 0x010. union of every profile's pilot unlocks; 0 = image uninitialized (swrRace_IsGameDataUninitialized)
+        swrSaveProfile profiles[4]; // 0x014. saved profile slots
+        float record3LapTimes[50]; // 0x154. per-track 3-lap (full race) record times, default 3599.99
+        float recordLapTimes[50]; // 0x21c. per-track best single-lap record times, default 3599.99
+        char record3LapNames[50][32]; // 0x2e4. record-holder names (default all 'A')
+        char recordLapNames[50][32]; // 0x924
+        char record3LapPilots[50]; // 0xf64. record-holder pilot ids (default = g_aTrackInfos[track].FavoritePilot)
+        char recordLapPilots[50]; // 0xf96
+        char unkfc8[12]; // 0xfc8
+    } swrSaveData; // sizeof(0xfd4)
 
     typedef struct swrObjJdge
     {
@@ -763,10 +811,9 @@ extern "C"
         int hud_mode; // 0x124. annodue: _hud_mode
         int event;
         char unk128[4];
-        void* camSweepState; // 0x12c. post-race camera-sweep state; while non-null F2 walks unk134_mat and F0 gates the finish -> results transition on it
-        rdMatrix44 unk134_mat; // 0x134. post-race fly-by transform, driven by swrSpline_EvaluateToMatrix only while camSweepState != NULL
-        float unk174[11];
-        float unk1a0; // 0x1a0. reset to 1.0 at 'Load'; purpose not yet identified (no reader found in the judge functions)
+        void* camSweepState; // 0x130. post-race camera-sweep state; while non-null F2 walks the fly-by cursor and F0 gates the finish -> results transition on it
+        swrSplineCursor postRaceCursor; // 0x134. post-race fly-by camera path cursor
+        rdMatrix44 postRaceMat; // 0x164. post-race fly-by transform, swrSpline_EvaluateToMatrix(postRaceCursor) while camSweepState != NULL; rows vB..vD identity-initialized at 'Load'
         void* cam_spline;
         int unk1a8;
         int planetId;
@@ -1073,7 +1120,9 @@ extern "C"
 
     typedef struct swrScore
     {
-        float time_unk;
+        float time_unk; // 0x0. for 'REMO' racers this holds the racer's int net slot (swrRace_LapCompletion
+                        // reads it as an int to index the swrMultiplayer_aRemoteLap* arrays; swrObjJdge_F4
+                        // compares it against event payloads as a float)
         int identifier; // 'Locl' (0x4c6f636c) = local player (assigned to firstLocalPlayer..); else AI/remote ('AAll')
         int flag; // 0x1 = active/in-race, 0x2 = finished (ranked by results_P1_total_time once set; see swrObjJdge_GetRacerRankValue)
         char unkc;
@@ -1093,7 +1142,8 @@ extern "C"
         float results_P1_Lap4;
         float results_P1_Lap5;
         float results_P1_total_time;
-        float results_P1_Lap; // 0x78. current lap counter (float; cast to int to index the lap-time array above)
+        int results_P1_Lap; // 0x78. current lap counter (indexes the lap-time array above; incremented as an
+                            // int by swrObjJdge_F2 and loaded via fild in swrObjJdge_GetRacerProgress)
         int unk7c;
         float lastRaceDamage;
         swrRace* obj_test_ptr;

--- a/src/types.h
+++ b/src/types.h
@@ -759,7 +759,10 @@ extern "C"
         uint8_t linkedToSave; // 0x21. 1 = swrRace_SaveCurrentProfile mirrors this profile into save slot `saveSlot`
         uint8_t saveSlot; // 0x22. save-image profile slot this profile syncs with (defaults to its own index)
         uint8_t unk23; // 0x23
-        uint8_t unlockData[6]; // 0x24. [1..3] = per-circuit track-unlocked bitmask; [4] = circuit-completion bits (see swrRace_ResultsMenu)
+        uint8_t pilotId; // 0x24. selected pilot (stamped as record holder by swrRace_ResultsMenu; default 0 = Anakin)
+        uint8_t tracksUnlocked[3]; // 0x25. per-circuit track-unlocked bitmask (bit N = track N; default 1)
+        uint8_t circuitsCompleted; // 0x28. bit c = circuit c finished; bit 3 = invitational circuit unlocked
+        uint8_t unk29; // 0x29
         uint16_t beatTrackPlace[4]; // 0x2a. per-circuit best finishing place, 2 bits per track
         char unk32[2]; // 0x32
         uint32_t pilotsUnlocked; // 0x34. pilot unlock bitfield (default 0x22e01)

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -70,6 +70,25 @@ typedef enum GameSettingFlag
     GAME_SETTING_MIRROR = 0x4000, // mirror-mode: steering + screen projection are flipped
 } GameSettingFlag;
 
+// swrUI_localPlayersInputPressedBitset menu-navigation bits (per-frame pressed edges).
+typedef enum swrUI_INPUTBIT
+{
+    swrUI_INPUT_MENU_UP = 0x4000,
+    swrUI_INPUT_MENU_DOWN = 0x8000,
+    swrUI_INPUT_MENU_LEFT = 0x10000, // decrease the focused option
+    swrUI_INPUT_MENU_RIGHT = 0x20000, // increase the focused option
+} swrUI_INPUTBIT;
+
+// swrRace_resultsStateFlags: one-shot latches while the results screen is up,
+// cleared when leaving it (swrRace_ResultsMenu).
+typedef enum swrRace_RESULTSFLAG
+{
+    swrRace_RESULTSFLAG_NAME_ENTRY_P1 = 0x1, // player 1 was sent to record name entry
+    swrRace_RESULTSFLAG_NAME_ENTRY_P2 = 0x2, // player 2 was sent to record name entry
+    swrRace_RESULTSFLAG_RECORDS_COMMITTED = 0x4, // new records copied into the save image
+    swrRace_RESULTSFLAG_PILOT_UNLOCK_SHOWN = 0x8, // tournament pilot-unlock cutaway triggered
+} swrRace_RESULTSFLAG;
+
 // swrSaveData.unlockFlags (tgfd.dat +0x8) bits.
 typedef enum swrSaveData_UNLOCKFLAGS
 {
@@ -300,6 +319,8 @@ typedef enum swrObjHang_STATE
     swrObjHang_STATE_SELECT_VEHICLE = 9,
     swrObjHang_STATE_SELECT_PLANET = 12,
     swrObjHang_STATE_SELECT_TRACK = 13,
+    swrObjHang_STATE_PODIUM = 16, // tournament awards podium (top-3 pilots in hang->podiumCharacters)
+    swrObjHang_STATE_PILOT_UNLOCK = 17, // "new racer unlocked" cutaway (swrRace_ResultsMenu)
     // more here to 18, but which ones ?
 } swrObjHang_STATE;
 

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -70,6 +70,21 @@ typedef enum GameSettingFlag
     GAME_SETTING_MIRROR = 0x4000, // mirror-mode: steering + screen projection are flipped
 } GameSettingFlag;
 
+// swrSaveData.unlockFlags (tgfd.dat +0x8) bits.
+typedef enum swrSaveData_UNLOCKFLAGS
+{
+    swrSaveData_UNLOCK_DEFAULT_Maybe = 0x3, // present in a fresh save image; meaning not yet identified
+    swrSaveData_UNLOCK_BEAT_ALL_TRACKS_FIRST = 0x20, // every track beaten in 1st place across all circuits
+                                                     // (swrRace_ResultsMenu); also forced by swrRace_CheatUnlockAll
+} swrSaveData_UNLOCKFLAGS;
+
+// Per-racer SFX guard bits (swrSound_SetSfxFlag / TestSfxFlag / ClearSfxFlag on
+// score->sfxChannel): each latches a one-shot line so it isn't spammed.
+typedef enum swrSound_SFXFLAG
+{
+    swrSound_SFXFLAG_LAP_FANFARE = 0x100000, // lap-record / finish fanfare played for this racer
+} swrSound_SFXFLAG;
+
 // swrRace (swrObjTest) flags0 @ +0x60. Bit meanings cross-checked against Ghidra
 // (swrRace_Init/swrRace_AI/swrObjTest_F0/F4) and annodue's Test entity RE.
 typedef enum swrObjTest_FLAG0


### PR DESCRIPTION
Stacked on #273 (its commit is included here; merging that first shrinks this diff to the second commit).

This finishes the times pipeline: `swrRace_ResultsMenu` is where track records actually get committed — it sanitizes and sorts the race scores, sends record-setting guest profiles through name entry, writes new 3-lap / best-lap records into the save image (holder name + pilot from the live profile), applies the full tournament progression step (circuit-scaled prize truguts, next-track/circuit/invitational unlocks, per-track beat-place bits, the favorite-pilot unlock cutaway, podium hand-off), and autosaves. `swrRace_CourseInfoMenu` is the other end: option rows, track preview, and both saved records with holder name + pod sprite.

Decodes that fell out:
- `swrSaveProfile` +0x24 isn't generic unlock data: [0] is the profile's selected **pilotId** (that's what gets stamped as record holder), [1..3] are per-circuit tracksUnlocked bitmasks, [4] is circuitsCompleted.
- `swrObjHang_STATE` 16/17 identified: PODIUM (top-3 pilots in `podiumCharacters`) and PILOT_UNLOCK.
- `swrObjHang_StartRace` documented: the 'Begn' payload carries the selected track's saved records, which `swrObjJdge_F4` latches into `jdge->best_lap_time_ms` / `recordLap3_ms` for the session — closing the loop on how records flow save -> race -> HUD -> results -> save.
- Named the results/course-info globals and swapped tracks_delta's raw `DAT_` uses over to them.

Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)