### PR TITLE
reimpl(swrRace): swrRace_CalcTargetTurnRate + control-type plumbing

### DIFF
--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1107,7 +1107,7 @@ void swrRace_UpdateCatchup(swrRace* player)
 {
     swrScore* score = player->score_ptr;
 
-    if ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0 || *(int*) &score->unkc == 0) {
+    if ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0 || score->localPlayerProfile == NULL) {
         if ((player->flags0 & swrObjTest_FLAG0_AI) != 0) {
             swrRace_AI((int) player);
         } else {
@@ -1125,6 +1125,75 @@ void swrRace_UpdateCatchup(swrRace* player)
         }
     }
     player->speedMultiplier = player->paceMultiplier;
+}
+
+// 0x0046b430
+void swrRace_ApplyPodProximityForce(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// 0x0046bb70
+void swrRace_UpdateAutopilotControl(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// 0x0046bec0
+void swrRace_UpdatePlayerControl(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// Computes this racer's per-frame target turn rate and throttle, dispatched by control ownership:
+// a 'Locl' human with a bound profile -> swrRace_UpdatePlayerControl; a racing remote pod replays
+// its stored turn target; AI -> autopilot (with a FORCE_GROUND repair kick). Then applies catchup,
+// folds speedMultiplier into throttle for AI, zeroes throttle while tilted/spun (unk12_1 > 0), and
+// clamps turnRateTarget to +/- podStats.maxTurnRate (both scaled by paceMultiplier).
+// 0x0046cf00
+void swrRace_CalcTargetTurnRate(swrRace* player)
+{
+    uint32_t flags0 = player->flags0;
+    player->throttle = 0.0f;
+    player->turnRateTarget = 0.0f;
+
+    if ((flags0 & swrObjTest_FLAG0_LOCAL) != 0 && player->score_ptr->localPlayerProfile != NULL) {
+        swrRace_UpdatePlayerControl(player);
+    } else if ((flags0 & swrObjTest_FLAG0_REMOTE) != 0) {
+        if (((uint8_t) flags0 & 0xf) != swrObjTest_FLAG0_RACING) {
+            return;
+        }
+        player->turnRateTarget = *(float*) (player->unk1eb8 + 0x10);
+    } else if ((flags0 & swrObjTest_FLAG0_AI) != 0) {
+        swrRace_UpdateAutopilotControl(player);
+        if ((player->flags1 & swrObjTest_FLAG1_FORCE_GROUND) != 0) {
+            player->flags0 |= swrObjTest_FLAG0_REPAIRING;
+            swrRace_Repair(player);
+        }
+        if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) {
+            swrRace_ApplyPodProximityForce(player);
+        }
+    }
+
+    if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) {
+        swrRace_UpdateCatchup(player);
+    }
+    if ((player->flags0 & swrObjTest_FLAG0_AI) != 0) {
+        player->throttle *= player->speedMultiplier;
+    }
+    if (0.0f < player->unk12_1) {
+        player->throttle = 0.0f;
+    }
+
+    float target = player->turnRateTarget * player->paceMultiplier;
+    float cap = player->podStats.maxTurnRate * player->paceMultiplier;
+    player->turnRateTarget = target;
+    if (cap < target) {
+        player->turnRateTarget = cap;
+    }
+    if (player->turnRateTarget < -cap) {
+        player->turnRateTarget = -cap;
+    }
 }
 
 // Accumulate collision/scrape damage into engine part `engineIndex`. The hit magnitude

--- a/src/types.h
+++ b/src/types.h
@@ -1076,9 +1076,11 @@ extern "C"
         float time_unk;
         int identifier; // 'Locl' (0x4c6f636c) = local player (assigned to firstLocalPlayer..); else AI/remote ('AAll')
         int flag; // 0x1 = active/in-race, 0x2 = finished (ranked by results_P1_total_time once set; see swrObjJdge_GetRacerRankValue)
-        char unkc;
-        char unkd;
-        char unke[2];
+        // 0xc. Pointer to this racer's live working profile record (swrRace_aProfiles + slot*0x50), set only for
+        // 'Locl' racers by the roster builders; NULL for AI/remote. Both a "this is a local human" flag and the
+        // handle used to fetch the player's persisted input config: swrRace_UpdatePlayerControl reads the
+        // control-type byte at profile+0x23 through it. swrRace_UpdateCatchup / swrRace_CalcTargetTurnRate NULL-check it.
+        void* localPlayerProfile;
         int sfxChannel; // 0x10. low byte = per-racer SFX channel index (swrSound_SetSfxFlag / swrSound_TestSfxFlag)
         int unk14;
         int unk18; // holds a pointer to the racer's sound source (dereferenced in swrObjJdge_F2 for the finish-line SFX)

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -83,6 +83,9 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_AI = 0x80, // 'AAII' racer (computer)
     swrObjTest_FLAG0_AI_SIMPLE = 0x100, // simplified AI path (set from score->flag & 0x20)
     swrObjTest_FLAG0_BRAKING = 0x200, // is braking
+    swrObjTest_FLAG0_REPAIRING = 0x400, // hold-to-repair active: pins repairTimer positive in swrRace_Repair so
+                                        // the engine-heal branch runs. Set by swrRace_UpdatePlayerControl (local:
+                                        // repair button held past threshold) and swrRace_CalcTargetTurnRate (AI + FORCE_GROUND).
     swrObjTest_FLAG0_RESET = 0x800, // 'reset pod' requested (death-snap)
     swrObjTest_FLAG0_RESPAWN = 0x1000, // 'respawn pod' requested
     swrObjTest_FLAG0_RESPAWN_INVINC = 0x2000, // respawn invincibility


### PR DESCRIPTION
Reimplements `swrRace_CalcTargetTurnRate` (0x46cf00) plus the structural naming the RE around it surfaced.

- `swrScore+0xc` was `char unkc/unkd/unke[2]` — it's really a pointer to the owning local player's working profile record (NULL for AI/remote), and the handle `UpdatePlayerControl` uses to read the control-type byte at `profile+0x23`. Retyped to `void* localPlayerProfile`; `UpdateCatchup` consumer updated to match.
- Named `swrObjTest_FLAG0_REPAIRING` (0x400) — hold-to-repair active; the sole reader `swrRace_Repair` pins `repairTimer` positive so the engine-heal branch runs.
- Adds `HANG("TODO")` reverse-hook stubs for the three callees `CalcTargetTurnRate` references that aren't reimplemented yet (`UpdatePlayerControl`, `UpdateAutopilotControl`, `ApplyPodProximityForce`) so the dll links. `UpdatePlayerControl` is coming in a stacked follow-up.

Builds + links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)