### PR TITLE
feat(crash): timestamped crash files + hang watchdog

### DIFF
--- a/dinput_hook/crash_logger.cpp
+++ b/dinput_hook/crash_logger.cpp
@@ -1,0 +1,278 @@
+#include "crash_logger.h"
+
+#include <windows.h>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <io.h>// _get_osfhandle / _fileno
+
+#include "hook_helper.h"// hook_log
+
+// Render-thread must make progress at least this often; a longer stall is treated as a hang.
+// Log-only, so a rare false trip during a legitimately long stall just leaves a spurious file.
+static const int HANG_TIMEOUT_MS = 15000;
+
+// ---------------------------------------------------------------------------------------------
+// Shared report writers. Everything writes through write_fmt to a caller-supplied Win32 file
+// HANDLE (never a CRT FILE): the crash filter runs on the faulting thread and the hang watchdog
+// snapshots a possibly-stuck thread, so either may run while the CRT heap or stdio lock is held
+// by the very thread we are reporting on. fopen/fprintf would re-acquire that lock and deadlock;
+// CreateFileA/WriteFile take neither, and vsnprintf into a stack buffer allocates nothing.
+// ---------------------------------------------------------------------------------------------
+
+// Formatted append to a raw file HANDLE -- stack buffer + WriteFile only, no CRT heap/stream lock.
+static void write_fmt(HANDLE out, const char *fmt, ...) {
+    if (out == INVALID_HANDLE_VALUE || out == nullptr)
+        return;
+    char buf[1024];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    if (n < 0)
+        return;
+    if (n > (int) sizeof(buf) - 1)
+        n = sizeof(buf) - 1;// vsnprintf returns the would-be length; clamp to what we buffered
+    DWORD written = 0;
+    WriteFile(out, buf, (DWORD) n, &written, nullptr);
+}
+
+static void log_addr(HANDLE out, void *addr) {
+    HMODULE mod = nullptr;
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           (LPCSTR) addr, &mod) &&
+        mod) {
+        char path[MAX_PATH] = {0};
+        GetModuleFileNameA(mod, path, MAX_PATH);
+        const char *name = strrchr(path, '\\');
+        name = name ? name + 1 : path;
+        write_fmt(out, "    %p  %s+0x%lx\n", addr, name,
+                  (unsigned long) ((UINT_PTR) addr - (UINT_PTR) mod));
+    } else {
+        write_fmt(out, "    %p  (no module)\n", addr);
+    }
+}
+
+static bool addr_is_code(void *addr) {
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(addr, &mbi, sizeof(mbi)) != sizeof(mbi))
+        return false;
+    if (mbi.State != MEM_COMMIT)
+        return false;
+    const DWORD prot = mbi.Protect & 0xff;
+    return prot == PAGE_EXECUTE || prot == PAGE_EXECUTE_READ || prot == PAGE_EXECUTE_READWRITE ||
+           prot == PAGE_EXECUTE_WRITECOPY;
+}
+
+// Heuristic: any committed-executable value on the stack is a likely return address. May include
+// false positives (data that looks like a code address); the genuine frames form the call chain.
+static void log_stack_scan(HANDLE out, UINT_PTR esp) {
+    write_fmt(out, "  on-stack code addresses:\n");
+    UINT_PTR *sp = (UINT_PTR *) esp;
+    int logged = 0;
+    for (int i = 0; i < 8192 && logged < 64; i++) {
+        if (IsBadReadPtr(&sp[i], sizeof(UINT_PTR)))
+            break;
+        const UINT_PTR val = sp[i];
+        if (val > 0x10000 && addr_is_code((void *) val)) {
+            log_addr(out, (void *) val);
+            logged++;
+        }
+    }
+}
+
+static void write_exception_report(HANDLE out, const EXCEPTION_RECORD *er, UINT_PTR esp) {
+    write_fmt(out, "*** unhandled exception: code=0x%08lx addr=%p ***\n", er->ExceptionCode,
+              er->ExceptionAddress);
+    if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
+        write_fmt(out, "    access %s at %p\n", er->ExceptionInformation[0] ? "write" : "read",
+                  (void *) er->ExceptionInformation[1]);
+    }
+    write_fmt(out, "  faulting instruction:\n");
+    log_addr(out, er->ExceptionAddress);
+    log_stack_scan(out, esp);
+    write_fmt(out, "*** end crash report ***\n");
+}
+
+// Open crashes\<kind>_YYYYMMDD_HHMMSS_mmm.log. The millisecond field keeps two reports in the
+// same second (e.g. a hang then a crash) from colliding. Returns INVALID_HANDLE_VALUE on failure;
+// the chosen path is copied into out_path for the pointer line written to hook.log.
+static HANDLE open_report_file(const char *kind, char *out_path, size_t out_path_size) {
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    CreateDirectoryA("crashes", nullptr);// ignore ERROR_ALREADY_EXISTS
+    char path[MAX_PATH];
+    snprintf(path, sizeof(path), "crashes\\%s_%04u%02u%02u_%02u%02u%02u_%03u.log", kind, st.wYear,
+             st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds);
+    if (out_path && out_path_size)
+        snprintf(out_path, out_path_size, "%s", path);
+    return CreateFileA(path, GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
+                       FILE_ATTRIBUTE_NORMAL, nullptr);
+}
+
+// Best-effort raw HANDLE onto hook.log's underlying file, for the fallback path only. The caller
+// must fflush(hook_log) first so buffered CRT output lands before our WriteFile appends to it.
+static HANDLE hook_log_handle(void) {
+    if (!hook_log)
+        return INVALID_HANDLE_VALUE;
+    return (HANDLE) (UINT_PTR) _get_osfhandle(_fileno(hook_log));
+}
+
+// ---------------------------------------------------------------------------------------------
+// Fatal-exception capture. The top-level unhandled filter is the single entry point: anything
+// reaching it is by definition unhandled -> fatal (a first-chance vectored handler was tried but
+// abandoned; see the note below unhandled_filter).
+//
+// A one-shot latch means the process writes at most one crash report: the first fatal fault wins.
+// This collapses any secondary fault that occurs while the OS is already tearing the process down
+// into a single shareable file. Trade-off: a fatal exception the game somehow recovers from would
+// latch and suppress a later report -- acceptable, as the game rarely handles access violations
+// and a genuinely fatal crash is the process's last act anyway.
+// ---------------------------------------------------------------------------------------------
+
+static volatile LONG g_crash_reported = 0;
+
+static void report_crash(EXCEPTION_POINTERS *ep) {
+    const EXCEPTION_RECORD *er = ep->ExceptionRecord;
+    const UINT_PTR esp = ep->ContextRecord->Esp;
+
+    // Write the standalone crash file first, via Win32 file I/O only, so a crash that faulted
+    // while holding the CRT heap lock -- the most common native crash -- still produces a report
+    // where fopen/fprintf would have deadlocked re-entering the allocator.
+    char path[MAX_PATH] = {0};
+    HANDLE cf = open_report_file("crash", path, sizeof(path));
+    if (cf != INVALID_HANDLE_VALUE) {
+        write_exception_report(cf, er, esp);
+        CloseHandle(cf);
+    }
+
+    // hook.log is a shared CRT stream used across the hook; touch it last and best-effort. The
+    // crash file above is already safe, so nothing is lost if these stdio calls block on a lock
+    // the faulting thread happens to hold. Flush first so buffered pre-crash lines survive.
+    if (hook_log) {
+        fflush(hook_log);
+        if (cf != INVALID_HANDLE_VALUE) {
+            fprintf(hook_log, "\n*** crash: code=0x%08lx addr=%p -> %s ***\n", er->ExceptionCode,
+                    er->ExceptionAddress, path);
+            fflush(hook_log);
+        } else {
+            // Crash file could not be created -- append the full report to hook.log's OS handle
+            // (WriteFile, no heap lock), landing after the just-flushed pre-crash lines.
+            write_exception_report(hook_log_handle(), er, esp);
+        }
+    }
+}
+
+static LONG WINAPI unhandled_filter(EXCEPTION_POINTERS *ep) {
+    // Anything reaching the top-level filter is by definition unhandled -> fatal, so report it.
+    // The latch collapses any secondary fault raised while the process is already tearing down
+    // into the single first report.
+    if (InterlockedExchange(&g_crash_reported, 1) == 0)
+        report_crash(ep);
+    return EXCEPTION_CONTINUE_SEARCH;// let WER / the normal crash path proceed
+}
+
+// A first-chance vectored handler was tried here but abandoned: routine code (IsBadReadPtr, the
+// D3D wrapper's SEH probes, ...) raises access violations it handles itself, and a VEH cannot
+// tell those from a real crash at first-chance time -> a flood of bogus reports. The top-level
+// filter only sees genuinely unhandled (fatal) exceptions. To stay robust against the game's CRT
+// installing its own top-level filter over ours, crash_logger_heartbeat() re-asserts ours each
+// frame (see below).
+
+// ---------------------------------------------------------------------------------------------
+// Hang watchdog. The render thread bumps g_heartbeat once per frame; a background thread that
+// sees it stall past HANG_TIMEOUT_MS snapshots the render thread's context and logs where it is
+// frozen. It only logs (never kills the thread), so a false trip is harmless.
+// ---------------------------------------------------------------------------------------------
+
+static volatile LONG g_heartbeat = 0;
+static HANDLE g_render_thread = nullptr;
+static volatile LONG g_render_thread_ready = 0;
+
+static void capture_hang(void) {
+    // Suspend only long enough to grab the register context (a kernel call), then resume before
+    // writing the report. Report I/O uses raw Win32 file handles (see write_fmt), so it cannot
+    // deadlock on a CRT lock the hung render thread may hold; the trailing hook.log write is
+    // best-effort. A truly hung thread's stack stays put, so the post-resume scan is stable.
+    if (SuspendThread(g_render_thread) == (DWORD) -1)
+        return;
+    CONTEXT ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+    const BOOL got = GetThreadContext(g_render_thread, &ctx);
+    ResumeThread(g_render_thread);
+    if (!got)
+        return;
+
+    char path[MAX_PATH] = {0};
+    HANDLE cf = open_report_file("hang", path, sizeof(path));
+    if (cf != INVALID_HANDLE_VALUE) {
+        write_fmt(cf, "*** hang detected: render thread made no progress for %d s ***\n",
+                  HANG_TIMEOUT_MS / 1000);
+        write_fmt(cf, "  frozen instruction:\n");
+        log_addr(cf, (void *) (UINT_PTR) ctx.Eip);
+        log_stack_scan(cf, ctx.Esp);
+        write_fmt(cf, "*** end hang report ***\n");
+        CloseHandle(cf);
+    }
+    if (hook_log) {
+        fprintf(hook_log, "\n*** hang detected (%d s) -> %s ***\n", HANG_TIMEOUT_MS / 1000, path);
+        fflush(hook_log);
+    }
+}
+
+static DWORD WINAPI watchdog_thread(LPVOID) {
+    LONG last = 0;
+    int stalled_ms = 0;
+    bool reported = false;
+    for (;;) {
+        Sleep(1000);
+        if (!g_render_thread_ready)
+            continue;// frames not started yet
+        const LONG now = g_heartbeat;
+        if (now != last) {
+            last = now;
+            stalled_ms = 0;
+            reported = false;
+            continue;
+        }
+        stalled_ms += 1000;
+        if (stalled_ms >= HANG_TIMEOUT_MS && !reported) {
+            reported = true;// one report per stall; re-arms when the heartbeat moves again
+            capture_hang();
+        }
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------------------------
+
+void crash_logger_install(void) {
+    // Just the top-level filter -- safe to register from DllMain, and early enough to catch a
+    // crash anywhere in startup. The watchdog thread is spawned lazily on the first heartbeat
+    // instead, off the render thread and clear of the loader lock.
+    SetUnhandledExceptionFilter(unhandled_filter);
+}
+
+void crash_logger_heartbeat(void) {
+    // Re-assert our filter each frame: if the game's CRT startup installed its own top-level
+    // filter over ours, this puts ours back on top so in-game crashes still reach us. Cheap
+    // (one syscall) next to a rendered frame, and idempotent once ours is already active.
+    SetUnhandledExceptionFilter(unhandled_filter);
+
+    if (!g_render_thread_ready) {
+        // First frame: capture a handle to the render thread for the watchdog to snapshot, then
+        // start the watchdog now that frames (and thus hang detection) are meaningful. Only arm
+        // the watchdog once we actually hold the handle -- otherwise it would spin uselessly, so
+        // on a (rare) DuplicateHandle failure we simply retry on the next frame.
+        if (DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(),
+                            &g_render_thread, THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT, FALSE,
+                            0) &&
+            g_render_thread) {
+            g_render_thread_ready = 1;
+            CreateThread(nullptr, 0, watchdog_thread, nullptr, 0, nullptr);
+        }
+    }
+    InterlockedIncrement(&g_heartbeat);
+}

--- a/dinput_hook/crash_logger.cpp
+++ b/dinput_hook/crash_logger.cpp
@@ -8,9 +8,22 @@
 
 #include "hook_helper.h"// hook_log
 
-// Render-thread must make progress at least this often; a longer stall is treated as a hang.
-// Log-only, so a rare false trip during a legitimately long stall just leaves a spurious file.
+// Render-thread must make progress at least this often once frames start; a longer stall is
+// treated as a hang. Log-only, so a rare false trip during a legitimately long stall just leaves
+// a spurious file.
 static const int HANG_TIMEOUT_MS = 15000;
+
+// Before the first frame renders, the main thread should reach its first present within this
+// long even on a slow Wine/Mac cold start. Overshooting it means startup is wedged (device or
+// window creation, the Wine graphics layer, ...), so we snapshot the main thread. Generous
+// because it is the "mod won't start" path and a false trip is only a spurious file.
+static const int STARTUP_TIMEOUT_MS = 45000;
+
+// Most recent boot/init milestone, echoed into every crash/hang report so a silent early failure
+// still shows how far startup got. Set via crash_logger_stage() from the main thread and read
+// from the crash filter / watchdog; a plain pointer swap is atomic on x86 and the strings are
+// static literals, so no lock is needed.
+static const char *volatile g_last_stage = "pre-init";
 
 // ---------------------------------------------------------------------------------------------
 // Shared report writers. Everything writes through write_fmt to a caller-supplied Win32 file
@@ -35,6 +48,29 @@ static void write_fmt(HANDLE out, const char *fmt, ...) {
         n = sizeof(buf) - 1;// vsnprintf returns the would-be length; clamp to what we buffered
     DWORD written = 0;
     WriteFile(out, buf, (DWORD) n, &written, nullptr);
+}
+
+// Stamp the runtime environment so a report shared by a Wine/Mac user self-describes. ntdll
+// exports wine_get_version only under Wine; absent means native Windows.
+static void write_env_line(HANDLE out) {
+    typedef const char *(__cdecl * wine_get_version_t)(void);
+    typedef void(__cdecl * wine_get_host_version_t)(const char **sysname, const char **release);
+
+    HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+    wine_get_version_t get_ver =
+        ntdll ? (wine_get_version_t) (void *) GetProcAddress(ntdll, "wine_get_version") : nullptr;
+    if (!get_ver) {
+        write_fmt(out, "  environment: native Windows\n");
+        return;
+    }
+    const char *ver = get_ver();
+    const char *sysname = "?";
+    const char *release = "?";
+    wine_get_host_version_t get_host =
+        (wine_get_host_version_t) (void *) GetProcAddress(ntdll, "wine_get_host_version");
+    if (get_host)
+        get_host(&sysname, &release);
+    write_fmt(out, "  environment: Wine %s on %s %s\n", ver ? ver : "?", sysname, release);
 }
 
 static void log_addr(HANDLE out, void *addr) {
@@ -85,6 +121,8 @@ static void log_stack_scan(HANDLE out, UINT_PTR esp) {
 static void write_exception_report(HANDLE out, const EXCEPTION_RECORD *er, UINT_PTR esp) {
     write_fmt(out, "*** unhandled exception: code=0x%08lx addr=%p ***\n", er->ExceptionCode,
               er->ExceptionAddress);
+    write_env_line(out);
+    write_fmt(out, "  last stage: %s\n", g_last_stage);
     if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
         write_fmt(out, "    access %s at %p\n", er->ExceptionInformation[0] ? "write" : "read",
                   (void *) er->ExceptionInformation[1]);
@@ -181,55 +219,73 @@ static LONG WINAPI unhandled_filter(EXCEPTION_POINTERS *ep) {
 // frame (see below).
 
 // ---------------------------------------------------------------------------------------------
-// Hang watchdog. The render thread bumps g_heartbeat once per frame; a background thread that
-// sees it stall past HANG_TIMEOUT_MS snapshots the render thread's context and logs where it is
-// frozen. It only logs (never kills the thread), so a false trip is harmless.
+// Hang watchdog. A background thread watches two phases: before the first frame it guards the
+// main thread against a startup that never reaches a frame; once frames begin it watches the
+// render thread's per-frame heartbeat. Either way it only snapshots where the thread is frozen
+// (never kills it), so a false trip is harmless.
 // ---------------------------------------------------------------------------------------------
 
 static volatile LONG g_heartbeat = 0;
-static HANDLE g_render_thread = nullptr;
+static HANDLE g_render_thread = nullptr; // captured on the first frame; watched while running
+static HANDLE g_startup_thread = nullptr;// captured at init; watched before the first frame
 static volatile LONG g_render_thread_ready = 0;
 
-static void capture_hang(void) {
+static void capture_hang(HANDLE thread, const char *kind, const char *headline, int seconds) {
     // Suspend only long enough to grab the register context (a kernel call), then resume before
     // writing the report. Report I/O uses raw Win32 file handles (see write_fmt), so it cannot
-    // deadlock on a CRT lock the hung render thread may hold; the trailing hook.log write is
-    // best-effort. A truly hung thread's stack stays put, so the post-resume scan is stable.
-    if (SuspendThread(g_render_thread) == (DWORD) -1)
+    // deadlock on a CRT lock the frozen thread may hold; the trailing hook.log write is
+    // best-effort. A truly stuck thread's stack stays put, so the post-resume scan is stable.
+    if (!thread || SuspendThread(thread) == (DWORD) -1)
         return;
     CONTEXT ctx;
     memset(&ctx, 0, sizeof(ctx));
     ctx.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
-    const BOOL got = GetThreadContext(g_render_thread, &ctx);
-    ResumeThread(g_render_thread);
+    const BOOL got = GetThreadContext(thread, &ctx);
+    ResumeThread(thread);
     if (!got)
         return;
 
     char path[MAX_PATH] = {0};
-    HANDLE cf = open_report_file("hang", path, sizeof(path));
+    HANDLE cf = open_report_file(kind, path, sizeof(path));
     if (cf != INVALID_HANDLE_VALUE) {
-        write_fmt(cf, "*** hang detected: render thread made no progress for %d s ***\n",
-                  HANG_TIMEOUT_MS / 1000);
+        write_fmt(cf, headline, seconds);
+        write_env_line(cf);
+        write_fmt(cf, "  last stage: %s\n", g_last_stage);
         write_fmt(cf, "  frozen instruction:\n");
         log_addr(cf, (void *) (UINT_PTR) ctx.Eip);
         log_stack_scan(cf, ctx.Esp);
-        write_fmt(cf, "*** end hang report ***\n");
+        write_fmt(cf, "*** end %s report ***\n", kind);
         CloseHandle(cf);
     }
     if (hook_log) {
-        fprintf(hook_log, "\n*** hang detected (%d s) -> %s ***\n", HANG_TIMEOUT_MS / 1000, path);
+        fprintf(hook_log, "\n*** %s (%d s) -> %s ***\n", kind, seconds, path);
         fflush(hook_log);
     }
 }
 
 static DWORD WINAPI watchdog_thread(LPVOID) {
+    int startup_ms = 0;
+    bool startup_reported = false;
     LONG last = 0;
     int stalled_ms = 0;
     bool reported = false;
     for (;;) {
         Sleep(1000);
-        if (!g_render_thread_ready)
-            continue;// frames not started yet
+        if (!g_render_thread_ready) {
+            // Startup phase: no frame has rendered yet. If the first frame never arrives, the
+            // main thread is wedged in init (device/window creation, the Wine graphics layer) --
+            // snapshot it so the report shows where startup froze.
+            startup_ms += 1000;
+            if (startup_ms >= STARTUP_TIMEOUT_MS && !startup_reported && g_startup_thread) {
+                startup_reported = true;
+                capture_hang(g_startup_thread, "startup",
+                             "*** startup hang: no first frame in %d s -- main thread frozen in "
+                             "init ***\n",
+                             STARTUP_TIMEOUT_MS / 1000);
+            }
+            continue;
+        }
+        // Running phase: the render thread must bump the heartbeat each frame.
         const LONG now = g_heartbeat;
         if (now != last) {
             last = now;
@@ -240,19 +296,57 @@ static DWORD WINAPI watchdog_thread(LPVOID) {
         stalled_ms += 1000;
         if (stalled_ms >= HANG_TIMEOUT_MS && !reported) {
             reported = true;// one report per stall; re-arms when the heartbeat moves again
-            capture_hang();
+            capture_hang(g_render_thread, "hang",
+                         "*** hang detected: render thread made no progress for %d s ***\n",
+                         HANG_TIMEOUT_MS / 1000);
         }
     }
     return 0;
+}
+
+static volatile LONG g_watchdog_started = 0;
+
+// Spawn the watchdog exactly once, whichever of crash_logger_start() (normal) or the first
+// heartbeat (fallback) reaches here first.
+static void start_watchdog_once(void) {
+    if (InterlockedExchange(&g_watchdog_started, 1) == 0)
+        CreateThread(nullptr, 0, watchdog_thread, nullptr, 0, nullptr);
 }
 
 // ---------------------------------------------------------------------------------------------
 
 void crash_logger_install(void) {
     // Just the top-level filter -- safe to register from DllMain, and early enough to catch a
-    // crash anywhere in startup. The watchdog thread is spawned lazily on the first heartbeat
-    // instead, off the render thread and clear of the loader lock.
+    // crash anywhere in startup. The watchdog thread is started later (crash_logger_start),
+    // off the loader lock.
     SetUnhandledExceptionFilter(unhandled_filter);
+}
+
+void crash_logger_start(void) {
+    // Runs once from the game's early init hook (after the loader lock is released, before
+    // renderer and device init). Capture the main thread and start the watchdog now -- so a hang
+    // BEFORE the first rendered frame is still caught -- and stamp the environment to hook.log so
+    // even a report with no crash/hang says whether it is Wine.
+    static volatile LONG started = 0;
+    if (InterlockedExchange(&started, 1) != 0)
+        return;
+    DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(),
+                    &g_startup_thread, THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT, FALSE, 0);
+    if (hook_log) {
+        fflush(hook_log);
+        write_env_line(hook_log_handle());
+    }
+    start_watchdog_once();
+}
+
+void crash_logger_stage(const char *name) {
+    // Record the latest boot/init milestone (echoed into every crash/hang report) and breadcrumb
+    // it to hook.log. `name` must be a static string -- it is stored, not copied.
+    g_last_stage = name;
+    if (hook_log) {
+        fprintf(hook_log, "[stage] %s\n", name);
+        fflush(hook_log);
+    }
 }
 
 void crash_logger_heartbeat(void) {
@@ -262,16 +356,17 @@ void crash_logger_heartbeat(void) {
     SetUnhandledExceptionFilter(unhandled_filter);
 
     if (!g_render_thread_ready) {
-        // First frame: capture a handle to the render thread for the watchdog to snapshot, then
-        // start the watchdog now that frames (and thus hang detection) are meaningful. Only arm
-        // the watchdog once we actually hold the handle -- otherwise it would spin uselessly, so
-        // on a (rare) DuplicateHandle failure we simply retry on the next frame.
+        // First frame: capture a handle to the render thread for the watchdog to snapshot, and
+        // hand off from the startup guard to per-frame hang detection. Only flip ready once we
+        // actually hold the handle -- otherwise the watchdog would snapshot a null thread -- so
+        // on a (rare) DuplicateHandle failure we retry next frame.
         if (DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(),
                             &g_render_thread, THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT, FALSE,
                             0) &&
             g_render_thread) {
             g_render_thread_ready = 1;
-            CreateThread(nullptr, 0, watchdog_thread, nullptr, 0, nullptr);
+            crash_logger_stage("running (first frame)");
+            start_watchdog_once();// fallback in case crash_logger_start() never ran
         }
     }
     InterlockedIncrement(&g_heartbeat);

--- a/dinput_hook/crash_logger.h
+++ b/dinput_hook/crash_logger.h
@@ -2,20 +2,30 @@
 
 // Diagnostic crash/hang capture for the dinput hook.
 //
-// On any unhandled (fatal) exception, and on a detected render-thread hang, a uniquely-named,
-// timestamped report is written under
-// crashes/ (crash_YYYYMMDD_HHMMSS_mmm.log / hang_...). Because each report is its own file it
-// survives relaunching, so players can share it with the dev team after the game restarts.
+// On any unhandled (fatal) exception, and on a detected hang -- whether the game froze mid-play
+// or never reached its first frame -- a uniquely-named, timestamped report is written under
+// crashes/ (crash_/hang_/startup_ YYYYMMDD_HHMMSS_mmm.log). Because each report is its own file
+// it survives relaunching, so players can share it with the dev team after the game restarts.
+// Every report stamps the environment (Wine version + host OS, or native Windows) and the last
+// init milestone reached, so a "won't start" report from a Wine/Mac user is self-describing.
 //
-// crash_logger_install() must run as early as possible in DllMain, before anything that can
-// fault, so even crashes deep in startup are captured. crash_logger_heartbeat() must be called
-// once per rendered frame; the hang watchdog uses it to tell a frozen game from a slow one.
+// Call order:
+//   crash_logger_install()   -- first thing in DllMain, before anything can fault, so even a
+//                               crash deep in startup is captured.
+//   crash_logger_start()     -- once from the game's early init hook (after the loader lock is
+//                               released, before renderer/device init); arms the startup hang
+//                               watchdog and stamps the environment.
+//   crash_logger_stage(name) -- at boot/init milestones; `name` must be a static string. The
+//                               most recent one is echoed into every report.
+//   crash_logger_heartbeat() -- once per rendered frame; drives per-frame hang detection.
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void crash_logger_install(void);
+void crash_logger_start(void);
+void crash_logger_stage(const char *name);
 void crash_logger_heartbeat(void);
 
 #ifdef __cplusplus

--- a/dinput_hook/crash_logger.h
+++ b/dinput_hook/crash_logger.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Diagnostic crash/hang capture for the dinput hook.
+//
+// On any unhandled (fatal) exception, and on a detected render-thread hang, a uniquely-named,
+// timestamped report is written under
+// crashes/ (crash_YYYYMMDD_HHMMSS_mmm.log / hang_...). Because each report is its own file it
+// survives relaunching, so players can share it with the dev team after the game restarts.
+//
+// crash_logger_install() must run as early as possible in DllMain, before anything that can
+// fault, so even crashes deep in startup are captured. crash_logger_heartbeat() must be called
+// once per rendered frame; the hang watchdog uses it to tell a frozen game from a slow one.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void crash_logger_install(void);
+void crash_logger_heartbeat(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/dinput_hook/main.cpp
+++ b/dinput_hook/main.cpp
@@ -116,13 +116,18 @@ extern "C" void set_ai_full_lod(bool on) {
 }
 
 HICON __stdcall LoadIconHook(HINSTANCE hInstance, LPCSTR lpIconName) {
-    // Main is ready. Patch the hooks and the function we are in to return properly
-    fprintf(hook_log, "LoadIcon Hook called\n");
-    fflush(hook_log);
+    // Main is ready. Patch the hooks and the function we are in to return properly.
+    // Arm the startup hang watchdog + stamp the environment before any init below can wedge, and
+    // breadcrumb each init step so a "won't start" report shows exactly how far it got.
+    crash_logger_start();
 
+    crash_logger_stage("init: renderer hooks");
     init_renderer_hooks();
+    crash_logger_stage("init: game hooks");
     init_hooks();
+    crash_logger_stage("init: custom tracks");
     init_customTracks();
+    crash_logger_stage("init: complete");
 
     // nop Window_CreateMainWindow from 0x0049cede to 0x0049cfb8 included, will return peacefully
     const uint32_t nop_addr = 0x0049cede;
@@ -158,8 +163,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
 
     hook_log = fopen("hook.log", "wb");
 
-    fprintf(hook_log, "[DllMain]\n");
-    fflush(hook_log);
+    crash_logger_stage("DllMain");
 
     // GOG Version works like Steam Version
     // Steam Version gets initialized with dinput_hook.c: LoadIconA patched to DirectInputCreateA

--- a/dinput_hook/main.cpp
+++ b/dinput_hook/main.cpp
@@ -11,74 +11,9 @@
 #include "hook_helper.h"
 #include "custom_tracks.h"
 #include "patch.h"
+#include "crash_logger.h"
 
 FILE *hook_log = nullptr;
-
-// Crash logger: on an unhandled exception, write the faulting address + the module it lands
-// in, plus a scan of on-stack return addresses (each resolved to module+offset), to
-// hook.log. A crash on a player's machine is then diagnosable from the log they send back
-// (dinput.dll offsets resolve via addr2line; game-exe offsets via the disassembly). It fires
-// only on an actual unhandled crash, so it is free in normal play.
-static void crash_log_addr(void *addr) {
-    HMODULE mod = nullptr;
-    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                           (LPCSTR) addr, &mod) &&
-        mod) {
-        char path[MAX_PATH] = {0};
-        GetModuleFileNameA(mod, path, MAX_PATH);
-        const char *name = strrchr(path, '\\');
-        name = name ? name + 1 : path;
-        fprintf(hook_log, "    %p  %s+0x%lx\n", addr, name,
-                (unsigned long) ((UINT_PTR) addr - (UINT_PTR) mod));
-    } else {
-        fprintf(hook_log, "    %p  (no module)\n", addr);
-    }
-}
-
-static bool crash_addr_is_code(void *addr) {
-    MEMORY_BASIC_INFORMATION mbi;
-    if (VirtualQuery(addr, &mbi, sizeof(mbi)) != sizeof(mbi))
-        return false;
-    if (mbi.State != MEM_COMMIT)
-        return false;
-    const DWORD prot = mbi.Protect & 0xff;
-    return prot == PAGE_EXECUTE || prot == PAGE_EXECUTE_READ || prot == PAGE_EXECUTE_READWRITE ||
-           prot == PAGE_EXECUTE_WRITECOPY;
-}
-
-static LONG WINAPI crash_log_filter(EXCEPTION_POINTERS *ep) {
-    if (!hook_log)
-        return EXCEPTION_CONTINUE_SEARCH;
-    const EXCEPTION_RECORD *er = ep->ExceptionRecord;
-    fflush(hook_log);// flush buffered output so the lines leading up to the crash survive
-    fprintf(hook_log, "\n*** unhandled exception: code=0x%08lx addr=%p ***\n", er->ExceptionCode,
-            er->ExceptionAddress);
-    if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
-        fprintf(hook_log, "    access %s at %p\n", er->ExceptionInformation[0] ? "write" : "read",
-                (void *) er->ExceptionInformation[1]);
-    }
-    fprintf(hook_log, "  faulting instruction:\n");
-    crash_log_addr(er->ExceptionAddress);
-    // Heuristic: any committed-executable value on the stack is a likely return address. May
-    // include false positives (data that looks like a code address); the genuine frames form
-    // the call chain.
-    fprintf(hook_log, "  on-stack code addresses:\n");
-    UINT_PTR *sp = (UINT_PTR *) ep->ContextRecord->Esp;
-    int logged = 0;
-    for (int i = 0; i < 8192 && logged < 64; i++) {
-        if (IsBadReadPtr(&sp[i], sizeof(UINT_PTR)))
-            break;
-        const UINT_PTR val = sp[i];
-        if (val > 0x10000 && crash_addr_is_code((void *) val)) {
-            crash_log_addr((void *) val);
-            logged++;
-        }
-    }
-    fprintf(hook_log, "*** end crash report ***\n");
-    fflush(hook_log);
-    return EXCEPTION_CONTINUE_SEARCH;// let WER / the normal crash path proceed
-}
 
 // https://github.com/lcsig/API-Hooking
 DWORD_PTR hookIAT(const char *libName, const char *API_Name, LPVOID newFun) {
@@ -217,8 +152,11 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason != DLL_PROCESS_ATTACH)
         return TRUE;
 
+    // Install crash/hang capture first thing, before anything below can fault, so even a crash
+    // deep in startup is written to its own timestamped file under crashes/.
+    crash_logger_install();
+
     hook_log = fopen("hook.log", "wb");
-    SetUnhandledExceptionFilter(crash_log_filter);
 
     fprintf(hook_log, "[DllMain]\n");
     fflush(hook_log);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -3,6 +3,7 @@
 //
 #include "renderer_hook.h"
 #include "hook_helper.h"
+#include "crash_logger.h"
 #include "node_utils.h"
 #include "imgui_utils.h"
 #include "renderer_utils.h"
@@ -1341,6 +1342,8 @@ extern "C" int stdDisplay_Update_Hook() {
     }
     glFinish();
     glfwSwapBuffers(glfwGetCurrentContext());
+
+    crash_logger_heartbeat();// tell the hang watchdog a frame completed
 
     limit_framerate(imgui_state.target_fps);
 


### PR DESCRIPTION
Splits the crash logger out of `main.cpp` into its own `crash_logger.cpp/.h`, and makes it write a uniquely-named timestamped report under `crashes/` per crash. Because each report is its own file it survives a relaunch, so players can just send the file after the game restarts (instead of it getting buried in / overwritten by `hook.log`). Also adds a lightweight render-thread hang watchdog: if no frame completes for 15s it snapshots where the thread is frozen into a `hang_*.log`. It only logs, never kills the thread, so a false trip is harmless.

Report I/O goes through raw Win32 `CreateFileA`/`WriteFile` rather than CRT `fopen`/`fprintf`. The crash filter runs on the faulting thread and the watchdog snapshots a possibly-stuck thread, so CRT calls risk deadlocking on the heap/stdio lock that thread already holds; the standalone report file is written first so it survives even if the trailing best-effort `hook.log` line blocks.

`hook.log` still gets a one-line pointer to the report file, and if the report file can't be created it falls back to the full report inline.

Builds/links clean (WinLibs GCC 13.2, full `dinput.dll` link).
