### PR TITLE
fix(cinematic): drop the dead DirectDraw video surface from the startup FMV path (#165)

### DIFF
--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -7,6 +7,7 @@
 #include "imgui_utils.h"
 #include "renderer_utils.h"
 #include "replacements.h"
+#include "patch.h"
 #include "stb_image.h"
 #include "texture_replacement.h"
 
@@ -1409,6 +1410,23 @@ extern "C" void init_renderer_hooks() {
     // hooked (registered in hook_generated) -> replace only.
     hook_replace(swrSound_Startup, swrSound_Startup_delta);
     hook_replace(Window_PlayCinematic, Window_PlayCinematic_delta);
+
+    // issue #165: strip the dead DirectDraw video-surface path out of Window_PlayCinematic (0x004252a0).
+    // Under the GL renderer each Smush frame is displayed by Window_SmushPlayCallback_delta ->
+    // renderer_drawSmushFrame, so the stock std3D_pDirectDraw->CreateSurface / ddSurfaceForVideo / Blt
+    // machinery is dead weight -- nothing reads it anymore. Stock only builds that surface when the
+    // backbuffer is still < 640x480, which is the boot state; there the dead DirectDraw call faults
+    // inside Smush.dll on AMD + dgVoodoo (the startup-intro CTD in the report). The in-game planet
+    // cutscenes run through the exact same Window_PlayCinematic but survive because by then the
+    // backbuffer is >= 640x480 and stock already skips the branch.
+    // Fix: force the no-surface path unconditionally by NOPping the two "backbuffer too small ->
+    // CreateSurface" branches (JC 0x004252e5) at 0x004252cd (72 16) and 0x004252db (72 08). Control then
+    // always falls through to swrDisplay_directlyBlitVideoToScreen = 1 -- exactly what the working
+    // cutscenes do -- and the end-of-function ddSurfaceForVideo->Release() (guarded by the same flag) is
+    // skipped too. Reversible via the patch journal.
+    static const uint8_t nop2[2] = {0x90, 0x90};
+    WriteMemory("smush_no_directdraw", (void *) 0x004252cd, nop2, sizeof(nop2));
+    WriteMemory("smush_no_directdraw", (void *) 0x004252db, nop2, sizeof(nop2));
 
 #if ENABLE_GAMEPAD_NAV
     // Feed the gamepad's D-pad / START / BACK into the game's menu + in-race input.

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1411,19 +1411,11 @@ extern "C" void init_renderer_hooks() {
     hook_replace(swrSound_Startup, swrSound_Startup_delta);
     hook_replace(Window_PlayCinematic, Window_PlayCinematic_delta);
 
-    // issue #165: strip the dead DirectDraw video-surface path out of Window_PlayCinematic (0x004252a0).
-    // Under the GL renderer each Smush frame is displayed by Window_SmushPlayCallback_delta ->
-    // renderer_drawSmushFrame, so the stock std3D_pDirectDraw->CreateSurface / ddSurfaceForVideo / Blt
-    // machinery is dead weight -- nothing reads it anymore. Stock only builds that surface when the
-    // backbuffer is still < 640x480, which is the boot state; there the dead DirectDraw call faults
-    // inside Smush.dll on AMD + dgVoodoo (the startup-intro CTD in the report). The in-game planet
-    // cutscenes run through the exact same Window_PlayCinematic but survive because by then the
-    // backbuffer is >= 640x480 and stock already skips the branch.
-    // Fix: force the no-surface path unconditionally by NOPping the two "backbuffer too small ->
-    // CreateSurface" branches (JC 0x004252e5) at 0x004252cd (72 16) and 0x004252db (72 08). Control then
-    // always falls through to swrDisplay_directlyBlitVideoToScreen = 1 -- exactly what the working
-    // cutscenes do -- and the end-of-function ddSurfaceForVideo->Release() (guarded by the same flag) is
-    // skipped too. Reversible via the patch journal.
+    // issue #165: the DirectDraw video-surface path in Window_PlayCinematic (0x004252a0) is dead under
+    // the GL renderer (frames go through renderer_drawSmushFrame), and stock only takes it while the
+    // backbuffer is < 640x480 -- i.e. at boot, where the call faults inside Smush.dll on AMD + dgVoodoo.
+    // NOP the two "too small -> CreateSurface" branches (JC 0x004252e5) so control always falls through
+    // to swrDisplay_directlyBlitVideoToScreen = 1, the path the in-game cutscenes already take.
     static const uint8_t nop2[2] = {0x90, 0x90};
     WriteMemory("smush_no_directdraw", (void *) 0x004252cd, nop2, sizeof(nop2));
     WriteMemory("smush_no_directdraw", (void *) 0x004252db, nop2, sizeof(nop2));


### PR DESCRIPTION
Fixes the startup-intro CTD in #165.

**Root cause.** The GL renderer already displays every Smush frame through `Window_SmushPlayCallback_delta` -> `renderer_drawSmushFrame`, so the legacy DirectDraw machinery in `Window_PlayCinematic` (`std3D_pDirectDraw->CreateSurface` -> `ddSurfaceForVideo` -> `Blt`) is dead code -- nothing consumes it anymore. Stock only builds that surface when the backbuffer is still `< 640x480`, which is the boot state; there the dead DirectDraw call faults inside `Smush.dll` on AMD + dgVoodoo (the crash in the report). The pre-race planet cutscenes run through the *same* `Window_PlayCinematic` but survive because by then the backbuffer is `>= 640x480` and stock already skips the branch.

**Fix.** Force the no-surface path unconditionally by NOPping the two "backbuffer too small -> `CreateSurface`" jumps (`0x004252cd` / `0x004252db`), so control always falls through to `swrDisplay_directlyBlitVideoToScreen = 1` -- exactly what the working cutscenes do -- and the end-of-function `ddSurfaceForVideo->Release()` (guarded by the same flag) is skipped too. Applied through the reversible patch journal (`smush_no_directdraw` owner), scoped to the GL renderer path.

I went with the 2-byte patch rather than reimplementing `Window_PlayCinematic` because the setup calls four `Smush.dll` imports and several game funcs that are still `HANG` stubs in `src/`, so a faithful reimpl would be a lot more surface area for a boot-critical function. Happy to do the full reimpl instead if you'd prefer.

**Testing.** Boots clean here (NVIDIA) -- patch applies at both sites, intro plays, no regression. I can't reproduce the AMD + dgVoodoo fault locally, so **this needs a playtest on the affected setup to confirm the crash is actually gone** -- opening as a draft for that reason. @-the reporter from #165, could you try this build?
