### PR TITLE
reimpl(swrRace): AI autopilot + player-blocking proximity force

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -563,7 +563,7 @@ swrViewport_force320x240 0x0050c058 int # when nonzero, swrViewport_SetViewport 
 
 swrRace_DebugLevel 0x0050c040 int
 swrRace_DebugMenu 0x0050c044 int # set to >= 1
-swrRace_DebugFlag 0x0050c048 char # set to 63 for text
+swrRace_DebugFlag 0x0050c048 int # bitfield read as a 32-bit dword (e.g. swrRace_UpdatePlayerControl tests 0x100 / 0x2000000); low byte set to 63 for text
 
 DebugMenuState 0x0050c07c int
 
@@ -1266,10 +1266,10 @@ texture_count 0x00e9823c unsigned int
 
 InRace_PauseMenu_ScrollInOut 0x00e9824c float
 
-DAT_00e98e80 0x00e98e80 float[1]
+DAT_00e98e80 0x00e98e80 float[4] # per-local-player pitch input (shared with tracks_delta)
 
 inRaceLocalPlayerInputBitset3 0x00E98E90 int[4]
-DAT_00e98ea0 0x00e98ea0 float[1]
+DAT_00e98ea0 0x00e98ea0 float[4] # per-local-player steer input (shared with tracks_delta)
 
 inRaceLocalPlayerInputBitset1 0x00E98EB0 int[4]
 inRaceLocalPlayerInputBitset2 0x00E98EC0 int[4]
@@ -1439,7 +1439,25 @@ swrRace_PitchInput 0x00ec883c float
 
 swrRace_ThrustInput 0x00ec884c float
 swrRace_BoostInput 0x00ec8850 float
-DAT_00ec8854 0x00ec8854 float
+DAT_00ec8854 0x00ec8854 float # button-state[5]: slide/lean (shared with tracks_delta)
+
+# swrControl per-action input state consumed by swrRace_UpdatePlayerControl (elements of the
+# button-state array @0x00ec8840 and the hold-time array @0x00ec88a0 written by swrControl_ProcessInputs).
+swrControl_brakeIsAnalog 0x00ec8820 int # 1 when this frame's brake comes from an analog axis (suppresses digital-brake handling)
+swrControl_viewButton 0x00ec8840 float # button-state[0]: change-camera-view pressed (feeds the 'cMan'/'CBut' event)
+swrControl_inputStateButton 0x00ec8844 float # button-state[1]: sets swrRace flags0 0x100000 while held
+swrControl_brakeButton 0x00ec8848 float # button-state[2]: brake / reverse
+swrControl_rollLeftButton 0x00ec8858 float # button-state[6]: roll/bank left (swapped with right under mirror mode)
+swrControl_rollRightButton 0x00ec885c float # button-state[7]: roll/bank right
+swrControl_tauntButton 0x00ec8860 float # button-state[8]: taunt / flame attack
+swrControl_repairButton 0x00ec8864 float # button-state[9]: repair (held)
+swrControl_thrustHoldTime 0x00ec88ac float # hold-time[3] seconds: thrust; in (0,0.2) = tapped -> boost
+swrControl_boostHoldTime 0x00ec88b0 float # hold-time[4] seconds: boost tap-detect
+swrControl_repairHoldTime 0x00ec88c4 float # hold-time[9] seconds: repair; > 0.5 fires repair
+swrRace_pendingCameraEvent 0x00ec83d0 int # pending 'cMan' sub-event fourcc queued by debug camera keys F1-F4; consumed+cleared in swrRace_UpdatePlayerControl
+swrControl_damageForceEffectPreempted 0x004d78a0 int # a one-shot damage FF effect preempted the continuous speed effect; swrControl_UpdateSpeedForceEffect restarts it
+swrRace_debugTauntRequest 0x004d79e0 int # debug key F5/F6 force-taunt/flame-attack latch; consumed+cleared in swrRace_UpdatePlayerControl
+swrRace_engineDamageSteeringPenalty 0x0050cae4 float # last engine-damage steering-pull magnitude (telemetry stash)
 
 stdControl_KeyPressed_unused 0x00ec88e0 char[0x100]
 

--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -20,7 +20,7 @@ extern FILE* hook_log;
 #include "../imgui_utils.h"  // imgui_state.mp_disable_collision (the debug-menu toggle)
 #include "swrModel_delta.h"  // swrModel_LoadFromId_delta (loads dust models through the GL path)
 
-// The pod's cockpit->engine cables (unk344_nodeArray[10] and [11]) are bent into a curve each
+// The pod's cockpit->engine cables (partNodes[10] and [11]) are bent into a curve each
 // frame by swrRace's connection-mesh deformer (FUN_00481c30 @ 0x481c30). That deformation is
 // written to the rd3d-converted mesh, which the OpenGL renderer replacement never builds or
 // uses - it renders the original mesh plus the node transform, i.e. the flat/straight cable.
@@ -52,7 +52,7 @@ static float compute_cable_amplitude(const swrRace* player, float k) {
 void swrRace_PoddAnimateVariousThings_delta(swrRace* player) {
     hook_call_original(swrRace_PoddAnimateVariousThings, player);
 
-    swrModel_Node** nodes = player->unk344_nodeArray;
+    swrModel_Node** nodes = player->partNodes;
     if (!nodes)
         return;
 

--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -125,7 +125,7 @@ void __cdecl swrRace_ResolvePodCollision_delta(swrRace* player) {
 }
 
 // --- Ground dust/splash effect: fix the AI-full-LOD contention -------------------------------------
-// swrRace_PoddAnimateVariousThings -> swrRace_SpawnGroundDustKick_Maybe spawns the ground dust/splash
+// swrRace_PoddAnimateVariousThings -> swrRace_SpawnGroundDustKick spawns the ground dust/splash
 // trail. Each spawn takes a Toss entity from a FIXED 16-slot pool (swrEvent_AllocObj) and, on
 // swamp/soft terrain, plays the splash sound (playASound id 0x45). That path only runs for full-model
 // pods, so in vanilla only the local player triggers it. With ai_full_lod every AI pod is a full
@@ -161,17 +161,17 @@ typedef void(__cdecl* playASound_t)(int, short, float, float, int);
 
 void __cdecl playASound_delta(int sound_id, short priority, float volume, float pitch, int flags) {
     // Drop the ground-dust splash sound while a non-local pod is spawning its dust kick (flag set by
-    // swrRace_SpawnGroundDustKick_Maybe_delta below). Only the local player's splash should be heard;
+    // swrRace_SpawnGroundDustKick_delta below). Only the local player's splash should be heard;
     // AI/remote splashes play non-spatially and restart the player's looping voice.
     if (g_suppress_dust_splash_sound && sound_id == DUST_SPLASH_SOUND_ID)
         return;
     hook_call_original((playASound_t) playASound_ADDR, sound_id, priority, volume, pitch, flags);
 }
 
-typedef void(__cdecl* swrRace_SpawnGroundDustKick_Maybe_t)(swrRace*, float*, float, float, float,
+typedef void(__cdecl* swrRace_SpawnGroundDustKick_t)(swrRace*, float*, float, float, float,
                                                            float, int);
 
-void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* transform, float sx,
+void __cdecl swrRace_SpawnGroundDustKick_delta(swrRace* player, float* transform, float sx,
                                                      float sy, float sz, float param_6,
                                                      int param_7) {
     const bool is_local = player != nullptr && (player->flags0 & swrObjTest_FLAG0_LOCAL) != 0;
@@ -183,13 +183,13 @@ void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* tra
         // Keep the AI dust visual, but silence its splash sound for the duration of this call.
         g_suppress_dust_splash_sound = true;
         hook_call_original(
-            (swrRace_SpawnGroundDustKick_Maybe_t) swrRace_SpawnGroundDustKick_Maybe_ADDR, player,
+            (swrRace_SpawnGroundDustKick_t) swrRace_SpawnGroundDustKick_ADDR, player,
             transform, sx, sy, sz, param_6, param_7);
         g_suppress_dust_splash_sound = false;
         return;
     }
 
-    hook_call_original((swrRace_SpawnGroundDustKick_Maybe_t) swrRace_SpawnGroundDustKick_Maybe_ADDR,
+    hook_call_original((swrRace_SpawnGroundDustKick_t) swrRace_SpawnGroundDustKick_ADDR,
                        player, transform, sx, sy, sz, param_6, param_7);
 }
 
@@ -202,7 +202,7 @@ void __cdecl swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* tra
 // function does the same. A NODE_TRANSFORMED_WITH_PIVOT node writes slots [0..3] in
 // swrModel_NodeInit, so each wrapper reserves 4 contiguous swrModel_Node slots.
 // Sized so the shared pool isn't exhausted once far AI also spawn dust (see the reserve in
-// swrRace_SpawnGroundDustKick_Maybe_delta): when free slots hit the reserve, ALL AI skip that frame
+// swrRace_SpawnGroundDustKick_delta): when free slots hit the reserve, ALL AI skip that frame
 // and their trails gap while the (unchecked) player stays smooth. More headroom keeps AI continuous.
 static const int DUST_POOL_SIZE = 128;
 static swrModel_Node g_dustWrappers[DUST_POOL_SIZE * 4];

--- a/dinput_hook/game_deltas/swrRace_delta.h
+++ b/dinput_hook/game_deltas/swrRace_delta.h
@@ -15,10 +15,10 @@ void swrRace_AnimateDisplayPod_delta(swrModel_Node** nodes, void* transform, int
 void swrRace_ResolvePodCollision_delta(swrRace* player);
 
 // ai_full_lod dust/splash fix (hooked by address, both dormant/reverse-hooked originals):
-// - swrRace_SpawnGroundDustKick_Maybe_delta: for non-local pods, reserve Toss-pool headroom (so AI
+// - swrRace_SpawnGroundDustKick_delta: for non-local pods, reserve Toss-pool headroom (so AI
 //   dust never starves the player's trail) and suppress the splash sound.
 // - playASound_delta: drops the dust-splash sound while a non-local dust kick is being spawned.
-void swrRace_SpawnGroundDustKick_Maybe_delta(swrRace* player, float* transform, float sx, float sy,
+void swrRace_SpawnGroundDustKick_delta(swrRace* player, float* transform, float sx, float sy,
                                              float sz, float param_6, int param_7);
 void playASound_delta(int sound_id, short priority, float volume, float pitch, int flags);
 

--- a/dinput_hook/node_utils.cpp
+++ b/dinput_hook/node_utils.cpp
@@ -191,7 +191,7 @@ bool is_foreign_hidden_pod_root(const swrModel_Node *node) {
     if ((owner->flags0 & (swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_DEAD)) !=
         swrObjTest_FLAG0_POD_HIDDEN)
         return false;
-    return owner->unk344_nodeArray != nullptr && node == owner->unk344_nodeArray[0];
+    return owner->partNodes != nullptr && node == owner->partNodes[0];
 }
 
 void apply_node_transform(rdMatrix44 &model_mat, const swrModel_Node *node,

--- a/dinput_hook/node_utils.h
+++ b/dinput_hook/node_utils.h
@@ -65,7 +65,7 @@ swrRace *find_entity_for_node(const swrModel_Node *node);
 // camera is hiding (POD_HIDDEN set, DEAD clear) -- a pod the stock game re-shows to other viewports
 // in swrViewport_Render, which the OpenGL renderer replaces and skips. Scene traversal uses this to
 // draw such a pod anyway (otherwise a remote player in bumper cam, or an AI on the post-race autopilot
-// cam, is invisible to everyone). Keyed on the exact node the game hides (owner->unk344_nodeArray[0])
+// cam, is invisible to everyone). Keyed on the exact node the game hides (owner->partNodes[0])
 // so the sub-nodes hidden on purpose (cockpit interior, shadows) are not un-hidden with it.
 bool is_foreign_hidden_pod_root(const swrModel_Node *node);
 

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1750,9 +1750,9 @@ extern "C" void init_renderer_hooks() {
     // trail + splash sound, draining the fixed 16-slot Toss pool and hammering the shared splash
     // voice so the player's trail/sound restarts. Reserve pool headroom + silence the sound for
     // non-local pods. Both originals are dormant (reverse-hooked); hooked by address.
-    hook_function("swrRace_SpawnGroundDustKick_Maybe",
-                  (uint32_t) swrRace_SpawnGroundDustKick_Maybe_ADDR,
-                  (uint8_t *) swrRace_SpawnGroundDustKick_Maybe_delta);
+    hook_function("swrRace_SpawnGroundDustKick",
+                  (uint32_t) swrRace_SpawnGroundDustKick_ADDR,
+                  (uint8_t *) swrRace_SpawnGroundDustKick_delta);
     hook_function("playASound", (uint32_t) playASound_ADDR, (uint8_t *) playASound_delta);
     // Enlarge the dust-kick Toss pool so full-LOD AI dust doesn't starve the player's trail.
     hook_function("swrObjToss_AddDustKickModelsToScene",

--- a/src/Main/swrControl.c
+++ b/src/Main/swrControl.c
@@ -49,3 +49,17 @@ int swrControl_Startup(void)
     HANG("TODO");
     return 0;
 }
+
+// 0x00409ee0
+int swrControl_PlayForceEffect(int effectId, int magnitude, int direction, int duration)
+{
+    HANG("TODO");
+    return 0;
+}
+
+// 0x0040a0b0
+int swrControl_StopForceEffect(int effectId)
+{
+    HANG("TODO");
+    return 0;
+}

--- a/src/Swr/swrEvent.c
+++ b/src/Swr/swrEvent.c
@@ -305,3 +305,57 @@ void swrEvent_Broadcast(int event, int* subEvents)
 {
     HANG("TODO");
 }
+
+// Collects up to maxResults objects of the given event type (0x416c6c21 'All!' = any type)
+// within sqrt(maxDistSq) of pos, sorted nearest-first. Skips disabled objects (flags 0x100)
+// and excludeObj. Fills squared distances, pos->object delta vectors and object pointers;
+// returns the number found. Positions are read from the object's transform.vD (+0x50), which
+// every caller relies on by passing 'Test' (swrRace) objects.
+// 0x00450e70
+int swrEvent_FindNearestObjects(int event, rdVector3* pos, float maxDistSq, void* excludeObj, int maxResults, float* outDistances, rdVector3* outDeltas, void** outObjects)
+{
+    int found = 0;
+    for (swrEventManager** it = eventManagerMain; *it != NULL; it++) {
+        swrEventManager* manager = *it;
+        if ((manager->event != event && event != 0x416c6c21) || (manager->flags & 1) == 0)
+            continue;
+
+        char* obj = (char*)manager->head;
+        for (int i = 0; i < manager->count; i++, obj += manager->size) {
+            if ((((swrObj*)obj)->flags & 0x100) != 0 || obj == (char*)excludeObj)
+                continue;
+
+            rdVector4* objPos = &((swrRace*)obj)->transform.vD;
+            float dx = objPos->x - pos->x;
+            float dy = objPos->y - pos->y;
+            float dz = objPos->z - pos->z;
+            float distSq = dz * dz + dy * dy + dx * dx;
+            if (maxDistSq <= distSq)
+                continue;
+
+            // Sorted insertion: find the first slot this distance does not beat.
+            int insertIdx = 0;
+            while (insertIdx < found && outDistances[insertIdx] < distSq)
+                insertIdx++;
+            if (insertIdx >= maxResults)
+                continue;
+
+            int lastIdx;
+            if (found < maxResults)
+                lastIdx = found++;
+            else
+                lastIdx = maxResults - 1;
+            for (int j = lastIdx; j > insertIdx; j--) {
+                outObjects[j] = outObjects[j - 1];
+                outDistances[j] = outDistances[j - 1];
+                outDeltas[j] = outDeltas[j - 1];
+            }
+            outDistances[insertIdx] = distSq;
+            outObjects[insertIdx] = obj;
+            outDeltas[insertIdx].x = dx;
+            outDeltas[insertIdx].y = dy;
+            outDeltas[insertIdx].z = dz;
+        }
+    }
+    return found;
+}

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -397,7 +397,7 @@ void swrModel_ByteSwapNode(swrModel_Node* node)
             mesh->num_vertices = SWAP16(mesh->num_vertices);
             // it seems like vertices and index buffer are not swapped, this seems weird...
 
-            mesh->splineNodeIndex = SWAP16(mesh->splineNodeIndex);
+            mesh->splineSampleIndex = SWAP16(mesh->splineSampleIndex);
             mesh->vertex_base_offset = SWAP16(mesh->vertex_base_offset);
         }
 

--- a/src/Swr/swrModel.c
+++ b/src/Swr/swrModel.c
@@ -397,7 +397,7 @@ void swrModel_ByteSwapNode(swrModel_Node* node)
             mesh->num_vertices = SWAP16(mesh->num_vertices);
             // it seems like vertices and index buffer are not swapped, this seems weird...
 
-            mesh->unk1 = SWAP16(mesh->unk1);
+            mesh->splineNodeIndex = SWAP16(mesh->splineNodeIndex);
             mesh->vertex_base_offset = SWAP16(mesh->vertex_base_offset);
         }
 

--- a/src/Swr/swrModel.h
+++ b/src/Swr/swrModel.h
@@ -190,8 +190,8 @@
 
 #define swrModel_SwapSceneModels_ADDR (0x0045cf30)
 #define swrModel_FxAnimGetState_Maybe_ADDR (0x0046d690)
-#define swrModel_FxAdvanceAnimTimers_Maybe_ADDR (0x0046d6a0)
-#define swrMath_ClampToRange_Maybe_ADDR (0x0046d730)
+#define swrRace_ApplyPartSinkOffset_ADDR (0x0046d6a0)
+#define swrMath_StepTowardClamped_ADDR (0x0046d730)
 #define BuildBasisFromDirection_ADDR (0x00481100)
 #define BuildLookAtTransform_ADDR (0x00481220)
 #define swrModel_ComputeNodeWorldMatrix_Maybe_ADDR (0x004816f0)
@@ -398,11 +398,13 @@ int swrModel_AnyFxAnimDone(swrModel_Animation** anims);
 // Returns zero as an always-not-done FX animation state (best guess).
 int swrModel_FxAnimGetState_Maybe(void);
 
-// Advances up to five FX or engine animation timers by the per-frame delta, gated by enable flags (best guess).
-void swrModel_FxAdvanceAnimTimers_Maybe(int entity);
+// Adds the pod's vertical sink offset (swrRace 0x250) to the Z translation of the engine /
+// cockpit part transforms (partXf[1..5]) each frame. Misnamed historically as anim timers.
+void swrRace_ApplyPartSinkOffset(int entity);
 
-// Clamps a value to a centered range and then to a min/max range (best guess).
-float swrMath_ClampToRange_Maybe(float value, float center, float min, float max, float upper, float lower);
+// Rate-limited approach: clamps value into [current - lower, current + upper], then into
+// [min, max] (asymmetric step toward a target).
+float swrMath_StepTowardClamped(float value, float current, float min, float max, float upper, float lower);
 
 swrModel_Material* swrModel_NodeFindFirstMaterial(swrModel_Node* node);
 void swrModel_NodeSetAnimationFlagsAndSpeed(swrModel_Node* node, swrModel_AnimationFlags flags_to_disable, swrModel_AnimationFlags flags_to_enable, float speed);

--- a/src/Swr/swrMultiplayer.c
+++ b/src/Swr/swrMultiplayer.c
@@ -161,3 +161,9 @@ unsigned int swrMultiplayer_SetSessionDesc(int unused, void* param_2)
     HANG("TODO");
     return 0;
 }
+
+// 0x0041df10
+void swrMultiplayer_SendEvent(int to, unsigned int flags, int eventMagic, int a4, float a5, float a6, double a7, void* a8, void* a9, int a10)
+{
+    HANG("TODO");
+}

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -1847,8 +1847,8 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->flags0 = racer->flags0 & ~swrObjTest_FLAG0_ZOFF;
     racer->splineSampleSpacing = 0.0f;
     racer->splineTrackMesh = NULL;
-    racer->unkf8 = 0;
-    racer->unk100 = 0;
+    racer->splineProjResult1 = 0;
+    racer->splineProjResult2 = 0;
     racer->trackOffset.w = 1.0f;
     racer->trackOffset.x = 0.0f;
     racer->trackOffset.y = 0.0f;

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -418,7 +418,7 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
             firstPlaceRank = rankValues[maxIdx];
 
         swrRace* pod = swrScoresPtr[maxIdx].obj_test_ptr;
-        pod->unk128 = (int)(firstPlaceRank - rankValues[maxIdx]);
+        pod->leaderGap = firstPlaceRank - rankValues[maxIdx];
 
         if (firstLocalPlayer == NULL) {
             pod->rivalGapAhead = -0x3d380000;
@@ -564,8 +564,8 @@ void swrObjJdge_StartPostRaceSequence(swrObjJdge* jdge)
         swrRace* racer = swrScoresPtr[i].obj_test_ptr;
         if (racer != NULL) {
             racer->flags1 &= ~swrObjTest_FLAG1_BOOST_START_CANCEL;
-            // set the flags0 low-nibble race state to 1 (clears RACING == 2)
-            racer->flags0 = (racer->flags0 & 0xfffffff1) | 1;
+            // set the flags0 low-nibble race state to post-race (clears RACING == 2)
+            racer->flags0 = (racer->flags0 & ~swrObjTest_FLAG0_STATE_MASK) | swrObjTest_FLAG0_STATE_POSTRACE;
         }
     }
 }
@@ -839,7 +839,7 @@ void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge)
                     if (gap < -0.5f)
                         gap -= -1.0f;
                     gap = gap * scale * 0.022222222f - -119.0f;
-                    if (*(int*)s->unk18 == -1 || gap > 164.0f || gap < 74.0f)
+                    if (*s->pilotId == -1 || gap > 164.0f || gap < 74.0f)
                         continue;
                     short sprite = (short)(0x2b + i);
                     uint8_t a;
@@ -885,7 +885,7 @@ void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge)
                 x = 20.0f;
                 y = 215.0f - (p - 720.0f);
             }
-            if (*(int*)s->unk18 == -1)
+            if (*s->pilotId == -1)
                 continue;
             short sprite = (short)(0x2b + i);
             swrSprite_SetColor(sprite, -1, -1, -1, -1);
@@ -1005,7 +1005,7 @@ void swrObjJdge_DrawRaceHUD(swrObjJdge* jdge)
                     xBase = 114.0f;
             }
             float y = q * 0.28901735f - -20.0f;
-            if (*(int*)s->unk18 != -1 && (s->obj_test_ptr->flags1 & (swrObjTest_FLAG1_FORCE_GROUND | swrObjTest_FLAG1_ON_LAVA)) == 0) {
+            if (*s->pilotId != -1 && (s->obj_test_ptr->flags1 & (swrObjTest_FLAG1_FORCE_GROUND | swrObjTest_FLAG1_ON_LAVA)) == 0) {
                 short sprite = (short)(0x2b + i);
                 swrSprite_SetVisible(sprite, 1);
                 swrSprite_SetPos(sprite, (short)(int)xBase, (short)(int)y);
@@ -1107,7 +1107,7 @@ int swrObjJdge_IsRacerRacing(swrObjJdge* jdge, swrRace* racer)
         return 0;
     }
 
-    if ((racer->flags1 & swrObjTest_FLAG1_FINISHED) == 0 && (4 < racer->unk10c || racer->speedValue < swrObjJdge_notRacingSpeedThreshold)) {
+    if ((racer->flags1 & swrObjTest_FLAG1_FINISHED) == 0 && (4 < racer->checkpointCount || racer->speedValue < swrObjJdge_notRacingSpeedThreshold)) {
         return 1;
     }
     return 0;
@@ -1126,7 +1126,7 @@ void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score)
 
     if ((racer->flags1 & swrObjTest_FLAG1_FINISHED) != 0) {
         swrRace_InRaceEndStatistics(jdge, score);
-        racer->flags0 &= 0xf7ffffff;
+        racer->flags0 &= ~swrObjTest_FLAG0_GUIDE_ARROW;
         if (someRootNodeChildNodes[nodeIdx] != NULL)
             swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, -4, 0x10, 3);
         swrObjJdge_HideEngineUI(score);
@@ -1135,17 +1135,17 @@ void swrObjJdge_UpdatePlayerHUD(swrObjJdge* jdge, swrScore* score)
 
     if ((jdge->flag & 0xf) == 1) {
         if (swrObjJdge_IsRacerRacing(jdge, racer) == 0) {
-            racer->flags0 &= 0xf7ffffff;
+            racer->flags0 &= ~swrObjTest_FLAG0_GUIDE_ARROW;
             if (someRootNodeChildNodes[nodeIdx] != NULL)
                 swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, -4, 0x10, 3);
         } else {
             if (someRootNodeChildNodes[nodeIdx] != NULL)
                 swrModel_NodeModifyFlags(someRootNodeChildNodes[nodeIdx], 2, 3, 0x10, 2);
-            racer->flags0 |= 0x8000000; // flags0 bit 0x8000000 not named in swrObjTest_FLAG0
+            racer->flags0 |= swrObjTest_FLAG0_GUIDE_ARROW;
             rdMatrix44 guideMat;
-            swrSpline_EvaluateAtOffset(&racer->unk4_mat, &guideMat, 0.5f);
-            rdVector_Copy3((rdVector3*)(racer->unk12 + 4), (rdVector3*)&guideMat.vD);
-            *(swrModel_Node**)racer->unk12 = someRootNodeChildNodes[nodeIdx];
+            swrSpline_EvaluateAtOffset(&racer->splineCursor, &guideMat, 0.5f);
+            rdVector_Copy3(&racer->guideArrowTarget, (rdVector3*)&guideMat.vD);
+            racer->guideArrowNode = someRootNodeChildNodes[nodeIdx];
         }
     }
 
@@ -1831,7 +1831,7 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     swrTranslationRotation splineRot;
     rdMatrix44 splineMat;
 
-    swrSpline_EvaluateAtOffset(&racer->unk4_mat, &splineMat, t);
+    swrSpline_EvaluateAtOffset(&racer->splineCursor, &splineMat, t);
     rdMatrix_ExtractTransform(&splineMat, &splineRot);
     racer->spawn_pos_rot.translation.x = splineRot.translation.x;
     racer->spawn_pos_rot.translation.y = splineRot.translation.y;
@@ -1841,20 +1841,20 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->spawn_pos_rot.yaw_roll_pitch.z = splineRot.yaw_roll_pitch.z;
     rdMatrix_SetTransform44(&racer->transform, &racer->spawn_pos_rot);
     // clear per-race transient state bits
-    racer->flags0 = racer->flags0 & ~(swrObjTest_FLAG0_UNDER_POWER_Maybe | swrObjTest_FLAG0_BRAKING | swrObjTest_FLAG0_TP_TO_SPLINE | swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_INPUT_STATE_Maybe | swrObjTest_FLAG0_BOOSTING);
+    racer->flags0 = racer->flags0 & ~(swrObjTest_FLAG0_THROTTLE_SETTLED | swrObjTest_FLAG0_BRAKING | swrObjTest_FLAG0_TP_TO_SPLINE | swrObjTest_FLAG0_POD_HIDDEN | swrObjTest_FLAG0_LOOK_BACK | swrObjTest_FLAG0_BOOSTING);
     racer->flags1 = racer->flags1 & ~(swrObjTest_FLAG1_FLAT_CACHE | swrObjTest_FLAG1_ON_FLAT);
     bool below = t < 0.0f;
     racer->flags0 = racer->flags0 & ~swrObjTest_FLAG0_ZOFF;
-    racer->unkdc = 0;
-    racer->unkec_node = NULL;
+    racer->splineSampleSpacing = 0.0f;
+    racer->splineTrackMesh = NULL;
     racer->unkf8 = 0;
     racer->unk100 = 0;
-    racer->unk118_vec.w = 1.0f;
-    racer->unk118_vec.x = 0.0f;
-    racer->unk118_vec.y = 0.0f;
-    racer->unk118_vec.z = 1.0f;
-    racer->unk10c = 0;
-    racer->unk10e = 0;
+    racer->trackOffset.w = 1.0f;
+    racer->trackOffset.x = 0.0f;
+    racer->trackOffset.y = 0.0f;
+    racer->trackOffset.z = 1.0f;
+    racer->checkpointCount = 0;
+    racer->splineRebindResult = 0;
     racer->idleTick = 0.0f;
     racer->moveTick = 0;
     if (below)
@@ -1869,15 +1869,15 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     racer->boostValue = 0.0f;
     racer->engineTemp = 100.0f;
     rdVector_Set3(&racer->velocityDir, 0.0f, 0.0f, 0.0f);
-    racer->unk1f00 = 0.25f;
+    racer->unk1efc = 0.25f;
     racer->turnRate = 0.0f;
     racer->turnRateTarget = 0.0f;
     racer->unk10_3 = 0;
-    racer->unk10_1 = 0.0f;
-    racer->unk10_2 = 0.0f;
+    racer->zeroGPitchRate = 0.0f;
+    racer->zeroGPitchRateTarget = 0.0f;
     racer->turnModifier = 0.0f;
     racer->autoTilt = 0.0f;
-    racer->unk8_11 = 0.0f;
+    racer->contactSteerKick = 0.0f;
     racer->tiltAngleTarget = 0.0f;
     racer->tiltAngle = 0.0f;
     rdVector_Set3(&racer->velocitySlope, 0.0f, 0.0f, 0.0f);
@@ -1888,20 +1888,20 @@ void swrRace_ResetToSpline(swrRace* racer, float t)
     rdVector_Copy3(&racer->positionPrev, (rdVector3*)&racer->transform.vD);
     rdVector_Copy3(&racer->positionDeath, (rdVector3*)&racer->transform.vD);
     racer->speedLoss = 0.0f;
-    racer->unk1f1c = 0;
-    racer->unk11_1 = 0;
-    racer->unk338 = 0;
-    racer->unk33c = 0;
-    racer->unk340 = 0;
     racer->unk1f18 = 0;
+    racer->unk11_1 = 0;
+    racer->spinoutEngineAngle = 0.0f;
+    racer->spinoutCockpitAngle = 0.0f;
+    racer->spinoutSpinRamp = 0.0f;
+    racer->unk1f14 = 0.0f;
     racer->tiltManualMult = 0.0f;
     racer->unk9 = 0;
-    racer->unk12_1 = 0.0f;
+    racer->wallHitCooldown = 0.0f;
     racer->unk19b0 = 0.0f;
     racer->groundToPodMeasure = 0.0f;
     racer->groundZ = 0.0f;
     racer->unk12_2 = 60.0f;
-    racer->unk19ac = 1.0f;
+    racer->wobbleAmplitude = 1.0f;
     racer->unk19b4 = 1.0f;
 }
 

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -444,7 +444,7 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
             firstPlaceRank = rankValues[maxIdx];
 
         swrRace* pod = swrScoresPtr[maxIdx].obj_test_ptr;
-        pod->leaderGap = firstPlaceRank - rankValues[maxIdx];
+        pod->gapToLeader = firstPlaceRank - rankValues[maxIdx];
 
         if (firstLocalPlayer == NULL) {
             pod->rivalGapAhead = -0x3d380000;

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -373,10 +373,12 @@ float swrObjJdge_GetRacerRankValue(swrScore* score)
     return swrObjJdge_maxRaceTime - score->results_P1_total_time;
 }
 
-// Assigns finishing positions and per-pod HUD gap values. For each racer it stores the gap to the
-// leader (unk128), the signed gap to the local player(s) (rivalGapAhead/rivalGapBehind), and the
-// gap to the lead pod (aiLineOffset). It also tags the two nearest rivals ahead (flag 0x8000) and, in 2-player, behind
-// (flag 0x10000) of the local players, for the on-screen rival arrows.
+// Assigns finishing positions and the per-pod progress-gap fields (all in laps: see types.h).
+// For each racer it stores the gap to the race leader (gapToLeader), the signed gap to the local
+// player(s) (gapToLocalPlayer1/gapToLocalPlayer2, -100.0 when no local player), and the gap to the
+// pace-setter (gapToPacer, measured against the AI_SIMPLE track-favorite pod). It also tags the two
+// AI nearest to local player 1 (AI_TETHER_LOCAL1) and, in 2-player, to local player 2
+// (AI_TETHER_LOCAL2); swrRace_AI paces those pods directly on their gap to that player.
 // 0x0045d4a0
 void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
 {
@@ -389,8 +391,8 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
     for (int i = 0; i < jdge->num_players; i++) {
         swrScore* score = &swrScoresPtr[i];
         *(short*)&score->results_P1_Position = -1;
-        score->obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_RIVAL_AHEAD;
-        score->obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_RIVAL_BEHIND;
+        score->obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_TETHER_LOCAL1;
+        score->obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_TETHER_LOCAL2;
         float rank = swrObjJdge_GetRacerRankValue(score);
         rankValues[i] = rank;
         if (score == firstLocalPlayer) {
@@ -447,14 +449,14 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
         pod->gapToLeader = firstPlaceRank - rankValues[maxIdx];
 
         if (firstLocalPlayer == NULL) {
-            pod->rivalGapAhead = -0x3d380000;
+            pod->gapToLocalPlayer1 = -100.0f; // no local player sentinel
         } else if (secondLocalPlayer == NULL) {
             if (firstLocalIdx == maxIdx) {
-                pod->rivalGapAhead = 0;
+                pod->gapToLocalPlayer1 = 0;
             } else {
                 float gap = firstLocalRank - rankValues[maxIdx];
                 bool neg = gap < 0.0f;
-                pod->rivalGapAhead = (int)gap;
+                pod->gapToLocalPlayer1 = gap;
                 if (neg)
                     gap = -gap;
                 if (aGapA <= gap) {
@@ -472,53 +474,53 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
                 }
             }
         } else if (firstLocalIdx == maxIdx) {
-            pod->rivalGapAhead = 0;
-            pod->rivalGapBehind = (int)(secondLocalRank - firstLocalRank);
+            pod->gapToLocalPlayer1 = 0;
+            pod->gapToLocalPlayer2 = secondLocalRank - firstLocalRank;
         } else if (secondLocalIdx == maxIdx) {
-            pod->rivalGapBehind = 0;
-            pod->rivalGapAhead = (int)(firstLocalRank - secondLocalRank);
+            pod->gapToLocalPlayer2 = 0;
+            pod->gapToLocalPlayer1 = firstLocalRank - secondLocalRank;
         } else {
-            float gapAhead = firstLocalRank - rankValues[maxIdx];
-            float gapBehind = secondLocalRank - rankValues[maxIdx];
-            bool neg = gapAhead < 0.0f;
-            pod->rivalGapAhead = (int)gapAhead;
-            pod->rivalGapBehind = (int)gapBehind;
+            float gapP1 = firstLocalRank - rankValues[maxIdx];
+            float gapP2 = secondLocalRank - rankValues[maxIdx];
+            bool neg = gapP1 < 0.0f;
+            pod->gapToLocalPlayer1 = gapP1;
+            pod->gapToLocalPlayer2 = gapP2;
             if (neg)
-                gapAhead = -gapAhead;
-            if (aGapA <= gapAhead) {
-                if (aGapB <= gapAhead) {
-                    if (gapAhead < aGapC)
-                        aGapC = gapAhead;
+                gapP1 = -gapP1;
+            if (aGapA <= gapP1) {
+                if (aGapB <= gapP1) {
+                    if (gapP1 < aGapC)
+                        aGapC = gapP1;
                 } else {
                     aGapC = aGapB;
-                    aGapB = gapAhead;
+                    aGapB = gapP1;
                     aheadIdx2 = maxIdx;
                 }
             } else {
                 aGapC = aGapB;
                 aheadIdx2 = aheadIdx1;
                 aGapB = aGapA;
-                aGapA = gapAhead;
+                aGapA = gapP1;
                 aheadIdx1 = maxIdx;
             }
-            if (gapBehind < 0.0f)
-                gapBehind = -gapBehind;
-            if (bGapA <= gapBehind) {
-                if (bGapB > gapBehind) {
+            if (gapP2 < 0.0f)
+                gapP2 = -gapP2;
+            if (bGapA <= gapP2) {
+                if (bGapB > gapP2) {
                     bGapC = bGapB;
-                    bGapB = gapBehind;
+                    bGapB = gapP2;
                     behindIdx2 = maxIdx;
                 }
             } else {
                 bGapC = bGapB;
                 behindIdx2 = behindIdx1;
                 bGapB = bGapA;
-                bGapA = gapBehind;
+                bGapA = gapP2;
                 behindIdx1 = maxIdx;
             }
         }
 
-        pod->aiLineOffset = (int)(leaderProgress - rankValues[maxIdx]);
+        pod->gapToPacer = leaderProgress - rankValues[maxIdx];
         rankValues[maxIdx] = 0.0f;
         *(short*)&swrScoresPtr[maxIdx].results_P1_Position = (short)pos;
         pos++;
@@ -527,17 +529,17 @@ void swrObjJdge_UpdateStandings(swrObjJdge* jdge)
     // tag the two nearest rivals behind (2-player only) and ahead of the local player(s)
     if (secondLocalPlayer != NULL) {
         if (behindIdx1 != -1 && rankValues[behindIdx1] < (float)jdge->num_laps - 0.1f)
-            swrScoresPtr[behindIdx1].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_RIVAL_BEHIND;
+            swrScoresPtr[behindIdx1].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_TETHER_LOCAL2;
         if (behindIdx2 != -1 && rankValues[behindIdx2] < (float)jdge->num_laps - 0.1f)
-            swrScoresPtr[behindIdx2].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_RIVAL_BEHIND;
+            swrScoresPtr[behindIdx2].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_TETHER_LOCAL2;
     }
     if (aheadIdx1 != -1 && rankValues[aheadIdx1] < (float)jdge->num_laps - 0.1f) {
-        swrScoresPtr[aheadIdx1].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_RIVAL_AHEAD;
-        swrScoresPtr[aheadIdx1].obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_RIVAL_BEHIND;
+        swrScoresPtr[aheadIdx1].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_TETHER_LOCAL1;
+        swrScoresPtr[aheadIdx1].obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_TETHER_LOCAL2;
     }
     if (aheadIdx2 != -1 && rankValues[aheadIdx2] < (float)jdge->num_laps - 0.1f) {
-        swrScoresPtr[aheadIdx2].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_RIVAL_AHEAD;
-        swrScoresPtr[aheadIdx2].obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_RIVAL_BEHIND;
+        swrScoresPtr[aheadIdx2].obj_test_ptr->flags0 |= swrObjTest_FLAG0_AI_TETHER_LOCAL1;
+        swrScoresPtr[aheadIdx2].obj_test_ptr->flags0 &= ~swrObjTest_FLAG0_AI_TETHER_LOCAL2;
     }
 }
 

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -48,7 +48,7 @@
 #define resetInRaceInputBuffer_ADDR (0x00440d90)
 #define getInRaceInputBufferEntry_Maybe_ADDR (0x00440de0)
 #define updateInRaceInputBitsets_ADDR (0x00440df0)
-#define setInRaceInputState_Maybe_ADDR (0x00441010)
+#define swrModel_SetRaycastIgnoreFacing_ADDR (0x00441010)
 #define swrObjJudge_PollPause_ADDR (0x00445680)
 #define GetPauseState_ADDR (0x00445690)
 #define GetPauseMenuScrollInOut_ADDR (0x004456a0)
@@ -244,7 +244,7 @@
 #define swrScene_Init_ADDR (0x004491f0)
 #define swrScene_ClearTextureAnim_Maybe_ADDR (0x00449260)
 #define swrScene_UpdateTextureScroll_Maybe_ADDR (0x00449270)
-#define swrObjcMan_UpdateSplineGuideMarker_Maybe_ADDR (0x004535c0)
+#define swrObjcMan_UpdateSplineGuideMarker_ADDR (0x004535c0)
 #define swrObjHang_LoadScreenAssets_ADDR (0x004586e0)
 #define swrObjHang_SetupScreenScene_ADDR (0x00459150)
 #define swrUI_ResetMenuInputBitsets_ADDR (0x0045a3e0)
@@ -266,7 +266,7 @@
 #define swrObjHang_StepTransition_ADDR (0x00469b90)
 #define swrObjHang_TickMenuRepeatDelay_Maybe_ADDR (0x00469bf0)
 #define swrObjHang_NavigateVehicleSelect_ADDR (0x00469c30)
-#define swrRace_ClosestApproach2D_Maybe_ADDR (0x0047aee0)
+#define swrRace_ClosestApproach2D_ADDR (0x0047aee0)
 #define swrObjTrig_AddTriggerDescriptions_ADDR (0x0047d380)
 #define swrObjTrig_InitColorBands_Maybe_ADDR (0x0047d890)
 #define swrObjTrig_ApplyNodeRegionColor_Maybe_ADDR (0x0047da10)
@@ -365,14 +365,17 @@ int VerifySelectedTrack(swrObjHang* hang, int selectedTrackIdx);
 // Companion to updateInRaceInputBitsets.
 void* resetInRaceInputBuffer(void);
 
-// Returns the indexed entry from the in-race input buffer (best guess).
+// Returns the indexed entry of the 4-int table at 0x50c5b0; the sole caller
+// (swrObjHang_UpdateSplashScreen) uses entry 1 to append an extra splash screen.
+// NOT input-related despite the name; writer unknown.
 int getInRaceInputBufferEntry_Maybe(int index);
 // Build the per-player rising-edge / held / released in-race input bitsets
 // (inRaceLocalPlayerInputBitset1/2/3) from the raw per-action input bytes.
 void updateInRaceInputBitsets(void);
 
-// Stores a value into the in-race input state global (best guess).
-void setInRaceInputState_Maybe(int value);
+// Sets the flag read by swrModel_CollideMeshNodeRay / CollideRayWithMesh that skips the
+// material-facing classification during raycasts (callers bracket a raycast with 1 / 0).
+void swrModel_SetRaycastIgnoreFacing(int value);
 
 void swrObjJudge_PollPause();
 int GetPauseState();
@@ -424,8 +427,9 @@ void swrObjcMan_UpdateTerrainVisuals(swrObjcMan* cman);
 // along the track spline relative to the pod.
 void swrObjcMan_UpdateSplineCamera(swrObjcMan* cman);
 
-// Per frame advances and positions a trailing spline guide-marker node, setting its color (best guess).
-void swrObjcMan_UpdateSplineGuideMarker_Maybe(int cman);
+// Draws the HUD spline guide arrow for the camera's pod: gated on FLAG0_GUIDE_ARROW,
+// orients guideArrowNode toward guideArrowTarget and tints it.
+void swrObjcMan_UpdateSplineGuideMarker(int cman);
 // Applies FOV/near/far to the viewport and updates fog color/distance and the
 // clear color each frame (swrViewport_SetCameraParameters + SetFogParameters).
 void swrObjcMan_UpdateFogAndViewport(swrObjcMan* cman);
@@ -770,8 +774,9 @@ int swrObjTest_F4(swrRace* player, int* subEvent, int ghost);
 
 void swrObjTest_UpdateControlAndMove(swrRace* player);
 
-// Computes the closest-approach parameter and points between two 2D segments (best guess).
-float swrRace_ClosestApproach2D_Maybe(rdVector2* a0, float* a1, rdVector2* b0, float* b1, rdVector2* outA, rdVector2* outB, rdVector2* outDirA, rdVector2* outDirB);
+// Closest-approach time of two moving 2D points (t clamped to [0,1]) and both positions at
+// that time; used by the pod-pod collision pass.
+float swrRace_ClosestApproach2D(rdVector2* a0, float* a1, rdVector2* b0, float* b1, rdVector2* outA, rdVector2* outB, rdVector2* outDirA, rdVector2* outDirB);
 
 void swrObjTest_UpdatePhysicsContact(swrRace* player);
 void swrObjToss_F2(swrObjToss* toss);

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -366,8 +366,9 @@ int VerifySelectedTrack(swrObjHang* hang, int selectedTrackIdx);
 void* resetInRaceInputBuffer(void);
 
 // Returns the indexed entry of the 4-int table at 0x50c5b0; the sole caller
-// (swrObjHang_UpdateSplashScreen) uses entry 1 to append an extra splash screen.
-// NOT input-related despite the name; writer unknown.
+// (swrObjHang_UpdateSplashScreen) uses entry 1 to append an extra splash screen. NOT
+// input-related despite the name. The table is never written anywhere in the retail
+// binary (BSS, always 0), so the extra splash never shows.
 int getInRaceInputBufferEntry_Maybe(int index);
 // Build the per-player rising-edge / held / released in-race input bitsets
 // (inRaceLocalPlayerInputBitset1/2/3) from the raw per-action input bytes.

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -826,7 +826,7 @@ void swrRace_SetAngleFromTurnRate(float* out_tilt, float cur_turnrate, void* unu
 }
 
 // 0x0044afb0
-void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos)
+void swrRace_GetEngineNodeOffsetPos(void** nodePair, rdVector3* outPos)
 {
     if (nodePair == NULL) {
         rdVector_Set3(outPos, 0.0f, 0.0f, 0.0f);
@@ -852,7 +852,7 @@ void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos)
 }
 
 // 0x0044b270
-void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos)
+void swrRace_SetEngineNodeTranslation(void** nodePair, rdVector3* pos)
 {
     if (nodePair == NULL)
         return;
@@ -872,7 +872,7 @@ void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos)
     }
     rdMatrix44 offsetMat;
     swrModel_NodeGetTransform(offsetNode, &offsetMat);
-    // remove the engine-height offset applied by swrRace_GetEngineNodeOffsetPos_Maybe
+    // remove the engine-height offset applied by swrRace_GetEngineNodeOffsetPos
     rdVector_Scale3Add3((rdVector3*) &out.vD, (rdVector3*) &out.vD, -offsetMat.vD.y, (rdVector3*) &out.vB);
     swrModel_NodeSetTransform(node, &out);
 }

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1585,20 +1585,20 @@ float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNorm
 
     swrRace_ResetCollisionHit();
     if ((player->flags1 & swrObjTest_FLAG1_FULL_RAYCAST) == 0)
-        hitDist = swrModel_CollideRayWithMesh((swrModel_Mesh*) player->unkec_node, ray,
+        hitDist = swrModel_CollideRayWithMesh((swrModel_Mesh*) player->splineTrackMesh, ray,
                                               (float*) &outPoint, (float*) &outNormal);
     else
         hitDist = -1.0f;
 
     if (hitDist < 0.0)
-        hitDist = swrRace_RaycastModel(player->model_unk, ray, &outPoint, &outNormal);
+        hitDist = swrRace_RaycastModel(player->collisionModel, ray, &outPoint, &outNormal);
 
     if (((player->flags1 & swrObjTest_FLAG1_MAGNET) != 0) && (hitDist < 0.0)) {
         // surface-relative cast missed: retry straight down (world gravity)
         ray[3] = player->world_gravity.x;
         ray[4] = player->world_gravity.y;
         ray[5] = player->world_gravity.z;
-        hitDist = swrRace_RaycastModel(player->model_unk, ray, &outPoint, &outNormal);
+        hitDist = swrRace_RaycastModel(player->collisionModel, ray, &outPoint, &outNormal);
     }
 
     player->terrainModel = swrRace_GetCollisionHit();
@@ -1654,7 +1654,7 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
             up->x = player->up.x;
             up->y = player->up.y;
             up->z = player->up.z;
-            player->terrainModel = player->unkec_node;
+            player->terrainModel = player->splineTrackMesh;
             flags1 = player->flags1 | swrObjTest_FLAG1_GROUND_CACHED;
         }
         player->flags1 = flags1;
@@ -1687,13 +1687,13 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
 
         if ((((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) && ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0) &&
             (0.0f <= progress && progress <= 1.0f)) {
-            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0);
             velocity[2] = progress * (splineMat.vD.z - velocity[2]) + velocity[2];
         }
 
         if ((player->flags1 & swrObjTest_FLAG1_ON_FLAT) == 0) {
             if ((player->flags0 & swrObjTest_FLAG0_LOCAL) == 0) {
-                swrRace_CollideBlockMove((rdVector3*) velocity, &prevPos, player->model_unk, &collideNormal);
+                swrRace_CollideBlockMove((rdVector3*) velocity, &prevPos, player->collisionModel, &collideNormal);
             } else {
                 rdVector3 before;
                 before.x = velocity[0];
@@ -1719,10 +1719,10 @@ float swrRace_UpdateGroundContact(swrRace* player, float* velocity, int scrapeDa
                                                  groundDist, &up->x);
         }
     } else {
-        player->terrainModel = player->unkec_node;
+        player->terrainModel = player->splineTrackMesh;
         player->flags1 = player->flags1 | swrObjTest_FLAG1_GROUND_CACHED;
         if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) {
-            swrSpline_EvaluateAtOffset(&player->unk4_mat, &splineMat, 0.0);
+            swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0);
             velocity[2] = splineMat.vD.z;
         }
         groundDist = 2.0f;
@@ -1917,7 +1917,7 @@ void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos
     int subEvent[4];
     subEvent[0] = 0x42697473; // 'Bits'
     swrEvent_CallF4(0x54657374, subEvent); // 'Test'
-    player->unk324 = engineSlot;
+    player->fireballEngineSlot = engineSlot;
 
     // Build a random orientation+scale basis for the fireball node.
     rdMatrix44 m;
@@ -1949,13 +1949,13 @@ void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos
 
     // When a valid engine slot is set, position the fireball at that engine's matrix;
     // otherwise use the caller-supplied point.
-    if (player->unk324 >= 0) {
-        pos = (rdVector3*) ((char*) player + (player->unk324 + 0xe) * 0x40);
+    if (player->fireballEngineSlot >= 0) {
+        pos = (rdVector3*) ((char*) player + (player->fireballEngineSlot + 0xe) * 0x40);
     }
     rdVector_Copy3((rdVector3*) &m.vD, pos);
 
     swrModel_Node* src =
-        (player->unk344_nodeArray == NULL) ? player->unk348_node : player->unk344_nodeArray[1];
+        (player->partNodes == NULL) ? player->lodBodyNode : player->partNodes[1];
     swrRace_RandomizeMeshNodes(fireballNodePtr, src);
     rdMatrix_Copy44(&swrRace_fireballTransform, &m);
     swrModel_NodeSetTransform((swrModel_NodeTransformed*) fireballNodePtr, &m);
@@ -2096,12 +2096,12 @@ void swrRace_UpdateTurn2(swrRace* player, rdVector3* pos, rdVector3* turnInput)
         player->transform.vC.y = rc * vCy + rs * vCx;
     }
 
-    player->unk1e6c = player->unk1e6c - 1;
-    if (player->unk1e6c < 0) {
+    player->orthoRenormCounter = player->orthoRenormCounter - 1;
+    if (player->orthoRenormCounter < 0) {
         rdVector_Normalize3Acc((rdVector3*) &player->transform.vA);
         rdVector_Normalize3Acc((rdVector3*) &player->transform.vB);
         rdVector_Normalize3Acc((rdVector3*) &player->transform.vC);
-        player->unk1e6c = 8;
+        player->orthoRenormCounter = 8;
     }
     player->transform.vD.x = pos->x;
     player->transform.vD.y = pos->y;
@@ -2449,9 +2449,9 @@ void swrRace_IntegrateMotion(swrRace* player, rdVector3* b, rdVector3* c, rdVect
     rdVector3 outNormal;
     float savedX = c->x, savedY = c->y, savedZ = c->z;
     int iter;
-    int hit = swrRace_CollideTrack(c, b, player->model_unk, &outNormal);
+    int hit = swrRace_CollideTrack(c, b, player->collisionModel, &outNormal);
     for (iter = 0; hit != 0 && iter < 6; iter++)
-        hit = swrRace_CollideTrack(c, b, player->model_unk, &outNormal);
+        hit = swrRace_CollideTrack(c, b, player->collisionModel, &outNormal);
     if (0 < iter && (player->flags0 & swrObjTest_FLAG0_AI) != 0)
         player->accelThrust *= stdMath_Decelerator(5.0f, swrRace_deltaTimeSecs);
     player->wallPushback.x = c->x - savedX;

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1444,16 +1444,16 @@ void swrRace_UpdatePlayerControl(swrRace* player)
     swrRace_ApplyEngineDamage(player);
     swrRace_Repair(player);
 
-    // ---- zero-g (ZON): pitch -> lateral torque unk10_2 ----
+    // ---- zero-g (ZON): the pitch stick becomes a pitch-RATE demand ----
     if ((player->flags0 & swrObjTest_FLAG0_ZON) != 0) {
         if (pitchForward >= SWR_CTL_STEER_DEADZONE || -pitchForward >= SWR_CTL_STEER_DEADZONE) {
             float squared = pitchForward * SWR_CTL_STEER_SQUARE_GAIN * (pitchForward * SWR_CTL_STEER_SQUARE_GAIN);
             if (pitchForward < 0.0f) {
                 squared = -squared;
             }
-            player->unk10_2 = -(player->podStats.maxTurnRate * squared * SWR_CTL_STEER_SCALE) * SWR_CTL_HALF;
+            player->zeroGPitchRateTarget = -(player->podStats.maxTurnRate * squared * SWR_CTL_STEER_SCALE) * SWR_CTL_HALF;
         } else {
-            player->unk10_2 = 0.0f;
+            player->zeroGPitchRateTarget = 0.0f;
         }
         pitchForward = 0.0f;
     }

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -1151,13 +1151,13 @@ void swrRace_ApplyPodProximityForce(swrRace* player)
 }
 
 // 0x0046ba30
-void swrRace_SpawnExplosionEffect(swrRace* player)
+void swrRace_SpawnFlameAttack(swrRace* player)
 {
     HANG("TODO");
 }
 
 // 0x0046bb30
-void swrRace_SendFlameEvent_Maybe(int player, double param_2, void* param_3, void* param_4, int param_5)
+void swrRace_SendFlameAttackEvent(int player, double param_2, void* param_3, void* param_4, int param_5)
 {
     HANG("TODO");
 }
@@ -1174,7 +1174,6 @@ void swrRace_UpdateAutopilotControl(swrRace* player)
 // repair/taunt, applies the engine-damage steering pull + force feedback, boost-start detection and
 // flame-attack, then commits turnRateTarget / throttle / tilt / flags0 / flags1. Reverse-hooked
 // (dormant). Preserves an original bug: the analog pitch LOW clamp also writes +0.8 (see below).
-// unk2f4 / unk1f14 are int-typed fields that store float bit-patterns (reinterpreted, not converted).
 // 0x0046bec0
 void swrRace_UpdatePlayerControl(swrRace* player)
 {
@@ -1258,20 +1257,20 @@ void swrRace_UpdatePlayerControl(swrRace* player)
         lookBackInput = bitset3 & 0x8;
         viewButtonInput = inRaceLocalPlayerInputBitset1[playerIndex] & 0x4;
         if ((inRaceLocalPlayerInputBitset1[playerIndex] & 0x80) != 0) {
-            if ((float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_BOOST_TAP_TIMEOUT) {
-                *((char*) &player->unk2f8 + 1) = 0;
+            if ((float) timetotal - player->tauntTapTime > (float) SWR_CTL_BOOST_TAP_TIMEOUT) {
+                *((char*) &player->tauntTapState + 1) = 0;
             }
-            char taps = *((char*) &player->unk2f8 + 1) + 1;
-            *(float*) &player->unk2f4 = (float) timetotal;
-            *((char*) &player->unk2f8 + 1) = taps;
+            char taps = *((char*) &player->tauntTapState + 1) + 1;
+            player->tauntTapTime = (float) timetotal;
+            *((char*) &player->tauntTapState + 1) = taps;
             if (taps > 1) {
                 flameTaunt = 1;
             }
         }
         if ((*(char*) &inRaceLocalPlayerInputBitset2[playerIndex] & 0x80) != 0) {
-            *(float*) &player->unk2f4 = (float) timetotal;
+            player->tauntTapTime = (float) timetotal;
         }
-        if ((bitset3 & 0x80) != 0 && (float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_HALF_HOLD) {
+        if ((bitset3 & 0x80) != 0 && (float) timetotal - player->tauntTapTime > (float) SWR_CTL_HALF_HOLD) {
             repairHold = true;
         }
         slideInput = (bitset3 & 0x100) != 0;
@@ -1304,35 +1303,37 @@ void swrRace_UpdatePlayerControl(swrRace* player)
         viewButtonInput = inRaceLocalPlayerInputBitset1[demoIndex] & 0x4;
         lookBackInput = inRaceLocalPlayerInputBitset3[demoIndex] & 0x8;
         if ((inRaceLocalPlayerInputBitset1[demoIndex] & 0x80) != 0) {
-            if ((float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_BOOST_TAP_TIMEOUT) {
-                *((char*) &player->unk2f8 + 1) = 0;
+            if ((float) timetotal - player->tauntTapTime > (float) SWR_CTL_BOOST_TAP_TIMEOUT) {
+                *((char*) &player->tauntTapState + 1) = 0;
             }
-            char taps = *((char*) &player->unk2f8 + 1) + 1;
-            *(float*) &player->unk2f4 = (float) timetotal;
-            *((char*) &player->unk2f8 + 1) = taps;
+            char taps = *((char*) &player->tauntTapState + 1) + 1;
+            player->tauntTapTime = (float) timetotal;
+            *((char*) &player->tauntTapState + 1) = taps;
             if (taps > 1) {
                 flameTaunt = 1;
             }
         }
         if ((*(char*) &inRaceLocalPlayerInputBitset2[demoIndex] & 0x80) != 0) {
-            *(float*) &player->unk2f4 = (float) timetotal;
+            player->tauntTapTime = (float) timetotal;
         }
         if ((*(char*) &inRaceLocalPlayerInputBitset3[demoIndex] & 0x80) != 0 &&
-            (float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_HALF_HOLD) {
+            (float) timetotal - player->tauntTapTime > (float) SWR_CTL_HALF_HOLD) {
             repairHold = true;
         }
         slideInput = steerA > SWR_CTL_HALF && steerB < SWR_CTL_DEMO_STEER_SCALE;
         playerIndex = demoIndex;
     }
 
-    // ---- scripted-camera zone flag (unk4_mat+0x28 written as an int bit-pattern of 1) ----
-    *(float*) ((char*) &player->unk4_mat + 0x28) = 0.0f;
+    // ---- scripted spline-fork override: force branch 1 during the script 5/6 lap windows ----
+    // (retail clears the slot with a float 0.0 store and sets it with an int 1; both are the same
+    // dword on this int field, so the plain integer assignments below are bit-identical.)
+    player->splineCursor.branchSelector = 0;
     if (ai_track_script > 0) {
         if (ai_track_script == 5 && SWR_CTL_SCRIPT5_LAP_MIN < player->lapComp && player->lapComp < SWR_CTL_SCRIPT5_LAP_MAX) {
-            *(int*) ((char*) &player->unk4_mat + 0x28) = 1;
+            player->splineCursor.branchSelector = 1;
         }
         if (ai_track_script == 6 && SWR_CTL_SCRIPT6_LAP_MIN < player->lapComp && player->lapComp < SWR_CTL_SCRIPT6_LAP_MAX) {
-            *(int*) ((char*) &player->unk4_mat + 0x28) = 1;
+            player->splineCursor.branchSelector = 1;
         }
     }
 
@@ -1387,11 +1388,11 @@ void swrRace_UpdatePlayerControl(swrRace* player)
         if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING &&
             (player->flags0 & (swrObjTest_FLAG0_RESET | swrObjTest_FLAG0_DEAD | swrObjTest_FLAG0_POD_HIDDEN)) == 0 &&
             (player->flags1 & swrObjTest_FLAG1_EXPLODING) == 0) {
-            int soundSource = *(int*) score->unk18;
+            int soundSource = *score->pilotId;
             if (soundSource == 2) {
-                swrRace_SpawnExplosionEffect(player);
+                swrRace_SpawnFlameAttack(player);
                 // retail passes only the timestamp; the reconstructed 5-arg prototype's extra params are fillers.
-                swrRace_SendFlameEvent_Maybe((int) score->time_unk, 0.0, NULL, NULL, 0);
+                swrRace_SendFlameAttackEvent((int) score->time_unk, 0.0, NULL, NULL, 0);
             }
             int rng = swrUtils_Rand();
             int sfxRet;
@@ -1473,7 +1474,7 @@ void swrRace_UpdatePlayerControl(swrRace* player)
     }
     if ((player->flags1 & swrObjTest_FLAG1_BOOST_START) != 0) {
         if (swrSound_TestSfxFlag(0, 0x80000) == 0) {
-            swrSound_PlayRandomSfx(1, *(int*) score->unk18, 2, 2, 2, 2, 2, (rdVector3*) &player->transform.vD);
+            swrSound_PlayRandomSfx(1, *score->pilotId, 2, 2, 2, 2, 2, (rdVector3*) &player->transform.vD);
             swrSound_SetSfxFlag(0, 0x80000);
         }
         if ((swrRace_ThrustInput == 0.0f && swrRace_ThrottleInput <= (float) SWR_CTL_BOOST_THROTTLE) ||
@@ -1558,7 +1559,7 @@ void swrRace_UpdatePlayerControl(swrRace* player)
         player->flags0 &= ~swrObjTest_FLAG0_BOOSTING;
     }
 
-    *(float*) &player->unk1f14 = *(float*) &player->unk1f14 - (float) swrRace_deltaTimeSecs;
+    player->unk1f14 -= (float) swrRace_deltaTimeSecs;
 
     // ---- tilt / bank ----
     if ((bankLeft != 0 || bankRight != 0) && (player->flags1 & swrObjTest_FLAG1_MAGNET) != 0) {

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -957,6 +957,200 @@ void swrRace_Repair(swrRace* player)
     // TODO
 }
 
+// AI glide-dive pitch. When the pod has dropped below its spline path, pitch hard nose-down
+// (-1.0) to dive back onto the line; swrRace_UpdateSpeed grants the AI a 1.3x speed bonus in
+// that state. Near/full-sim pods (useGroundClearance) only dive when actually launched high
+// (ground clearance > 400) unless the AIRBORNE flag is set; far simplified pods dive whenever
+// they are below the line. lookaheadPos is passed by the caller but unused.
+// 0x0046aec0
+void swrRace_UpdateAIGlidePitch(swrRace* player, rdVector3* lookaheadPos, rdVector3* splinePos, int useGroundClearance)
+{
+    float height = 0.0f;
+    if (player->transform.vD.z <= splinePos->z) {
+        height = 500.0f;
+        if ((player->flags1 & swrObjTest_FLAG1_AIRBORNE) == 0 && useGroundClearance != 0) {
+            height = player->groundToPodMeasure;
+        }
+    }
+    player->pitch = (height <= 400.0f) ? 0.0f : -1.0f;
+}
+
+// AI steering autopilot for one racing pod. Sets the throttle (0.98 under power, 0.48
+// coasting), re-rolls the spline fork branch choice (coin flip each frame, overridden on
+// the six ai_track_script tracks inside fixed lap-fraction windows = the scripted shortcut
+// take/avoid forks), updates the glide-dive pitch, adapts the spline look-ahead parameter
+// so the look-ahead segment's world length tracks aiLookAheadDistSq (~90 units), then
+// steers at the look-ahead point with a proportional heading controller: deadzone +/-0.02,
+// gain -10/7, and a throttle lift ((1 - |err|) * 0.5) when the error exceeds +/-0.3.
+// The final turn rate scales with paceMultiplier, so a rubberbanding AI also turns harder.
+// 0x0046af20
+void swrRace_AutopilotSteer(swrRace* player)
+{
+    if ((player->flags0 & swrObjTest_FLAG0_THROTTLE_SETTLED) == 0) {
+        player->throttle = 0.48f;
+    } else {
+        player->throttle = 0.98f;
+    }
+
+    if (player->aiLookAhead < 0.01f) {
+        player->aiLookAhead = 0.01f;
+    }
+    if (2.0f < player->aiLookAhead) {
+        player->aiLookAhead = 2.0f;
+    }
+
+    // Coin-flip the spline fork branch selector for this frame. The selector lives in the
+    // spline cursor's scale.y slot but is an INT (the original stores the __ftol result and
+    // the literals 0/1 directly). swrUtils_Rand is non-negative, so the negative-sample
+    // branch below is defensively dead: pick is uniform over {0, 1}.
+    float sample = (float)swrUtils_Rand() * 4.6566129e-10f * 2.0f;
+    float pick;
+    if (sample < 0.0f) {
+        pick = (float)swrUtils_Rand() * 4.6566129e-10f * 2.0f - 0.99999905f;
+    } else {
+        pick = (float)swrUtils_Rand() * 4.6566129e-10f * 2.0f;
+    }
+    player->splineCursor.branchSelector = (int)pick;
+
+    // Scripted fork choices: signature tracks force the branch inside lap-fraction windows
+    // (scripts 1-4 force the main line = 0, scripts 5-6 force the alternate = 1).
+    if (0 < ai_track_script) {
+        if (ai_track_script == 1) {
+            if (player->lapCompMax < 0.01f) {
+                player->splineCursor.branchSelector = 0;
+            } else if (0.07f < player->lapComp && player->lapComp < 0.14f) {
+                player->splineCursor.branchSelector = 0;
+            }
+        } else if (ai_track_script == 2) {
+            if ((0.53f < player->lapComp && player->lapComp < 0.54f) || (0.55f < player->lapComp && player->lapComp < 0.57f)) {
+                player->splineCursor.branchSelector = 0;
+            }
+        } else if (ai_track_script == 3) {
+            if (0.27f < player->lapComp && player->lapComp < 0.29f) {
+                player->splineCursor.branchSelector = 0;
+            }
+        } else if (ai_track_script == 4) {
+            if (0.72f < player->lapComp && player->lapComp < 0.73f) {
+                player->splineCursor.branchSelector = 0;
+            }
+        } else if (ai_track_script == 5) {
+            if (0.063f < player->lapComp && player->lapComp < 0.072f) {
+                player->splineCursor.branchSelector = 1;
+            }
+        } else if (ai_track_script == 6) {
+            if (0.093f < player->lapComp && player->lapComp < 0.108f) {
+                player->splineCursor.branchSelector = 1;
+            }
+        }
+    }
+
+    rdMatrix44 splineMat;
+    swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, 0.0f);
+    rdVector3 cursorPos;
+    cursorPos.x = splineMat.vD.x;
+    cursorPos.y = splineMat.vD.y;
+    cursorPos.z = splineMat.vD.z;
+    swrSpline_EvaluateAtOffset(&player->splineCursor, &splineMat, player->aiLookAhead);
+
+    // Full-sim pods: within 500 units of a camera, a local human, or force-grounded.
+    int useGroundClearance = ((float)player->lodDistance - 400.0f) * 0.01f < 1.0f || (player->flags0 & swrObjTest_FLAG0_LOCAL) != 0 || (player->flags1 & swrObjTest_FLAG1_FORCE_GROUND) != 0;
+    swrRace_UpdateAIGlidePitch(player, (rdVector3*)&splineMat.vD, &cursorPos, useGroundClearance);
+
+    // Ease the look-ahead parameter so the segment's world length tracks aiLookAheadDistSq.
+    float dx = cursorPos.x - splineMat.vD.x;
+    float dy = cursorPos.y - splineMat.vD.y;
+    float dz = cursorPos.z - splineMat.vD.z;
+    float segLenSq = dz * dz + dy * dy + dx * dx;
+    if (segLenSq < player->aiLookAheadDistSq) {
+        player->aiLookAhead += 0.01f;
+    } else if (player->aiLookAheadDistSq < segLenSq) {
+        player->aiLookAhead -= 0.01f;
+    }
+
+    // Aim point = the look-ahead spline point, lifted to the pod's height along gravity.
+    rdVector3 target;
+    target.x = splineMat.vD.x;
+    target.y = splineMat.vD.y;
+    target.z = splineMat.vD.z;
+    float heightAlongGravity = (player->transform.vD.y - target.y) * player->world_gravity.y + (player->transform.vD.z - target.z) * player->world_gravity.z + (player->transform.vD.x - target.x) * player->world_gravity.x;
+    rdVector3 aimPoint;
+    rdVector_Scale3Add3(&aimPoint, &target, heightAlongGravity, &player->world_gravity);
+
+    rdVector3 dir;
+    dir.x = aimPoint.x - player->transform.vD.x;
+    dir.y = aimPoint.y - player->transform.vD.y;
+    dir.z = aimPoint.z - player->transform.vD.z;
+    float len = rdVector_Len3(&dir);
+    if (len <= 0.01f) {
+        return; // on top of the aim point: keep the caller's zeroed turn rate
+    }
+    float invLen = 1.0f / len;
+    dir.x *= invLen;
+    dir.y *= invLen;
+    dir.z *= invLen;
+
+    // Signed heading error: cross(forward, dir) projected on the gravity axis.
+    rdVector3 cross;
+    rdVector_Cross3(&cross, (rdVector3*)&player->transform.vB, &dir);
+    float err = cross.y * player->world_gravity.y + cross.x * player->world_gravity.x + cross.z * player->world_gravity.z;
+
+    float steer;
+    if (err <= 0.02f) {
+        steer = 0.0f;
+        if (err < -0.02f) {
+            steer = err * -1.42857146f; // -10/7
+            if (err < -0.3f) {
+                player->throttle = (err - -1.0f) * 0.5f * player->throttle;
+            }
+        }
+    } else {
+        steer = err * -1.42857146f;
+        if (0.3f < err) {
+            player->throttle = (1.0f - err) * 0.5f * player->throttle;
+        }
+    }
+    player->turnRateTarget = player->paceMultiplier * player->podStats.maxTurnRate * steer;
+}
+
+// Pod-vs-pod steering interaction for a racing AI pod (called from swrRace_CalcTargetTurnRate).
+// Finds the nearest other pod within 50 units and adds a turn-rate nudge steering away from
+// its side, ramping quadratically as they close: ((50 - d) * 0.2)^2 * 0.8, up to 80 at contact.
+// Special case: when the single nearby pod is a local human closing from behind, the sign
+// flips and the AI steers INTO the player's line instead -- the "blocking" wiggle. AI never
+// block each other, and blocking disengages as soon as a second pod is within range.
+// 0x0046b430
+void swrRace_ApplyPodProximityForce(swrRace* player)
+{
+    float distsSq[4];
+    void* objs[4];
+    rdVector3 deltas[4];
+
+    float sign = 1.0f;
+    player->speedLoss = 0.0f;
+    int count = swrEvent_FindNearestObjects(0x54657374, (rdVector3*)&player->transform.vD, 2500.0f, player, 4, distsSq, deltas, objs);
+    if (count < 1) {
+        return;
+    }
+
+    rdVector3 cross;
+    rdVector_Cross3(&cross, (rdVector3*)&player->transform.vB, deltas);
+    float dist = stdMath_Sqrt(distsSq[0]);
+    float closeness = (50.0f - dist) * 0.2f;
+    float force = closeness * closeness * 0.1f * 8.0f;
+    // Which side the nearest pod is on: cross(forward, delta) projected on the gravity axis.
+    float side = player->world_gravity.y * cross.y + player->world_gravity.z * cross.z + player->world_gravity.x * cross.x;
+
+    // Block instead of avoid: exactly one pod nearby, it is a local human, and it is behind us.
+    if (count == 1 && (((swrRace*)objs[0])->flags0 & swrObjTest_FLAG0_LOCAL) != 0 && player->transform.vB.z * deltas[0].z + player->transform.vB.y * deltas[0].y + deltas[0].x * player->transform.vB.x < 0.0f) {
+        sign = -1.0f;
+    }
+    if (0.0f < side) {
+        player->turnRateTarget = sign * force + player->turnRateTarget;
+    } else if (side < 0.0f) {
+        player->turnRateTarget = player->turnRateTarget - sign * force;
+    }
+}
+
 // 0x0046b5a0
 void swrRace_Tilt(swrRace* player, float b)
 {
@@ -990,12 +1184,15 @@ void swrRace_Tilt(swrRace* player, float b)
     }
 }
 
-// Per-frame "brain" for one AI racer. It never touches the flight model directly;
+// Per-frame pacing "brain" for one AI racer. It never touches the flight model directly;
 // it only computes a per-racer speed multiplier (aiSpeedTarget, smoothed into
-// paceMultiplier) and a cross-track steer target (aiSteerTarget). The smoothed
-// multiplier is copied into speedMultiplier by swrRace_UpdateCatchup and scales the
-// pod in swrRace_UpdateSpeed. The two tuning inputs are the globals swrRace_AILevel
+// paceMultiplier) and a station-keeping offset target (aiPaceOffsetTarget, laps behind the
+// pace-setter). The smoothed multiplier is copied into speedMultiplier by swrRace_UpdateCatchup
+// and scales the pod in swrRace_UpdateSpeed. The two tuning inputs are the globals swrRace_AILevel
 // (track base level * AI Speed setting) and ai_spread, both set in InitAISettingsForTrack.
+// The rubberband is player-relative on three paths: the AI_SIMPLE pace-setter chases local
+// player 1 directly, tethered pods (AI_TETHER_LOCAL*) pace on their raw gap to that player,
+// and everyone else station-keeps behind the pace-setter.
 // 0x0046b670
 void swrRace_AI(int player)
 {
@@ -1021,18 +1218,20 @@ void swrRace_AI(int player)
         float spreadBand = spreadScaled * invTrackLen;
 
         if ((p->flags0 & swrObjTest_FLAG0_AI_SIMPLE) != 0) {
-            // Locked control (e.g. pre-start): no steering, pick a coarse pace.
-            p->aiSteerTarget = 0.0f;
+            // Pace-setter (the track-favorite pod): coarse player-relative pacing.
+            // 1.06x while leading, 1.4x when local player 1 is far ahead (catch back
+            // up to the player), 1.1x otherwise (pull ahead of the player).
+            p->aiPaceOffsetTarget = 0.0f;
             if ((short) p->score_ptr->results_P1_Position == 1) {
                 p->aiSpeedTarget *= 1.06f;
-            } else if (spreadBand * 3.0f < p->rivalGapAhead) {
+            } else if (spreadBand * 3.0f < p->gapToLocalPlayer1) {
                 p->aiSpeedTarget *= 1.4f;
             } else {
                 p->aiSpeedTarget *= 1.1f;
             }
         } else if ((short) p->score_ptr->results_P1_Position == 1) {
-            // Not racing for this slot: freeze steering, leave the target at base.
-            p->aiSteerTarget = 0.0f;
+            // Leading the race: cruise at the base level.
+            p->aiPaceOffsetTarget = 0.0f;
         } else {
             // Tick the decision timer; on expiry reroll the interval and nudge the
             // target finishing position by +/-1, kept within +/-2 of the baseline.
@@ -1064,17 +1263,18 @@ void swrRace_AI(int player)
                 p->aiSpeedTarget =
                     (1.0f - ((float) p->aiRankTarget - 1.0f) * ai_rank_speed_factor) * base;
             } else {
-                // Full model: a cross-track steer target, plus a speed target derived
-                // from the gap to the racing line, the target rank, and the spread band.
-                float steer = (((float) p->aiRankTarget - 1.0f) * spreadScaled - 0.0008f) * invTrackLen;
-                p->aiSteerTarget = steer;
+                // Full model: hold a rank-derived station behind the pace-setter, unless
+                // this pod is tethered to a local player, in which case pace directly on
+                // the raw gap to that player (10.3 catching up vs 10.02 easing off).
+                float paceOffset = (((float)p->aiRankTarget - 1.0f) * spreadScaled - 0.0008f) * invTrackLen;
+                p->aiPaceOffsetTarget = paceOffset;
 
                 float v;
-                if (spreadBand * 0.25f < p->aiLineOffset && (p->flags0 & (swrObjTest_FLAG0_AI_RIVAL_AHEAD | swrObjTest_FLAG0_AI_RIVAL_BEHIND)) != 0) {
-                    float gap = (p->flags0 & swrObjTest_FLAG0_AI_RIVAL_AHEAD) != 0 ? p->rivalGapAhead : p->rivalGapBehind;
+                if (spreadBand * 0.25f < p->gapToPacer && (p->flags0 & (swrObjTest_FLAG0_AI_TETHER_LOCAL1 | swrObjTest_FLAG0_AI_TETHER_LOCAL2)) != 0) {
+                    float gap = (p->flags0 & swrObjTest_FLAG0_AI_TETHER_LOCAL1) != 0 ? p->gapToLocalPlayer1 : p->gapToLocalPlayer2;
                     v = (0.0f < gap) ? gap * 10.3f : gap * 10.02f;
                 } else {
-                    v = (p->aiLineOffset - steer) * 10.0f;
+                    v = (p->gapToPacer - paceOffset) * 10.0f;
                 }
 
                 float target = (v * 40.0f) / invTrackLen + 1.045f;
@@ -1103,6 +1303,42 @@ void swrRace_AI(int player)
     }
 }
 
+// Per-frame control entry for an AI pod (dispatched by swrRace_CalcTargetTurnRate). In demo
+// mode it fires a 'Snap' sub-event each frame; with the AI debug flag set (0x100 + debug
+// level), keyboard inputs fire manual 'Snap's. While racing it runs the steering autopilot,
+// cuts the throttle when dead, and tilts into Side-tagged surfaces.
+// 0x0046bb70
+void swrRace_UpdateAutopilotControl(swrRace* player)
+{
+    if (swrRace_demoMode != 0) {
+        int subEvents[2];
+        subEvents[0] = 0x536e6170; // 'Snap'
+        subEvents[1] = 2;
+        swrEvent_DispatchSubEvents(player, subEvents);
+    }
+    if ((swrRace_DebugFlag & 0x100) != 0 && swrRace_DebugLevel != 0) {
+        swrRace_CheckResetInput(player, 1);
+        if ((inRaceLocalPlayerInputBitset3[0] & 0x800) != 0 || (inRaceLocalPlayerInputBitset3[0] & 0x400) != 0) {
+            int subEvents[2];
+            subEvents[0] = 0x536e6170; // 'Snap'
+            subEvents[1] = (inRaceLocalPlayerInputBitset3[0] & 0x800) != 0 ? -1 : 1;
+            swrEvent_DispatchSubEvents(player, subEvents);
+        }
+    }
+    if (((uint8_t)player->flags0 & 0xf) == swrObjTest_FLAG0_RACING) {
+        swrRace_AutopilotSteer(player);
+        if ((player->flags0 & swrObjTest_FLAG0_DEAD) != 0) {
+            player->throttle = 0.0f;
+            return;
+        }
+        if ((player->flags1 & swrObjTest_FLAG1_ON_SIDE) != 0) {
+            swrRace_Tilt(player, 1.0f);
+            return;
+        }
+        swrRace_Tilt(player, 0.0f);
+    }
+}
+
 // Picks the speed multiplier source for one racer and commits it to speedMultiplier.
 // AI racers (flags0 0x80) defer to swrRace_AI. 'Locl' splitscreen humans (flags0 0x20)
 // with an active catchup field get a distance-based boost (capped at 1.25x); everyone
@@ -1120,9 +1356,9 @@ void swrRace_UpdateCatchup(swrRace* player)
         }
     } else {
         player->paceMultiplier = 1.0f;
-        if (1 < NumLocalPlayers() && 0.0f < player->rivalGapAhead) {
+        if (1 < NumLocalPlayers() && 0.0f < player->gapToLocalPlayer1) {
             float invTrackLen = 500000.0f / swrSpline_GetTrackLength();
-            float boost = (player->rivalGapAhead * 100.0f) / invTrackLen + 1.0f;
+            float boost = (player->gapToLocalPlayer1 * 100.0f) / invTrackLen + 1.0f;
             player->paceMultiplier = boost;
             if (1.25f < boost) {
                 player->paceMultiplier = 1.25f;
@@ -1144,12 +1380,6 @@ void swrRace_ApplyEngineDamage(swrRace* player)
     HANG("TODO");
 }
 
-// 0x0046b430
-void swrRace_ApplyPodProximityForce(swrRace* player)
-{
-    HANG("TODO");
-}
-
 // 0x0046ba30
 void swrRace_SpawnFlameAttack(swrRace* player)
 {
@@ -1158,12 +1388,6 @@ void swrRace_SpawnFlameAttack(swrRace* player)
 
 // 0x0046bb30
 void swrRace_SendFlameAttackEvent(int player, double param_2, void* param_3, void* param_4, int param_5)
-{
-    HANG("TODO");
-}
-
-// 0x0046bb70
-void swrRace_UpdateAutopilotControl(swrRace* player)
 {
     HANG("TODO");
 }
@@ -2709,8 +2933,9 @@ float swrRace_UpdateSpeed(swrRace* player)
         speed = 75.0f;
 
     // AI glide-assist speed bonus. This is not a player nose-down input: for AI, `pitch` is
-    // driven to -1.0 (else 0.0) by swrRace_UpdateAIGlidePitch when the pod is gliding above
-    // its spline target, so this branch only fires in that glide state -- 1.3x (1.9x if finished).
+    // driven to -1.0 (else 0.0) by swrRace_UpdateAIGlidePitch when the pod has dropped below
+    // its spline path (glide-dive back onto the line), so this branch only fires in that
+    // dive state -- 1.3x (1.9x if finished).
     if ((player->flags0 & swrObjTest_FLAG0_AI) != 0 && player->pitch < -0.5f)
     {
         if ((player->flags1 & swrObjTest_FLAG1_FINISHED) != 0)

--- a/src/Swr/swrRace.c
+++ b/src/Swr/swrRace.c
@@ -4,8 +4,13 @@
 #include "swrModel.h"
 #include "swrSpline.h"
 #include "swrEvent.h"
+#include "swrSound.h"
+#include "swrMultiplayer.h"
+#include "swr.h"
+#include <Main/swrControl.h>
 #include "macros.h"
 #include "globals.h"
+#include "engine_config.h"
 
 #include <General/stdMath.h>
 #include <General/utils.h>
@@ -1127,8 +1132,32 @@ void swrRace_UpdateCatchup(swrRace* player)
     player->speedMultiplier = player->paceMultiplier;
 }
 
+// 0x0046a990
+void swrRace_CheckResetInput(swrRace* player, int playerIndex)
+{
+    HANG("TODO");
+}
+
+// 0x0046aa30
+void swrRace_ApplyEngineDamage(swrRace* player)
+{
+    HANG("TODO");
+}
+
 // 0x0046b430
 void swrRace_ApplyPodProximityForce(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// 0x0046ba30
+void swrRace_SpawnExplosionEffect(swrRace* player)
+{
+    HANG("TODO");
+}
+
+// 0x0046bb30
+void swrRace_SendFlameEvent_Maybe(int player, double param_2, void* param_3, void* param_4, int param_5)
 {
     HANG("TODO");
 }
@@ -1139,10 +1168,435 @@ void swrRace_UpdateAutopilotControl(swrRace* player)
     HANG("TODO");
 }
 
+// The per-frame human-input -> pod-intent routine for a 'Locl' racer. Reads the processed input
+// (swrControl button-state @0x00ec8840[] / hold-time @0x00ec88a0[] arrays + analog axes), dispatches
+// on the profile control-type byte (profile+0x23) to gather steer/pitch/throttle/brake/bank/boost/
+// repair/taunt, applies the engine-damage steering pull + force feedback, boost-start detection and
+// flame-attack, then commits turnRateTarget / throttle / tilt / flags0 / flags1. Reverse-hooked
+// (dormant). Preserves an original bug: the analog pitch LOW clamp also writes +0.8 (see below).
+// unk2f4 / unk1f14 are int-typed fields that store float bit-patterns (reinterpreted, not converted).
 // 0x0046bec0
 void swrRace_UpdatePlayerControl(swrRace* player)
 {
-    HANG("TODO");
+    float steerInput = 0.0f;
+    float pitchForward = 0.0f;
+    float throttleRaw = 0.0f;
+    int thrustDigital = 0;
+    int brakeDigital = 0;
+    int bankLeft = 0;
+    int bankRight = 0;
+    int viewButtonInput = 0;
+    int lookBackInput = 0;
+    int flameTaunt = 0;
+    int slideInput = 0;
+    bool repairHold = false;
+
+    player->throttle = 0.0f;
+    player->turnRateTarget = 0.0f;
+
+    swrScore* score = player->score_ptr;
+    int playerIndex = *(int8_t*) &score->sfxChannel; // score+0x10 low byte = local-player slot
+    int controlType = *((int8_t*) score->localPlayerProfile + 0x23);
+    score->flag &= ~0x4;
+    player->score_ptr->flag &= ~0x8;
+
+    uint32_t canChargeBoost = player->flags0 & swrObjTest_FLAG0_CAN_CHARGE_BOOST;
+    int bitset3 = inRaceLocalPlayerInputBitset3[playerIndex];
+    int mirror = GameSettingFlags & 0x4000; // invert-steering option
+
+    // ---- input-gather dispatch on the profile control-type byte ----
+    // controlType 0/9 -> analog axes; 1..7 -> per-player bitset; 8/>9 -> no input (all stay zero).
+    if (controlType == 0 || controlType == 9) {
+        if (mirror) {
+            steerInput = -swrRace_SteeringInput;
+            bankRight = (int) swrControl_rollLeftButton;
+            bankLeft = (int) swrControl_rollRightButton;
+        } else {
+            steerInput = swrRace_SteeringInput;
+            bankLeft = (int) swrControl_rollLeftButton;
+            bankRight = (int) swrControl_rollRightButton;
+        }
+        thrustDigital = (int) swrRace_ThrustInput;
+        brakeDigital = (int) swrControl_brakeButton;
+        viewButtonInput = (int) swrControl_viewButton;
+        lookBackInput = (int) swrControl_inputStateButton;
+        flameTaunt = (int) swrControl_tauntButton;
+        repairHold = swrControl_repairButton != 0.0f && swrControl_repairHoldTime > (float) SWR_CTL_HALF_HOLD;
+        slideInput = (int) DAT_00ec8854;
+        throttleRaw = swrRace_ThrottleInput;
+
+        if ((swrControl_brakeIsAnalog == 0 && brakeDigital != 0) || thrustDigital != 0) {
+            score->flag &= ~0x8;
+        } else if (swrRace_ThrottleInput != 0.0f) {
+            score->flag |= 0x8;
+        }
+        if (thrustDigital != 0 && swrControl_brakeIsAnalog != 0 && brakeDigital != 0) {
+            brakeDigital = 0;
+        }
+
+        pitchForward = swrRace_PitchInput * SWR_CTL_STEER_SCALE;
+        if (SWR_CTL_STEER_SCALE < swrRace_PitchInput * SWR_CTL_STEER_SCALE) {
+            pitchForward = SWR_CTL_STEER_SCALE;
+        }
+        // BUG (preserved from retail): the low clamp writes +0.8, not -0.8.
+        if (pitchForward < -SWR_CTL_STEER_SCALE) {
+            pitchForward = SWR_CTL_STEER_SCALE;
+        }
+    } else if (controlType >= 1 && controlType <= 7) {
+        steerInput = DAT_00e98ea0[playerIndex];
+        if (mirror) {
+            steerInput = -steerInput;
+            bankRight = bitset3 & 0x10;
+            bankLeft = bitset3 & 0x20;
+        } else {
+            bankLeft = bitset3 & 0x10;
+            bankRight = bitset3 & 0x20;
+        }
+        pitchForward = DAT_00e98e80[playerIndex];
+        thrustDigital = (int) swrRace_ThrustInput;
+        brakeDigital = bitset3 & 0x2;
+        lookBackInput = bitset3 & 0x8;
+        viewButtonInput = inRaceLocalPlayerInputBitset1[playerIndex] & 0x4;
+        if ((inRaceLocalPlayerInputBitset1[playerIndex] & 0x80) != 0) {
+            if ((float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_BOOST_TAP_TIMEOUT) {
+                *((char*) &player->unk2f8 + 1) = 0;
+            }
+            char taps = *((char*) &player->unk2f8 + 1) + 1;
+            *(float*) &player->unk2f4 = (float) timetotal;
+            *((char*) &player->unk2f8 + 1) = taps;
+            if (taps > 1) {
+                flameTaunt = 1;
+            }
+        }
+        if ((*(char*) &inRaceLocalPlayerInputBitset2[playerIndex] & 0x80) != 0) {
+            *(float*) &player->unk2f4 = (float) timetotal;
+        }
+        if ((bitset3 & 0x80) != 0 && (float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_HALF_HOLD) {
+            repairHold = true;
+        }
+        slideInput = (bitset3 & 0x100) != 0;
+        if (controlType == 1) {
+            slideInput = thrustDigital == 0;
+        }
+    }
+
+    int boostCharge = swrRace_BoostCharge((int) player);
+
+    // ---- debug demo-replay input override (blends two local players' recorded inputs) ----
+    if ((swrRace_DebugFlag & 0x2000000) != 0) {
+        int demoIndex = (char) player->score_ptr->sfxChannel != '\0';
+        float steerA = DAT_00e98ea0[demoIndex];
+        float pitchA = DAT_00e98e80[demoIndex];
+        float steerB = DAT_00e98ea0[2 + demoIndex];
+        float pitchB = DAT_00e98e80[2 + demoIndex];
+        thrustDigital = pitchA > SWR_CTL_THROTTLE_SETTLE_MIN || pitchB > SWR_CTL_THROTTLE_SETTLE_MIN;
+        if (mirror == 0) {
+            steerInput = (pitchA - pitchB) * SWR_CTL_HALF;
+            bankLeft = steerA < SWR_CTL_DEMO_STEER_SCALE && steerB < SWR_CTL_DEMO_STEER_SCALE;
+            bankRight = steerA > SWR_CTL_HALF && steerB > SWR_CTL_HALF;
+        } else {
+            steerInput = (pitchA - pitchB) * SWR_CTL_DEMO_STEER_SCALE;
+            bankRight = steerA < SWR_CTL_DEMO_STEER_SCALE && steerB < SWR_CTL_DEMO_STEER_SCALE;
+            bankLeft = steerA > SWR_CTL_HALF && steerB > SWR_CTL_HALF;
+        }
+        pitchForward = (pitchB + pitchA) * SWR_CTL_HALF;
+        brakeDigital = pitchA < SWR_CTL_DMG_STEER_PULL && pitchB < SWR_CTL_DMG_STEER_PULL;
+        viewButtonInput = inRaceLocalPlayerInputBitset1[demoIndex] & 0x4;
+        lookBackInput = inRaceLocalPlayerInputBitset3[demoIndex] & 0x8;
+        if ((inRaceLocalPlayerInputBitset1[demoIndex] & 0x80) != 0) {
+            if ((float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_BOOST_TAP_TIMEOUT) {
+                *((char*) &player->unk2f8 + 1) = 0;
+            }
+            char taps = *((char*) &player->unk2f8 + 1) + 1;
+            *(float*) &player->unk2f4 = (float) timetotal;
+            *((char*) &player->unk2f8 + 1) = taps;
+            if (taps > 1) {
+                flameTaunt = 1;
+            }
+        }
+        if ((*(char*) &inRaceLocalPlayerInputBitset2[demoIndex] & 0x80) != 0) {
+            *(float*) &player->unk2f4 = (float) timetotal;
+        }
+        if ((*(char*) &inRaceLocalPlayerInputBitset3[demoIndex] & 0x80) != 0 &&
+            (float) timetotal - *(float*) &player->unk2f4 > (float) SWR_CTL_HALF_HOLD) {
+            repairHold = true;
+        }
+        slideInput = steerA > SWR_CTL_HALF && steerB < SWR_CTL_DEMO_STEER_SCALE;
+        playerIndex = demoIndex;
+    }
+
+    // ---- scripted-camera zone flag (unk4_mat+0x28 written as an int bit-pattern of 1) ----
+    *(float*) ((char*) &player->unk4_mat + 0x28) = 0.0f;
+    if (ai_track_script > 0) {
+        if (ai_track_script == 5 && SWR_CTL_SCRIPT5_LAP_MIN < player->lapComp && player->lapComp < SWR_CTL_SCRIPT5_LAP_MAX) {
+            *(int*) ((char*) &player->unk4_mat + 0x28) = 1;
+        }
+        if (ai_track_script == 6 && SWR_CTL_SCRIPT6_LAP_MIN < player->lapComp && player->lapComp < SWR_CTL_SCRIPT6_LAP_MAX) {
+            *(int*) ((char*) &player->unk4_mat + 0x28) = 1;
+        }
+    }
+
+    int damagedSides = swrRace_GetDamagedEngineSides(player);
+    if (damagedSides != 0) {
+        damagedSides = 1;
+        bankLeft = 0;
+        bankRight = 0;
+        boostCharge = 0;
+        player->flags0 &= ~swrObjTest_FLAG0_BOOSTING;
+    }
+
+    // ---- engine-damage steering pull + force feedback ----
+    if ((player->flags0 & swrObjTest_FLAG0_THROTTLE_SETTLED) != 0 &&
+        (player->flags0 & swrObjTest_FLAG0_BRAKING) == 0 &&
+        (player->flags1 & swrObjTest_FLAG1_FINISHED) == 0) {
+        float penalty = swrRace_GetEngineDamagePenalty(player);
+        if ((damagedSides & 1) != 0) {
+            penalty -= SWR_CTL_DMG_PEN_LEFT;
+        } else if ((damagedSides & 2) != 0) {
+            penalty -= SWR_CTL_DMG_PEN_RIGHT;
+        }
+        penalty *= SWR_CTL_DMG_PEN_GAIN;
+        if (penalty == 0.0f) {
+            swrControl_StopForceEffect(1);
+        } else {
+            int direction = penalty >= 0.0f ? 0x5a + 0xb4 : 0x5a;
+            int magnitude = (int) (SWR_CTL_FF_MAG_BASE - penalty * SWR_CTL_FF_MAG_SLOPE);
+            swrControl_PlayForceEffect(1, magnitude, direction, -1);
+            swrControl_damageForceEffectPreempted = 1;
+        }
+        steerInput -= penalty * SWR_CTL_DMG_STEER_PULL;
+        swrRace_engineDamageSteeringPenalty = penalty;
+    }
+
+    // ---- debug event dispatch ('Snap' teleport + reset-input) ----
+    if ((swrRace_DebugFlag & 0x100) != 0 && swrRace_DebugLevel != 0) {
+        if ((bitset3 & 0x800) != 0 || (bitset3 & 0x400) != 0) {
+            int snap[2];
+            snap[0] = 0x536e6170; // 'Snap'
+            snap[1] = (bitset3 & 0x800) != 0 ? 1 : 2;
+            swrEvent_DispatchSubEvents(player, snap);
+        }
+        if ((swrRace_DebugFlag & 0x100) != 0 && swrRace_DebugLevel != 0) {
+            swrRace_CheckResetInput(player, playerIndex);
+        }
+    }
+
+    // ---- flame attack / taunt ----
+    if (flameTaunt != 0 || swrRace_debugTauntRequest != 0) {
+        swrRace_debugTauntRequest = 0;
+        if (((uint8_t) player->flags0 & 0xf) == swrObjTest_FLAG0_RACING &&
+            (player->flags0 & (swrObjTest_FLAG0_RESET | swrObjTest_FLAG0_DEAD | swrObjTest_FLAG0_POD_HIDDEN)) == 0 &&
+            (player->flags1 & swrObjTest_FLAG1_EXPLODING) == 0) {
+            int soundSource = *(int*) score->unk18;
+            if (soundSource == 2) {
+                swrRace_SpawnExplosionEffect(player);
+                // retail passes only the timestamp; the reconstructed 5-arg prototype's extra params are fillers.
+                swrRace_SendFlameEvent_Maybe((int) score->time_unk, 0.0, NULL, NULL, 0);
+            }
+            int rng = swrUtils_Rand();
+            int sfxRet;
+            int to;
+            if ((float) SWR_CTL_HALF_HOLD <= (float) rng * SWR_CTL_RAND_NORM) {
+                sfxRet = swrSound_PlayRandomSfx(1, soundSource, 0x15, 0x16, 0x17, 0x18, 0x19,
+                                                (rdVector3*) &player->transform.vD);
+                to = -1;
+            } else if (soundSource == 0xe) {
+                sfxRet = swrSound_PlayRandomSfx(1, 0xe, 3, 0x12, 0x12, 0x13, 0x14,
+                                                (rdVector3*) &player->transform.vD);
+                to = -1;
+            } else {
+                sfxRet = swrSound_PlayRandomSfx(1, soundSource, 3, 0x11, 0x12, 0x13, 0x14,
+                                                (rdVector3*) &player->transform.vD);
+                to = 1;
+            }
+            // retail passes 6 args (a7-a10 undefined); satisfy the wider prototype with fillers.
+            // a5 is the sound-source's first dword reinterpreted as float, as retail does.
+            float srcAsFloat = *(float*) &soundSource;
+            swrMultiplayer_SendEvent(to, 0, 0x7461756e, 1, srcAsFloat, (float) sfxRet, 0.0, NULL, NULL, 0);
+        }
+    }
+
+    // ---- flags0 write-back: INPUT_STATE (0x100000), REPAIRING (0x400), clear high bit ----
+    player->flags0 = lookBackInput != 0 ? (player->flags0 | swrObjTest_FLAG0_LOOK_BACK)
+                                        : (player->flags0 & ~swrObjTest_FLAG0_LOOK_BACK);
+    player->flags0 = repairHold ? (player->flags0 | swrObjTest_FLAG0_REPAIRING)
+                                : (player->flags0 & ~swrObjTest_FLAG0_REPAIRING);
+    player->flags0 &= 0x7fffffff;
+
+    // ---- camera ('cMan') event: view button held -> 'CBut', else a pending debug camera event ----
+    if (((uint8_t) player->flags0 & 0xf) != 0 && (player->flags0 & swrObjTest_FLAG0_DEAD) == 0) {
+        if (viewButtonInput == 0) {
+            if (swrRace_pendingCameraEvent != 0) {
+                int event[2];
+                event[0] = swrRace_pendingCameraEvent;
+                event[1] = (int) player;
+                swrEvent_CallF4(0x634d616e, event); // 'cMan'
+                swrRace_pendingCameraEvent = 0;
+            }
+        } else {
+            int event[2];
+            event[0] = 0x43427574; // 'CBut'
+            event[1] = (int) player;
+            swrEvent_CallF4(0x634d616e, event); // 'cMan'
+        }
+    }
+
+    swrRace_ApplyEngineDamage(player);
+    swrRace_Repair(player);
+
+    // ---- zero-g (ZON): pitch -> lateral torque unk10_2 ----
+    if ((player->flags0 & swrObjTest_FLAG0_ZON) != 0) {
+        if (pitchForward >= SWR_CTL_STEER_DEADZONE || -pitchForward >= SWR_CTL_STEER_DEADZONE) {
+            float squared = pitchForward * SWR_CTL_STEER_SQUARE_GAIN * (pitchForward * SWR_CTL_STEER_SQUARE_GAIN);
+            if (pitchForward < 0.0f) {
+                squared = -squared;
+            }
+            player->unk10_2 = -(player->podStats.maxTurnRate * squared * SWR_CTL_STEER_SCALE) * SWR_CTL_HALF;
+        } else {
+            player->unk10_2 = 0.0f;
+        }
+        pitchForward = 0.0f;
+    }
+
+    // ---- boost-start window (flags1 0x800 -> 0x1000 -> 0x2000) ----
+    if ((swrRace_ThrustInput != 0.0f && swrControl_thrustHoldTime < (float) SWR_CTL_BOOST_WINDOW &&
+         (float) SWR_CTL_BOOST_WINDOW_LO < swrControl_thrustHoldTime) ||
+        (swrRace_ThrottleInput > (float) SWR_CTL_BOOST_THROTTLE && swrRace_BoostInput != 0.0f &&
+         swrControl_boostHoldTime < (float) SWR_CTL_BOOST_WINDOW &&
+         (float) SWR_CTL_BOOST_WINDOW_LO < swrControl_boostHoldTime)) {
+        if ((player->flags1 & swrObjTest_FLAG1_BOOST_START_CANCEL) == 0) {
+            player->flags1 |= swrObjTest_FLAG1_BOOST_START_CANCEL;
+            if ((player->flags1 & swrObjTest_FLAG1_BOOST_START_WINDOW) != 0) {
+                player->flags1 |= swrObjTest_FLAG1_BOOST_START;
+            }
+        }
+    }
+    if ((player->flags1 & swrObjTest_FLAG1_BOOST_START) != 0) {
+        if (swrSound_TestSfxFlag(0, 0x80000) == 0) {
+            swrSound_PlayRandomSfx(1, *(int*) score->unk18, 2, 2, 2, 2, 2, (rdVector3*) &player->transform.vD);
+            swrSound_SetSfxFlag(0, 0x80000);
+        }
+        if ((swrRace_ThrustInput == 0.0f && swrRace_ThrottleInput <= (float) SWR_CTL_BOOST_THROTTLE) ||
+            player->speedValue > SWR_CTL_BOOST_CANCEL_SPEED) {
+            player->flags1 &= ~swrObjTest_FLAG1_BOOST_START;
+        }
+    }
+
+    if (((uint8_t) player->flags0 & 0xf) != swrObjTest_FLAG0_RACING) {
+        return;
+    }
+    if ((player->flags0 & swrObjTest_FLAG0_DEAD) != 0) {
+        return;
+    }
+
+    // ---- BRAKING ----
+    if (brakeDigital == 0) {
+        player->flags0 &= ~swrObjTest_FLAG0_BRAKING;
+    } else {
+        player->flags0 |= swrObjTest_FLAG0_BRAKING;
+        if (player->speedValue < (float) SWR_CTL_BRAKE_SETTLE_SPEED) {
+            player->flags0 = (player->flags0 & ~swrObjTest_FLAG0_THROTTLE_SETTLED) | swrObjTest_FLAG0_BRAKING;
+        }
+    }
+
+    // ---- throttle ----
+    if ((score->flag & 0x8) != 0) {
+        float mapped = (throttleRaw - SWR_CTL_NEG_ONE) * SWR_CTL_HALF * SWR_CTL_ANALOG_THROTTLE_GAIN;
+        player->throttle = mapped;
+        if (mapped > SWR_CTL_ONE) {
+            player->throttle = 1.0f;
+        }
+        if (player->throttle < SWR_CTL_NEG_ONE) {
+            player->throttle = -1.0f;
+        }
+    } else if (thrustDigital == 0) {
+        if (pitchForward >= SWR_CTL_NEG_HALF || player->speedValue >= (float) SWR_CTL_IDLE_SPEED) {
+            player->throttle = 0.1f;
+        } else {
+            player->throttle = pitchForward * SWR_CTL_PITCH_TRIM;
+        }
+    } else {
+        player->throttle = 1.0f;
+        if (damagedSides != 0) {
+            player->throttle = 0.5f;
+        }
+    }
+
+    if (player->wallHitCooldown <= 0.0f && player->throttle > SWR_CTL_THROTTLE_SETTLE_MIN) {
+        player->flags0 |= swrObjTest_FLAG0_THROTTLE_SETTLED;
+    }
+
+    // ---- SLIDING (airborne forces it) ----
+    uint32_t sliding = (player->flags1 & swrObjTest_FLAG1_AIRBORNE) != 0 ? 1u : (uint32_t) slideInput;
+    player->flags1 = sliding != 0 ? (player->flags1 | swrObjTest_FLAG1_SLIDING)
+                                  : (player->flags1 & ~swrObjTest_FLAG1_SLIDING);
+
+    // ---- NOT_ACCEL ----
+    player->flags1 = (thrustDigital != 0 || throttleRaw > SWR_CTL_HALF)
+                         ? (player->flags1 & ~swrObjTest_FLAG1_NOT_ACCEL)
+                         : (player->flags1 | swrObjTest_FLAG1_NOT_ACCEL);
+
+    // ---- slide2 easing ----
+    if (sliding == 0 || player->speedValue <= SWR_CTL_SLIDE_SPEED) {
+        player->slide -= (float) (swrRace_deltaTimeSecs * SWR_CTL_HALF_HOLD);
+        if (player->slide < 0.0f) {
+            player->slide = 0.0f;
+        }
+    } else {
+        player->slide -= (float) (swrRace_deltaTimeSecs * SWR_CTL_NEG_HALF);
+        if (player->slide > SWR_CTL_ONE) {
+            player->slide = 1.0f;
+        }
+    }
+
+    // ---- boost latch ----
+    if (boostCharge != 0 && canChargeBoost != 0) {
+        swrUtils_Rand();
+        player->flags0 |= swrObjTest_FLAG0_BOOSTING;
+    }
+    if ((player->flags0 & swrObjTest_FLAG0_BOOSTING) != 0 && thrustDigital == 0 && throttleRaw <= SWR_CTL_HALF) {
+        player->flags0 &= ~swrObjTest_FLAG0_BOOSTING;
+    }
+
+    *(float*) &player->unk1f14 = *(float*) &player->unk1f14 - (float) swrRace_deltaTimeSecs;
+
+    // ---- tilt / bank ----
+    if ((bankLeft != 0 || bankRight != 0) && (player->flags1 & swrObjTest_FLAG1_MAGNET) != 0) {
+        playASound(0x4b, 7, 0.5f, 1.0f, 1);
+    }
+    float tilt = (bankLeft != 0 && bankRight == 0) ? -1.0f : (bankLeft == 0 && bankRight != 0) ? 1.0f : 0.0f;
+    swrRace_Tilt(player, tilt);
+
+    // ---- turnRateTarget from steer (squared) ----
+    if (steerInput >= SWR_CTL_STEER_DEADZONE || -steerInput >= SWR_CTL_STEER_DEADZONE) {
+        float squared = steerInput * SWR_CTL_STEER_SQUARE_GAIN * (steerInput * SWR_CTL_STEER_SQUARE_GAIN);
+        if (steerInput < 0.0f) {
+            squared = -squared;
+        }
+        player->turnRateTarget = -(player->podStats.maxTurnRate * squared * SWR_CTL_STEER_SCALE);
+    } else {
+        player->turnRateTarget = 0.0f;
+    }
+
+    // ---- pitch trims turn rate + throttle ----
+    player->pitch = pitchForward;
+    if (pitchForward > SWR_CTL_PITCH_HI) {
+        player->turnRateTarget *= (SWR_CTL_ONE - pitchForward * SWR_CTL_PITCH_TRIM);
+        if (player->throttle > SWR_CTL_HALF) {
+            player->throttle -= pitchForward * SWR_CTL_PITCH_THROTTLE_TRIM;
+        }
+    }
+    if (pitchForward < SWR_CTL_PITCH_LO) {
+        player->turnRateTarget *= (SWR_CTL_ONE - pitchForward * SWR_CTL_PITCH_TRIM);
+        if ((player->flags1 & swrObjTest_FLAG1_AIRBORNE) == 0 && player->throttle > SWR_CTL_HALF) {
+            player->throttle -= pitchForward * SWR_CTL_PITCH_THROTTLE_TRIM;
+        }
+    }
+    if ((player->flags0 & swrObjTest_FLAG0_BOOST_OVERDRIVE) != 0 && player->throttle < SWR_CTL_FLAT_THROTTLE_FLOOR) {
+        player->throttle = 1.2f;
+    }
+
+    player->paceMultiplier = 1.0f;
 }
 
 // Computes this racer's per-frame target turn rate and throttle, dispatched by control ownership:

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -164,7 +164,7 @@
 #define swrRace_UpdateCatchup_ADDR (0x0046ce30)
 
 // collision / ground-contact physics + explosion spawn
-#define swrRace_SpawnExplosionEffect_ADDR (0x0046ba30)
+#define swrRace_SpawnFlameAttack_ADDR (0x0046ba30)
 #define swrRace_RaycastGround_ADDR (0x004772f0)
 #define swrRace_UpdateHoverPads_ADDR (0x00476740)
 #define swrRace_ApplySlopeSteering_ADDR (0x004791d0)
@@ -219,9 +219,9 @@
 #define swrRace_ResetAllProfiles_ADDR (0x0043d970)
 #define swrRace_CheatUnlockAll_ADDR (0x0043d9a0)
 #define swrRace_ComputeUpgradePrices_ADDR (0x0043eb50)
-#define swrRace_GetEngineNodeOffsetPos_Maybe_ADDR (0x0044afb0)
-#define swrRace_SetEngineNodeRotScale_Maybe_ADDR (0x0044b180)
-#define swrRace_SetEngineNodeTranslation_Maybe_ADDR (0x0044b270)
+#define swrRace_GetEngineNodeOffsetPos_ADDR (0x0044afb0)
+#define swrRace_SetEngineNodeRotScale_ADDR (0x0044b180)
+#define swrRace_SetEngineNodeTranslation_ADDR (0x0044b270)
 #define swrRace_InitDefaultGameData_ADDR (0x0044e320)
 #define swrRace_ComputeSaveChecksum_ADDR (0x0044e440)
 #define swrRace_Crc32_ADDR (0x0044e460)
@@ -233,18 +233,18 @@
 #define swrRace_GetProfileRecordVec3_Maybe_ADDR (0x0044e5a0)
 #define swrRace_UpdatePitDroidModels_Maybe_ADDR (0x00456200)
 #define swrRace_UpdateAIGlidePitch_ADDR (0x0046aec0)
-#define swrRace_SendFlameEvent_Maybe_ADDR (0x0046bb30)
-#define swrRace_SpawnExplosionByIndex_Maybe_ADDR (0x0046bb50)
-#define swrRace_GetEngineUiBarColor_Maybe_ADDR (0x0046bc50)
-#define swrRace_UpdateEngineFireballNode_Maybe_ADDR (0x0046ebf0)
-#define swrRace_ApplyEngineProximityPush_Maybe_ADDR (0x0046ecd0)
-#define swrRace_SpawnGroundDustKick_Maybe_ADDR (0x0046fd60)
-#define swrRace_SmoothEngineExhaustSize_Maybe_ADDR (0x00470510)
-#define swrRace_ResetGravityDown_Maybe_ADDR (0x004764a0)
-#define swrRace_HandleWallScrapeHit_Maybe_ADDR (0x00479d40)
-#define swrRace_UpdateScrapeContact_Maybe_ADDR (0x0047a3a0)
-#define swrRace_UpdateSplineOrientation_Maybe_ADDR (0x0047a610)
-#define swrRace_GetSplineProgressValue_Maybe_ADDR (0x0047f890)
+#define swrRace_SendFlameAttackEvent_ADDR (0x0046bb30)
+#define swrRace_SpawnFlameAttackByIndex_ADDR (0x0046bb50)
+#define swrRace_GetBoostBarColor_ADDR (0x0046bc50)
+#define swrRace_UpdateEngineFireballNode_ADDR (0x0046ebf0)
+#define swrRace_ApplyEngineProximityPush_ADDR (0x0046ecd0)
+#define swrRace_SpawnGroundDustKick_ADDR (0x0046fd60)
+#define swrRace_SmoothEngineExhaustSize_ADDR (0x00470510)
+#define swrRace_ResetGravityDown_ADDR (0x004764a0)
+#define swrRace_HandleWallScrapeHit_ADDR (0x00479d40)
+#define swrRace_ApplySmokProximityPush_ADDR (0x0047a3a0)
+#define swrRace_UpdateSplineOrientation_ADDR (0x0047a610)
+#define swrRace_GetTrackMeshAtCursor_ADDR (0x0047f890)
 
 int swrRace_SelectProfileMenu(void* param_1, unsigned int param_2, unsigned int param_3, int param_4);
 
@@ -345,13 +345,13 @@ void swrRace_UpdateTurn(float* param_1, float* param_2, float param_3, float par
 void swrRace_SetAngleFromTurnRate(float* out_tilt, float cur_turnrate, void* unused, float max_turnrate, float max_angle);
 
 // Reads an engine node's world translation and offsets it by the paired node's Y position (best guess).
-void swrRace_GetEngineNodeOffsetPos_Maybe(void** nodePair, rdVector3* outPos);
+void swrRace_GetEngineNodeOffsetPos(void** nodePair, rdVector3* outPos);
 
 // Builds a rotation and scale transform for an engine node, offset by the paired node's Y (best guess).
-void swrRace_SetEngineNodeRotScale_Maybe(void** nodePair, float scale, float angle);
+void swrRace_SetEngineNodeRotScale(void** nodePair, float scale, float angle);
 
 // Copies an engine node's transform and sets its translation minus the paired node's Y offset (best guess).
-void swrRace_SetEngineNodeTranslation_Maybe(void** nodePair, rdVector3* pos);
+void swrRace_SetEngineNodeTranslation(void** nodePair, rdVector3* pos);
 
 void swrRace_ReplaceMarsGuoWithJinnReeso(void);
 void swrRace_ReplaceBullseyeWithCyYunga(void);
@@ -387,8 +387,8 @@ void swrRace_CalculateTiltFromTurn(int pEngine, rdVector4* pXformZ, float ZMotio
 // Extracts pitch + signed-roll angles of a forward/right basis relative to a reference (down) vector.
 void swrRace_ComputeTiltAngles(rdVector3* fwd, rdVector3* right, rdVector3* ref, rdVector3* out);
 
-// Resets the pod's gravity field and down-reference vector to negative Z (best guess).
-void swrRace_ResetGravityDown_Maybe(int player);
+// Resets the pod's gravityScale to its default and world_gravity to negative Z.
+void swrRace_ResetGravityDown(int player);
 // Builds a surface-aligned basis from the pod forward + surface normal and accumulates the heading/tilt
 // correction into pRDot (turn input). The +-85 deg pitch clamp + the magnet (flags1 0x400) gating live here.
 void swrRace_AlignToSurface(swrRace* player, rdVector3* up, rdVector3* fwd_vB, rdVector3* vA_fallback,
@@ -444,10 +444,10 @@ void swrRace_UpdateEngineSound(swrRace* player);
 void swrRace_UpdateEngineDamageFX(swrRace* player);
 
 // Spawns a per-planet ground dust kick with a scrape sound during a vehicle reaction (best guess).
-void swrRace_SpawnGroundDustKick_Maybe(swrRace* player, float* transform, float sx, float sy, float sz, float param_6, int param_7);
+void swrRace_SpawnGroundDustKick(swrRace* player, float* transform, float sx, float sy, float sz, float param_6, int param_7);
 
 // Smooths a per-side engine exhaust size toward a target over time (best guess).
-void swrRace_SmoothEngineExhaustSize_Maybe(int player, float side, float a, float b, float c, float rate, int param_7, int param_8);
+void swrRace_SmoothEngineExhaustSize(int player, float side, float a, float b, float c, float rate, int param_7, int param_8);
 
 // pod state + engine secondary-motion helpers:
 // Counts down the death timer; on expiry dispatches the 'Snap' event and resets engine health/flags.
@@ -471,10 +471,10 @@ void swrRace_RandomizeMeshNodes(swrModel_Node* dst, swrModel_Node* src);
 void swrRace_SpawnEngineFireball(swrRace* player, int engineSlot, rdVector3* pos, float scale);
 
 // Animates the engine fireball node's transform and hides it when its animation finishes (best guess).
-void swrRace_UpdateEngineFireballNode_Maybe(int player);
+void swrRace_UpdateEngineFireballNode(int player);
 
 // Projects a relative position onto the two engine bases to push pods apart in proximity (best guess).
-void swrRace_ApplyEngineProximityPush_Maybe(swrRace* player, float* otherPos, rdVector3* out);
+void swrRace_ApplyEngineProximityPush(swrRace* player, float* otherPos, rdVector3* out);
 
 // player/AI/autopilot control + engine-damage helpers:
 // Sets the respawn flag (flags0 0x1000) when the player's reset input bit is held.
@@ -493,23 +493,25 @@ void swrRace_ApplyPodProximityForce(swrRace* player);
 // Autopilot/pre-race control: snap events and tilt while not under player input.
 void swrRace_UpdateAutopilotControl(swrRace* player);
 
-// Fills the HUD engine-bar color and fill amount from the pod's engine state.
-void swrRace_GetEngineUiBarColor_Maybe(int player, uint8_t* outRgb, uint8_t* outRgba, float* outFill);
+// Fills the HUD boost-bar colors and fill from boostIndicatorStatus: 0 = green speed fill
+// (speed / (0.75 * maxSpeed)), 1 = orange boost-charge fill, 2 = yellow ready (full).
+void swrRace_GetBoostBarColor(int player, uint8_t* outRgb, uint8_t* outRgba, float* outFill);
 // Human player control: maps input to turn/pitch/brake/boost, drives force
 // feedback and tilt, and sets projTurnRate/pitch/throttle.
 void swrRace_UpdatePlayerControl(swrRace* player);
 // Runs AI steering for AI pods and computes the rubber-band/catch-up multiplier.
 void swrRace_UpdateCatchup(swrRace* player);
 
-// collision / ground-contact physics + explosion spawn:
-// Spawns the explosion effect (type-8 Smok) and destruction sounds for the pod.
-void swrRace_SpawnExplosionEffect(swrRace* player);
+// Sebulba's flame attack: plays the two flame-burst sounds and attaches a type-8 Smok to the
+// pod (handle in flameSmokeHandle, cooldown in unk12_2). Triggered by the AI in F0, by the
+// local player's taunt double-tap, and by the 'flam' network event via SpawnFlameAttackByIndex.
+void swrRace_SpawnFlameAttack(swrRace* player);
 
-// Sends a 'flam' flame multiplayer event for the given player (best guess).
-void swrRace_SendFlameEvent_Maybe(int player, double param_2, void* param_3, void* param_4, int param_5);
+// Sends the 'flam' flame-attack multiplayer event for the given player.
+void swrRace_SendFlameAttackEvent(int player, double param_2, void* param_3, void* param_4, int param_5);
 
-// Spawn the explosion effect for the racer at the given index (best guess).
-void swrRace_SpawnExplosionByIndex_Maybe(int racerIndex);
+// 'flam' event receiver: spawns the flame attack on swrScores[racerIndex]'s pod.
+void swrRace_SpawnFlameAttackByIndex(int racerIndex);
 // Raycasts the terrain collision mesh; sets terrainModel (0x140) and ground height, returns distance.
 float swrRace_RaycastGround(swrRace* player, rdVector3* pos, int* outSurfaceNormal);
 // Samples the 4 hover-pad ground heights and builds the shadow transforms (0x1290); returns hover height.
@@ -522,7 +524,7 @@ void swrRace_ApplySlopeSteeringMagnet(swrRace* player, int velocity, int scrapeD
 void swrRace_ApplyWallCollision(swrRace* player, rdVector3* normal, rdVector3* dir);
 
 // Handles a wall-scrape hit: spawns spray and sends the scrape multiplayer event (best guess).
-void swrRace_HandleWallScrapeHit_Maybe(swrRace* player);
+void swrRace_HandleWallScrapeHit(swrRace* player);
 
 // pod init + death/scrape/collision-toggle helpers:
 // Initializes a pod for a race: loads stats from the racer data, sets the spawn
@@ -546,11 +548,15 @@ void swrRace_BuildStretchedQuad(rdMatrix44* a, rdMatrix44* b, float param_3, flo
 // Wall-contact dispatch: wall-scrape + collision response when fast/airborne, else terrain follow.
 float swrRace_UpdateWallContact(swrRace* player, float* param_2, float* param_3, rdVector3* param_4);
 
-// Decays the scrape timer, finds nearby smoke, and computes the scrape reflection force (best guess).
-void swrRace_UpdateScrapeContact_Maybe(int player, int param_2);
+// Reaction to nearby 'Smok' objects (fire geysers / smoke columns): computes a decaying yaw
+// kick into contactSteerKick (FLAG1_SLIDE_LOCK while active); a close type-2 Smok can also
+// set a random engine-damage bit.
+void swrRace_ApplySmokProximityPush(int player, int param_2);
 
-// Integrates spline-bound pod orientation, rebuilding the basis and applying turn, pitch, and roll (best guess).
-void swrRace_UpdateSplineOrientation_Maybe(int player, rdVector3* up);
+// Spline-follow (AI / zero-g exit) orientation: eases aiLookAhead, blends the forward vector
+// toward the cursor lookahead point, rebuilds the basis, then applies yaw (turnRate), pitch
+// (zeroGPitchRate) and roll (gravityTubeAngle) rotations.
+void swrRace_UpdateSplineOrientation(int player, rdVector3* up);
 // Pod-to-pod collision: finds a nearby pod and resolves the 2D collision (push apart + DeathSpeed).
 void swrRace_ResolvePodCollision(swrRace* player);
 
@@ -558,8 +564,9 @@ void swrRace_TriggerHandler(int player, int a, char b);
 
 float swrRace_LapProgress(int a);
 
-// Returns a component of the spline progress values for a spline cursor (best guess).
-float swrRace_GetSplineProgressValue_Maybe(void* splineCursor);
+// Returns the baked track mesh at the cursor's spline sample (the spline_progress_values
+// scratch block stores 10 mesh pointers per control point, indexed by segmentT * 10).
+struct swrModel_Node* swrRace_GetTrackMeshAtCursor(void* splineCursor);
 
 bool swrRace_LapCompletion(void* engineData, int param_2);
 

--- a/src/Swr/swrRace.h
+++ b/src/Swr/swrRace.h
@@ -367,7 +367,7 @@ void swrRace_InRaceEndStatistics(void* param_1, void* param_2);
 void swrRace_Repair(swrRace* player);
 
 // Sets the pod death-pitch field based on a speed or flag threshold (best guess).
-void swrRace_UpdateAIGlidePitch(int player, float param_2, int param_3, int param_4);
+void swrRace_UpdateAIGlidePitch(swrRace* player, rdVector3* lookaheadPos, rdVector3* splinePos, int useGroundClearance);
 
 void swrRace_Tilt(swrRace* player, float b);
 

--- a/src/Swr/swrSpline.c
+++ b/src/Swr/swrSpline.c
@@ -505,8 +505,9 @@ void swrSpline_ForEachSample(swrSpline* spline, float step, void* arg3, void* ar
 }
 
 // spline_progress_values packs two per-node regions in one array: the [node] entry
-// (.x = arc-length progress, .y = segment delta) and a 10-float scratch block at
-// +0xfc (stride 5 rdVector2 per node). Clear both for one node.
+// (.x = arc-length progress, .y = segment delta) and, at +0xfc, the baked sample->track-mesh
+// table (10 mesh pointers per node, written by swrSpline_BakeSampleTrackMesh, read by
+// swrRace_GetTrackMeshAtCursor). Clear both for one node.
 // 0x0047f6c0
 void swrSpline_ResetNodeProgress(int nodeIndex)
 {
@@ -519,7 +520,7 @@ void swrSpline_ResetNodeProgress(int nodeIndex)
 
 // Returns the .rdata sample-spacing constant at 0x004adf40 (0.0f in retail).
 // 0x0047f800
-float swrSpline_GetSampleSpacing_Maybe(void)
+float swrSpline_GetSampleSpacing(void)
 {
     return 0.0f;
 }

--- a/src/Swr/swrSpline.h
+++ b/src/Swr/swrSpline.h
@@ -27,14 +27,16 @@
 #define swrSpline_GetTrackLength_ADDR (0x0047e870)
 #define swrSpline_CursorInit_ADDR (0x0047e880)
 #define swrSpline_CursorSeekToProgress_ADDR (0x0047e8b0)
-#define swrSpline_ProjectPointStub_Maybe_ADDR (0x0047eb50)
+#define swrSpline_BakeSampleTrackMesh_ADDR (0x0047ea20)
+#define swrSpline_ProjectPointStub_ADDR (0x0047eb50)
 #define swrSpline_ProjectPoint_ADDR (0x0047eb60)
+#define swrSpline_ValidateSampleTrackMesh_ADDR (0x0047ece0)
 #define swrSpline_ForEachSample_ADDR (0x0047ee20)
 #define swrSpline_TraceProgress_ADDR (0x0047f060)
 #define swrSpline_BuildProgressTable_ADDR (0x0047f470)
 #define swrSpline_ResetNodeProgress_ADDR (0x0047f6c0)
 #define swrSpline_Build_ADDR (0x0047f6f0)
-#define swrSpline_GetSampleSpacing_Maybe_ADDR (0x0047f800)
+#define swrSpline_GetSampleSpacing_ADDR (0x0047f800)
 #define swrSpline_CollectNearbyPoints_ADDR (0x00480170)
 #define swr_SetFixedDeltaTime_ADDR (0x00480480)
 
@@ -84,8 +86,22 @@ void* swrSpline_CursorInit(void* cursor, swrSpline* spline);
 // the remainder becomes the segment parameter, then fill the node lookahead chain.
 void swrSpline_CursorSeekToProgress(void* cursor, int progress);
 
-// A stubbed spline helper that writes zero and returns zero (best guess).
-int swrSpline_ProjectPointStub_Maybe(void* cursor, int* out);
+// Retired/compiled-out projection: writes 0 to the out-slot and returns 0 unconditionally
+// (the swrRace 0xf4..0x100 block it feeds is therefore always zero in retail).
+int swrSpline_ProjectPointStub(void* cursor, int* out);
+
+// ForEachSample callback (10 samples/node, from swrSpline_Build): raycasts down (then up)
+// 5000 units from the spline sample (facing check disabled), stores the hit track mesh into
+// the baked sample->mesh table (spline_progress_values scratch region), stamps mesh
+// splineSampleIndex with the first sample that hit it, and marks meshes shared between
+// traversal orders as spline-ambiguous (behavior unk1 bit 8; assigns the static behavior
+// @0x4c7be8 if the mesh has none).
+void swrSpline_BakeSampleTrackMesh(void* cursor, float samplesPerNode, swrModel_Node* trackModel, unsigned short* order);
+
+// Optional debug pass over the baked sample->mesh table (gated on the global at 0xe259a0 in
+// swrSpline_Build): re-seeks a cursor to each mesh's anchor sample and distance-checks it;
+// the mismatch branch is a stripped debug print.
+void swrSpline_ValidateSampleTrackMesh(void* cursor, float samplesPerNode);
 
 // Advance the cursor to the point on the spline nearest the given world point
 // (used to map a world position back to a spline parameter / progress).
@@ -105,12 +121,13 @@ void swrSpline_BuildProgressTable(swrSpline* spline, float segmentLength, unsign
 // Clear the runtime progress/state arrays for one node index.
 void swrSpline_ResetNodeProgress(int nodeIndex);
 
-// Top level post-load processing (called by LoadTrackSpline): resets junction
-// nodes, builds the progress table, then tessellates.
-void swrSpline_Build(swrSpline* spline, int unk);
+// Top level post-load processing (called by LoadTrackSpline): resets junction nodes, builds
+// the arc-length progress table (100-unit tracing), then bakes the 10-samples-per-node
+// sample->track-mesh table against the track model (+ an optional debug validation pass).
+void swrSpline_Build(swrSpline* spline, struct swrModel_Node* trackModel);
 
 // Returns the .rdata sample-spacing constant (0.0f in retail).
-float swrSpline_GetSampleSpacing_Maybe(void);
+float swrSpline_GetSampleSpacing(void);
 
 // Returns the integrated track/spline length (swrSpline_trackLength, set by swrSpline_TraceProgress).
 float swrSpline_GetTrackLength(void);

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -12,4 +12,43 @@
 #define DAALLOC_ARENA_COUNT (0x421)      // number of daAlloc_struct arena slots (1057)
 #define DAALLOC_SMALL_ALLOC_MAX (0x1000) // requests larger than this bypass the arena (daSmallAlloc)
 
+// swrRace human-input -> pod-control tuning (swrRace_UpdatePlayerControl @0x46bec0 /
+// swrRace_CalcTargetTurnRate). Values read from the retail .rdata constant pool
+// (0x004ad7xx..0x004ad9xx). Doubles are loaded as qword compares; floats as dword.
+#define SWR_CTL_RAND_NORM (4.656612873e-10f) // 2^-31, normalizes swrUtils_Rand() to [0,1)
+#define SWR_CTL_HALF (0.5f)                    // generic 0.5 (0x004ad774)
+#define SWR_CTL_ONE (1.0f)                     // generic 1.0 (0x004ad7f4)
+#define SWR_CTL_NEG_ONE (-1.0f)                // generic -1.0 (0x004ad80c)
+#define SWR_CTL_HALF_HOLD (0.5)                // 0.5s button-hold threshold (0x004ad778, double)
+#define SWR_CTL_NEG_HALF (-0.5)                // -0.5: slide+ easing step; idle-throttle pitch gate (0x004ad928, double)
+#define SWR_CTL_STEER_DEADZONE (0.05f)         // |steer|/|pitch| below this -> turn target zeroed
+#define SWR_CTL_STEER_SQUARE_GAIN (1.25f)      // pre-square gain on steer/pitch before squaring
+#define SWR_CTL_STEER_SCALE (0.8f)             // steer/pitch output scale; also the analog pitch clamp
+#define SWR_CTL_DEMO_STEER_SCALE (-0.5f)       // demo-replay steer scale / bank threshold (0x004ad8e0)
+#define SWR_CTL_PITCH_HI (0.1f)                // pitch above this (nose down) trims turn rate/throttle (0x004ad76c)
+#define SWR_CTL_PITCH_LO (-0.1f)               // pitch below this (nose up) trims turn rate/throttle (0x004ad770)
+#define SWR_CTL_PITCH_TRIM (0.4f)              // pitch -> turn-rate and idle-throttle factor (0x004ad938)
+#define SWR_CTL_PITCH_THROTTLE_TRIM (-0.4f)    // pitch -> throttle trim subtrahend (0x004ad940)
+#define SWR_CTL_THROTTLE_SETTLE_MIN (0.3f)     // throttle above this (wallHitCooldown<=0) sets THROTTLE_SETTLED; demo input gate
+#define SWR_CTL_ANALOG_THROTTLE_GAIN (1.176468f) // analog reverse/throttle remap gain (0x004ad920)
+#define SWR_CTL_IDLE_SPEED (20.0)              // below this speed, idle throttle follows pitch*trim (0x004ad930, double)
+#define SWR_CTL_SLIDE_SPEED (100.0f)           // slide2 easing speed threshold (0x004ad93c)
+#define SWR_CTL_BRAKE_SETTLE_SPEED (70.0)      // braking below this speed also clears THROTTLE_SETTLED (0x004ad918, double)
+#define SWR_CTL_BOOST_THROTTLE (0.6)           // throttle above this + boost input opens the boost window (0x004ad8c8, double)
+#define SWR_CTL_BOOST_WINDOW (0.2)             // boost-start input timing window upper bound (0x004ad908, double)
+#define SWR_CTL_BOOST_WINDOW_LO (0.0)          // boost-start window lower bound (0x004ad830, double)
+#define SWR_CTL_BOOST_CANCEL_SPEED (290.0f)    // speed above which a pending boost-start is cancelled (0x004ad910)
+#define SWR_CTL_BOOST_TAP_TIMEOUT (0.25)       // double-tap window for flame-attack / boost (0x004ad8d0, double)
+#define SWR_CTL_FLAT_THROTTLE_FLOOR (1.2f)     // flags0 0x400000 overdrive: minimum throttle (0x004ad944)
+#define SWR_CTL_DMG_PEN_GAIN (1.5f)            // engine-damage steering-penalty gain (0x004ad8f0)
+#define SWR_CTL_DMG_PEN_LEFT (-0.2f)           // penalty offset when left engines are the damaged side (0x004ad8e8)
+#define SWR_CTL_DMG_PEN_RIGHT (0.2f)           // penalty offset when right engines are the damaged side (0x004ad8ec)
+#define SWR_CTL_DMG_STEER_PULL (-0.6f)         // damage penalty -> steer-pull factor; also demo-replay brake pitch gate (0x004ad8e4)
+#define SWR_CTL_FF_MAG_BASE (60.0f)            // damage force-feedback magnitude base (0x004ad8f8)
+#define SWR_CTL_FF_MAG_SLOPE (-30.0f)          // damage force-feedback magnitude slope (0x004ad8f4)
+#define SWR_CTL_SCRIPT5_LAP_MIN (0.063f)       // ai_track_script==5 scripted-zone lapComp bounds
+#define SWR_CTL_SCRIPT5_LAP_MAX (0.072f)
+#define SWR_CTL_SCRIPT6_LAP_MIN (0.093f)       // ai_track_script==6 scripted-zone lapComp bounds
+#define SWR_CTL_SCRIPT6_LAP_MAX (0.108f)
+
 #endif // ENGINE_CONFIG_H

--- a/src/types.h
+++ b/src/types.h
@@ -467,10 +467,10 @@ extern "C"
         float lapCompMax;
         struct swrModel_Node* splineTrackMesh; // 0xec. baked track mesh under the spline cursor (swrRace_GetTrackMeshAtCursor); raycast target when FULL_RAYCAST is clear; copied to terrainModel on the cached-ground path
         struct swrModel_Node* splineTrackMeshPrev; // 0xf0. previous frame's splineTrackMesh; a change (pod crossed into the next track chunk) zeroes unk1f24
-        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress; the stub always writes 0 (projection compiled out of retail), so 0xf4..0x100 are always zero
-        int unkf8; // 0xf8. its return value (always 0 in retail)
-        int unkfc; // 0xfc. out-slot of the 2nd call (always 0)
-        int unk100; // 0x100. its return value (always 0)
+        int splineProjOut1; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress; the stub always writes 0 (projection compiled out of retail), so 0xf4..0x100 are always zero
+        int splineProjResult1; // 0xf8. its return value (always 0 in retail)
+        int splineProjOut2; // 0xfc. out-slot of the 2nd call (always 0)
+        int splineProjResult2; // 0x100. its return value (always 0)
         float aiLookAhead;    // 0x104. AI autopilot look-ahead offset (spline param, eased within [0.01, 2.0])
         float aiLookAheadDistSq; // 0x108. AI autopilot target look-ahead segment length^2 (init 8100 = 90^2)
         short checkpointCount; // 0x10c. incremented per lap, reset to 0 when off-track; swrObjJdge_IsRacerRacing gates on > 4
@@ -555,7 +555,7 @@ extern "C"
         int tauntTapState; // 0x2f8. byte @0x2f9 = consecutive-tap counter; > 1 within the window fires the taunt (and, for Sebulba, the flame attack)
         float pitch; // 0x2fc .8 pitch down -.8 pitch up
         int current_light_index;
-        int unk304; // 0x304. pod light color mode 0/1/2 read by swrObjcMan_UpdateLighting (2 = second local player)
+        int lightColorMode; // 0x304. pod light color mode 0/1/2 read by swrObjcMan_UpdateLighting (2 = second local player)
         float vehicleBumpTimer; // 0x308. set rand[2,8) on the 'Hitt'/'VhLt' vehicle-bump event; counts down in UpdatePhysicsContact
         float respawnInvincibilityTimer; // 0x30c
         float deathExplodeTimer; // 0x310. set rand[2,3) in swrRace_Explode; HandleDeathSnap / UpdatePhysicsContact count it down to the 'Snap' event / respawn

--- a/src/types.h
+++ b/src/types.h
@@ -467,10 +467,10 @@ extern "C"
         float lapCompMax;
         struct swrModel_Node* splineTrackMesh; // 0xec. baked track mesh under the spline cursor (swrRace_GetTrackMeshAtCursor); raycast target when FULL_RAYCAST is clear; copied to terrainModel on the cached-ground path
         struct swrModel_Node* splineTrackMeshPrev; // 0xf0. previous frame's splineTrackMesh; a change (pod crossed into the next track chunk) zeroes unk1f24
-        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress
-        int unkf8; // 0xf8. its return value
-        int unkfc; // 0xfc. out-slot of the 2nd call
-        int unk100; // 0x100. its return value
+        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress; the stub always writes 0 (projection compiled out of retail), so 0xf4..0x100 are always zero
+        int unkf8; // 0xf8. its return value (always 0 in retail)
+        int unkfc; // 0xfc. out-slot of the 2nd call (always 0)
+        int unk100; // 0x100. its return value (always 0)
         float aiLookAhead;    // 0x104. AI autopilot look-ahead offset (spline param, eased within [0.01, 2.0])
         float aiLookAheadDistSq; // 0x108. AI autopilot target look-ahead segment length^2 (init 8100 = 90^2)
         short checkpointCount; // 0x10c. incremented per lap, reset to 0 when off-track; swrObjJdge_IsRacerRacing gates on > 4
@@ -533,7 +533,7 @@ extern "C"
         float surfaceSpeedFactor; // 0x244
         float surfaceGripFactor; // 0x248
         float slide2; // 0x24c
-        int unk11_1; // 0x250. vertical Z offset applied per-frame to the engine/cockpit part transforms (swrRace_ApplyPartSinkOffset), binder endpoints and cMan camera targets; only zero writes found
+        int unk11_1; // 0x250. vertical Z offset applied per-frame to the engine/cockpit part transforms (swrRace_ApplyPartSinkOffset), binder endpoints and cMan camera targets; no non-zero writer exists in the retail binary (vestigial sink mechanism)
         struct swrModel_Node* guideArrowNode; // 0x254. HUD spline guide arrow node (written by swrObjJdge_UpdatePlayerHUD while FLAG0_GUIDE_ARROW; drawn by swrObjcMan_UpdateSplineGuideMarker)
         rdVector3 guideArrowTarget; // 0x258. spline point 0.5 ahead that the guide arrow points at
         float wallHitCooldown; // 0x264. set 0.1 on a hard wall impact (ApplyWallCollision, clearing FLAG0_THROTTLE_SETTLED); counts down in F0; expiry re-sets the flag
@@ -617,16 +617,16 @@ extern "C"
         int remoteId; // 0x1eb4. network id of the owning remote player (-1 = unassigned; set by the 'RmHi' event, REMO pods only)
         char remoteState[64]; // 0x1eb8. remote-pod staging: controls @+0/+4/+8 ('RmCn'), steer target @+0x10 ('RmTh', consumed by CalcTargetTurnRate -> turnRateTarget), pos+rot 6 floats @+0x14 ('RmLc'/'RmHi')
         float unk1ef8; // 0x1ef8. never referenced (label was 4 bytes off pre-2026-07: unk1ebc)
-        float unk1efc; // 0x1efc. init 0.25 (Init/ResetToSpline); reader unknown
-        float unk1f00; // 0x1f00. init 80.0; reader unknown
+        float unk1efc; // 0x1efc. init 0.25 (Init/ResetToSpline); no reader in the retail binary
+        float unk1f00; // 0x1f00. init 80.0; no reader in the retail binary
         int unk1f04;
         char unk1f08[8];
         int unk1f10;
-        float unk1f14; // 0x1f14. free-running countdown in UpdatePlayerControl; setter unknown
-        int unk1f18; // 0x1f18. zeroed at the end of UpdatePhysicsContact each frame
+        float unk1f14; // 0x1f14. decremented every frame by UpdatePlayerControl but never set or read (vestigial)
+        int unk1f18; // 0x1f18. zeroed at the end of UpdatePhysicsContact each frame; never set or read otherwise
         int unk1f1c;
         int unk1f20;
-        int unk1f24; // 0x1f24. zeroed by UpdateRaceProgress when the cursor's track mesh changes
+        int unk1f24; // 0x1f24. zeroed by UpdateRaceProgress when the cursor's track mesh changes; no other access (vestigial)
     } swrRace; // at 0x00e29c44 sizeof(0x1f28)
 
     typedef struct swrObjToss
@@ -1422,7 +1422,7 @@ extern "C"
         union Vtx* vertices;
         uint16_t num_collision_vertices;
         uint16_t num_vertices;
-        uint16_t splineNodeIndex; // for track collision meshes: the baked spline control-point index this mesh belongs to (swrRace_UpdateSplineBinding re-seeks the cursor here)
+        uint16_t splineSampleIndex; // for track collision meshes: the first baked spline sample index (node * 10 + sub, 0 = unset) that hit this mesh (swrSpline_BakeSampleTrackMesh); swrRace_UpdateSplineBinding re-seeks the cursor to it
         int16_t vertex_base_offset; // only set for mesh parts with bone animtation, equal to "v0" in display list.
     } swrModel_Mesh;
 
@@ -1547,7 +1547,7 @@ extern "C"
     // packing on this one
     typedef struct swrModel_Behavior
     {
-        uint16_t unk1;
+        uint16_t unk1; // bit 0x8 = spline-ambiguous mesh (shared between spline branches; set at bake time by swrSpline_BakeSampleTrackMesh, blocks swrRace_UpdateSplineBinding and marks the not-racing zone in swrObjJdge_IsRacerRacing); 0x10 = force full raycast (no cached-mesh shortcut); 0x20 = surface-magnet gravity
         uint8_t fog_flags;
         uint8_t fog_color[3];
         uint16_t fog_start;

--- a/src/types.h
+++ b/src/types.h
@@ -435,6 +435,21 @@ extern "C"
 
     // TODO 0x00475ad0
 
+    // Runtime cursor walking a spline graph (0x30 bytes). swrRace embeds one at +0xac,
+    // swrObjJdge at +0x34. See swrSpline_CursorInit / CursorSeek / CursorEvaluate.
+    typedef struct swrSplineCursor
+    {
+        struct swrSpline* spline; // 0x00
+        float velocity; // 0x04 signed; sign selects step direction
+        float segmentT; // 0x08 parameter along the current segment, clamped 0..1
+        float tangentLength; // 0x0c length of the evaluated path tangent
+        int nodeLookahead[4]; // 0x10 current node + 3-level lookahead window
+        int endFlag; // 0x20 set when the forward end of the path is reached
+        int startFlag; // 0x24 set when the backward start of the path is reached
+        int branchSelector; // 0x28
+        int branchFlags; // 0x2c
+    } swrSplineCursor; // sizeof(0x30)
+
     typedef struct swrRace // swrObjTest
     {
         swrObj obj;
@@ -445,30 +460,30 @@ extern "C"
         char unk1_1[2];
         PodHandlingData podStats;
         char unk4[4];
-        rdMatrix34 unk4_mat; // 0xac. Not a matrix ? LapCompStruct
-        int unkdc;
+        swrSplineCursor splineCursor; // 0xac. the pod's track-spline cursor (advanced by swrRace_UpdateRaceProgress; progress source for lapComp)
+        float splineSampleSpacing; // 0xdc. = swrSpline_GetSampleSpacing() each frame; that returns the .rdata const @0x4adf40 which is 0.0 in retail (vestigial)
         float lapComp;
         float lapCompPrev;
         float lapCompMax;
-        struct swrModel_Node* unkec_node;
-        int unkf0;
-        int unkf4;
-        int unkf8;
-        int unkfc;
-        int unk100;
+        struct swrModel_Node* splineTrackMesh; // 0xec. baked track mesh under the spline cursor (swrRace_GetTrackMeshAtCursor); raycast target when FULL_RAYCAST is clear; copied to terrainModel on the cached-ground path
+        struct swrModel_Node* splineTrackMeshPrev; // 0xf0. previous frame's splineTrackMesh; a change (pod crossed into the next track chunk) zeroes unk1f24
+        int unkf4; // 0xf4. out-slot of the 1st swrSpline_ProjectPointStub call in swrRace_UpdateRaceProgress
+        int unkf8; // 0xf8. its return value
+        int unkfc; // 0xfc. out-slot of the 2nd call
+        int unk100; // 0x100. its return value
         float aiLookAhead;    // 0x104. AI autopilot look-ahead offset (spline param, eased within [0.01, 2.0])
         float aiLookAheadDistSq; // 0x108. AI autopilot target look-ahead segment length^2 (init 8100 = 90^2)
-        short unk10c;
-        short unk10e;
+        short checkpointCount; // 0x10c. incremented per lap, reset to 0 when off-track; swrObjJdge_IsRacerRacing gates on > 4
+        short splineRebindResult; // 0x10e. last swrRace_UpdateSplineBinding result (-1 blocked / 0 no rebind / 1 rebound to the stood-on mesh)
         float idleTick; // See fn 0x47fdd0
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
-        rdVector4 unk118_vec;
-        int unk128;
+        rdVector4 trackOffset; // 0x118. lateral offset from the racing line: xyz = unit direction spline->pod, w = raw distance (swrRace_ComputeTrackOffset; {0,0,1,dist} within threshold)
+        float leaderGap; // 0x128. race leader's progress minus this racer's (written by swrObjJdge_UpdateStandings)
         float aiLineOffset;  // 0x12c. AI lateral offset from the racing line (also a HUD rival-gap slot)
         float rivalGapAhead; // 0x130. signed progress gap to the rival ahead (AI rubber-band + splitscreen catchup)
         float rivalGapBehind;// 0x134. signed progress gap to the rival behind
         float aiSteerTarget; // 0x138. AI cross-track steer target (written by swrRace_AI)
-        struct swrModel_Node* model_unk; // 0x13c. Collision related ?
+        struct swrModel_Node* collisionModel; // 0x13c. track collision model (Init param); sole target of RaycastModel / CollideBlockMove / CollideTrack
         struct swrModel_Node* terrainModel;
         rdVector3 bumpDirection;
         float speedLoss;
@@ -497,7 +512,7 @@ extern "C"
         float turnRateTarget; // 0x1f0
         float turnModifier; // 0x1f4
         float autoTilt; // 0x1f8. slope auto-tilt torque (drives the pod's bank toward the downhill/surface alignment)
-        float unk8_11; // 0x1fc
+        float contactSteerKick; // 0x1fc. decaying signed yaw impulse from wall scrapes / nearby Smok blasts (swrRace_ApplySmokProximityPush); added to the turn in UpdateControlAndMove; FLAG1_STEER_KICK marks it active
         float tiltAngleTarget; // 0x200
         float tiltAngle; // 0x204
         float tiltManualMult; // 0x208 -1 tilt left, 0 neutral, 1 tilt right
@@ -506,9 +521,9 @@ extern "C"
         float boostChargeTimer; // 0x214
         float engineTemp; // 0x218
         float gravityTubeAngle;
-        float unk10_1; // 0x220
-        float unk10_2; // 0x224
-        int unk10_3; // 0x228
+        float zeroGPitchRate; // 0x220. zero-g secondary (pitch) turn rate, ramped toward zeroGPitchRateTarget at turnResponse while ZON; X-axis rotation rate in swrRace_UpdateSplineOrientation
+        float zeroGPitchRateTarget; // 0x224. target for the above, from pitch input in zero-g (0 otherwise)
+        int unk10_3; // 0x228. float bits: set to 3.0f on the ZOn->ZOff spline-follow transition (swrRace_UpdateSurfaceTag); reader unknown
         float paceMultiplier; // 0x22c. Applied speed multiplier this frame; for AI, the smoothed value swrRace_AI ramps toward aiSpeedTarget
         float aiSpeedTarget;    // 0x230. AI target speed multiplier (base swrRace_AILevel, modulated by rank/spread)
         float aiDecisionTimer;  // 0x234. AI countdown to the next target-rank reroll
@@ -518,10 +533,11 @@ extern "C"
         float surfaceSpeedFactor; // 0x244
         float surfaceGripFactor; // 0x248
         float slide2; // 0x24c
-        int unk11_1; // 0x250
-        char unk12[16];
-        float unk12_1; // 0x264
-        float unk12_2; // 0x268 an angle of some kind ?
+        int unk11_1; // 0x250. vertical Z offset applied per-frame to the engine/cockpit part transforms (swrRace_ApplyPartSinkOffset), binder endpoints and cMan camera targets; only zero writes found
+        struct swrModel_Node* guideArrowNode; // 0x254. HUD spline guide arrow node (written by swrObjJdge_UpdatePlayerHUD while FLAG0_GUIDE_ARROW; drawn by swrObjcMan_UpdateSplineGuideMarker)
+        rdVector3 guideArrowTarget; // 0x258. spline point 0.5 ahead that the guide arrow points at
+        float wallHitCooldown; // 0x264. set 0.1 on a hard wall impact (ApplyWallCollision, clearing FLAG0_THROTTLE_SETTLED); counts down in F0; expiry re-sets the flag
+        float unk12_2; // 0x268. Sebulba flame-attack timer: 15 on spawn, pinned >= 5 while the flame Smok lives, ticks down otherwise; reader unknown
         int collisionToggles; // 0x26C. Some flag. See FUN_0047a930
         float engineHealthMin[6]; // engine health related
         float engineHealth[6]; // 0x288 left top-mid-bot, right top-mid-bot
@@ -535,30 +551,32 @@ extern "C"
         rdVector3 nextRotation; //
         rdVector3 turnInput; // 0x2e4
         int unk2f0;
-        int unk2f4;
-        int unk2f8;
+        float tauntTapTime; // 0x2f4. timetotal stamp of the last taunt-button tap (double-tap window check in UpdatePlayerControl)
+        int tauntTapState; // 0x2f8. byte @0x2f9 = consecutive-tap counter; > 1 within the window fires the taunt (and, for Sebulba, the flame attack)
         float pitch; // 0x2fc .8 pitch down -.8 pitch up
         int current_light_index;
-        int unk304;
-        int unk308;
+        int unk304; // 0x304. pod light color mode 0/1/2 read by swrObjcMan_UpdateLighting (2 = second local player)
+        float vehicleBumpTimer; // 0x308. set rand[2,8) on the 'Hitt'/'VhLt' vehicle-bump event; counts down in UpdatePhysicsContact
         float respawnInvincibilityTimer; // 0x30c
-        int unk310;
-        int unk314;
-        int unk318;
-        int unk31c;
+        float deathExplodeTimer; // 0x310. set rand[2,3) in swrRace_Explode; HandleDeathSnap / UpdatePhysicsContact count it down to the 'Snap' event / respawn
+        struct swrObjSmok* engineDamageSmoke[2]; // 0x314. persistent R/L engine damage smoke handles (Spawn type 6 + SetOwnerHandle in UpdateEngineDamageFX)
+        struct swrObjSmok* flameSmokeHandle; // 0x31c. Sebulba flame-attack Smok (type 8), auto-nulled via SetOwnerHandle; killed on death/reset
         int unk320;
-        int unk324;
+        int fireballEngineSlot; // 0x324. engine index whose fireball FX is burning (-1 = none); anchors the fireball node at that engine matrix
         int unk328;
         int unk32c;
         float exhaustSizeLeft;
         float exhaustSizeRight;
-        int unk338;
-        int unk33c;
-        int unk340;
-        struct swrModel_Node** unk344_nodeArray;
-        struct swrModel_Node* unk348_node;
-        struct swrModel_Node* unk34c_node;
-        rdMatrix44 unk350_mat;
+        float spinoutEngineAngle; // 0x338. accumulated engine spin during the death spinout (AnimateSpinoutEngines)
+        float spinoutCockpitAngle; // 0x33c. same for the cockpit
+        float spinoutSpinRamp; // 0x340. ramp toward 1.0 scaling both spinout spin rates
+        struct swrModel_Node** partNodes; // 0x344. pod part-node array (podModel param of Init): [1..4] engines, [5] cockpit, [0x3e..0x40] shadows, [0x41/0x42] scrape sparks, [0x43/0x44] exhausts; NULL = far-LOD pod
+        struct swrModel_Node* lodBodyNode; // 0x348. single-node far-LOD pod body (transform = farLodPodXf), used when partNodes == NULL
+        struct swrModel_Node* lodSelectorNode; // 0x34c. LOD selector node; F3 selects child (lodDistance < 101 ? 0 : 1)
+        // 0x350..0x1610 is one rdMatrix44[75] per-part transform array, index-aligned with
+        // partNodes (Init resets all 75 in a single loop); the named engineXf*/cockpitXf/
+        // shadowXf*/scrapeSparkXf*/engineExhaustXf*/farLodPodXf members are its elements.
+        rdMatrix44 unk350_mat; // 0x350. partXf[0] (root)
         rdMatrix44 engineXfR;
         rdMatrix44 engineXfL;
         rdMatrix44 engineXfR2;
@@ -572,42 +590,43 @@ extern "C"
         rdMatrix44 scrapeSparkXf2;
         rdMatrix44 engineExhaustXfR;
         rdMatrix44 engineExhaustXfL;
-        rdMatrix44 unk1490_mat;
-        rdMatrix44 unk14d0_mat;
-        char unk1510[192];
-        rdMatrix44 unk15d0_mat;
-        char unk1610[900];
+        rdMatrix44 engineGlowXfR; // 0x1490. right engine afterburner-glow billboard transform (diagonal scale, PoddAnimateVariousThings -> partNodes[0x45])
+        rdMatrix44 engineGlowXfL; // 0x14d0. left engine glow billboard (partNodes[0x46])
+        char unk1510[192]; // 0x1510. partXf[71..73], never referenced
+        rdMatrix44 farLodPodXf; // 0x15d0. transform of the single-node far-LOD pod (0.004-scaled pod transform; set on lodBodyNode in F3)
+        char unk1610[900]; // 0x1610. rdVector3 partOffset[75], index-aligned with partNodes: per-part positional offset / animation accumulators (exhaust size at [side].y, steering-part spin at +400)
         struct swrModel_Node* reflectionNode; // 0x1994. pod's planar ground-reflection node (drawn by swrRace_UpdateReflectionNode on ON_MIRR surfaces)
         int lodDistance;
-        char unk199c[16];
-        float unk19ac;
+        float wobblePhase[4]; // 0x199c. per-part wobble sine phases, random-seeded in Init, advanced by dt (AnimateEngineWobble)
+        float wobbleAmplitude; // 0x19ac. engine-wobble amplitude: forced 1.0 on HIT_BOTTOM, decays to a 0.4 floor
         float unk19b0;
-        float unk19b4;
-        int unk19b8;
-        rdMatrix44 matArray[18];
-        int unk1e3c;
-        int unk1e40;
-        int unk1e44;
-        rdVector3 unk1e48_vec;
-        rdVector3 unk1e54_vec;
-        int unk1e60;
-        int unk1e64_flag;
-        int unk1e68_flag;
-        int unk1e6c;
+        float unk19b4; // 0x19b4. cockpit bob delta from thrust/speed (PoddAnimateEngines)
+        int unk19b8; // 0x19b8. float bits: smoothed engine tilt (TiltEngines)
+        rdMatrix44 transformHistory[18]; // 0x19bc. ring buffer of recent pod transforms; engines lag 16 frames, cockpit 10 (PoddAnimateEngines)
+        int historyWriteIdx; // 0x1e3c. (idx + 1) % 18 each frame
+        int historyLagEngines; // 0x1e40. constant 16, rewritten each frame
+        int historyLagCockpit; // 0x1e44. constant 10, rewritten each frame
+        rdVector3 cockpitSpringPos; // 0x1e48. cockpit lag-spring position state
+        rdVector3 cockpitSpringVel; // 0x1e54. cockpit lag-spring velocity state (stdMath_Decelerator)
+        int unk1e60; // 0x1e60. float bits: previous-frame cockpit gravity-projection scalar
+        int unk1e64_flag; // 0x1e64. float bits: pod footprint half-extent X from the shadow node AABB (default 2.0, Neva Kee 3.0); also the engine-proximity push radius
+        int unk1e68_flag; // 0x1e68. float bits: half-extent Y (default 2.0, Neva Kee 5.0)
+        int orthoRenormCounter; // 0x1e6c. every 8 frames UpdateTurn2 re-normalizes the transform basis vectors
         struct swrScore* score_ptr;
         char unk1e74[64];
-        int unk1eb4;
-        char unk1eb8[64];
-        float unk1ebc;
-        float unk1f00;
+        int remoteId; // 0x1eb4. network id of the owning remote player (-1 = unassigned; set by the 'RmHi' event, REMO pods only)
+        char remoteState[64]; // 0x1eb8. remote-pod staging: controls @+0/+4/+8 ('RmCn'), steer target @+0x10 ('RmTh', consumed by CalcTargetTurnRate -> turnRateTarget), pos+rot 6 floats @+0x14 ('RmLc'/'RmHi')
+        float unk1ef8; // 0x1ef8. never referenced (label was 4 bytes off pre-2026-07: unk1ebc)
+        float unk1efc; // 0x1efc. init 0.25 (Init/ResetToSpline); reader unknown
+        float unk1f00; // 0x1f00. init 80.0; reader unknown
         int unk1f04;
-        int unk1f08;
-        char unk1f0c[8];
-        int unk1f14;
-        int unk1f18;
+        char unk1f08[8];
+        int unk1f10;
+        float unk1f14; // 0x1f14. free-running countdown in UpdatePlayerControl; setter unknown
+        int unk1f18; // 0x1f18. zeroed at the end of UpdatePhysicsContact each frame
         int unk1f1c;
         int unk1f20;
-        int unk1f24;
+        int unk1f24; // 0x1f24. zeroed by UpdateRaceProgress when the cursor's track mesh changes
     } swrRace; // at 0x00e29c44 sizeof(0x1f28)
 
     typedef struct swrObjToss
@@ -730,21 +749,6 @@ extern "C"
         char podiumCharacters[3];
         char unkcf;
     } swrObjHang; // sizeof(0xd0)
-
-    // Runtime cursor walking a spline graph (0x30 bytes). swrObjJdge embeds one
-    // at +0x34. See swrSpline_CursorInit / CursorSeek / CursorEvaluate.
-    typedef struct swrSplineCursor
-    {
-        struct swrSpline* spline; // 0x00
-        float velocity; // 0x04 signed; sign selects step direction
-        float segmentT; // 0x08 parameter along the current segment, clamped 0..1
-        float tangentLength; // 0x0c length of the evaluated path tangent
-        int nodeLookahead[4]; // 0x10 current node + 3-level lookahead window
-        int endFlag; // 0x20 set when the forward end of the path is reached
-        int startFlag; // 0x24 set when the backward start of the path is reached
-        int branchSelector; // 0x28
-        int branchFlags; // 0x2c
-    } swrSplineCursor; // sizeof(0x30)
 
     typedef struct swrObjJdge
     {
@@ -1081,7 +1085,7 @@ extern "C"
         char unke[2];
         int sfxChannel; // 0x10. low byte = per-racer SFX channel index (swrSound_SetSfxFlag / swrSound_TestSfxFlag)
         int unk14;
-        int unk18; // holds a pointer to the racer's sound source (dereferenced in swrObjJdge_F2 for the finish-line SFX)
+        int* pilotId; // 0x18. points at the racer's selected pilot/vehicle index (0..22, -1 = none); selects the pilot voice bank (swrSound_ResolveSfxId bounds-checks 0..0x16) and gates pilot specials (2 = Sebulba flame attack, 0xe = Neva Kee fused engines)
         PodHandlingData podStats;
         short unk58;
         short unk5a;
@@ -1418,7 +1422,7 @@ extern "C"
         union Vtx* vertices;
         uint16_t num_collision_vertices;
         uint16_t num_vertices;
-        uint16_t unk1;
+        uint16_t splineNodeIndex; // for track collision meshes: the baked spline control-point index this mesh belongs to (swrRace_UpdateSplineBinding re-seeks the cursor here)
         int16_t vertex_base_offset; // only set for mesh parts with bone animtation, equal to "v0" in display list.
     } swrModel_Mesh;
 

--- a/src/types.h
+++ b/src/types.h
@@ -478,11 +478,16 @@ extern "C"
         float idleTick; // See fn 0x47fdd0
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
         rdVector4 trackOffset; // 0x118. lateral offset from the racing line: xyz = unit direction spline->pod, w = raw distance (swrRace_ComputeTrackOffset; {0,0,1,dist} within threshold)
-        float gapToLeader; // 0x128. race leader's progress minus this racer's, so >= 0 (written by swrObjJdge_UpdateStandings)
-        float aiLineOffset;  // 0x12c. AI lateral offset from the racing line (also a HUD rival-gap slot)
-        float rivalGapAhead; // 0x130. signed progress gap to the rival ahead (AI rubber-band + splitscreen catchup)
-        float rivalGapBehind;// 0x134. signed progress gap to the rival behind
-        float aiSteerTarget; // 0x138. AI cross-track steer target (written by swrRace_AI)
+        // The four gap fields below are written for EVERY racer by swrObjJdge_UpdateStandings,
+        // in units of race progress (laps: lap count + fraction of the current lap).
+        float gapToLeader; // 0x128. progress gap behind the current race leader (>= 0)
+        float gapToPacer; // 0x12c. signed progress gap behind the pace-setter (the track-favorite
+                          // AI_SIMPLE pod); the AI field station-keeps on this in swrRace_AI
+        float gapToLocalPlayer1; // 0x130. signed gap to local player 1 (>0 = P1 is ahead); -100.0 when no
+                                 // local player. Drives the AI rival tether + the splitscreen catchup boost
+        float gapToLocalPlayer2; // 0x134. signed gap to local player 2 (splitscreen only)
+        float aiPaceOffsetTarget; // 0x138. AI station-keeping target: desired progress offset (laps)
+                                  // behind the pacer, derived from aiRankTarget (written by swrRace_AI)
         struct swrModel_Node* collisionModel; // 0x13c. track collision model (Init param); sole target of RaycastModel / CollideBlockMove / CollideTrack
         struct swrModel_Node* terrainModel;
         rdVector3 bumpDirection;

--- a/src/types.h
+++ b/src/types.h
@@ -478,7 +478,7 @@ extern "C"
         float idleTick; // See fn 0x47fdd0
         int moveTick; // 0 when moving backward, tick up to 200 max when moving forward
         rdVector4 trackOffset; // 0x118. lateral offset from the racing line: xyz = unit direction spline->pod, w = raw distance (swrRace_ComputeTrackOffset; {0,0,1,dist} within threshold)
-        float leaderGap; // 0x128. race leader's progress minus this racer's (written by swrObjJdge_UpdateStandings)
+        float gapToLeader; // 0x128. race leader's progress minus this racer's, so >= 0 (written by swrObjJdge_UpdateStandings)
         float aiLineOffset;  // 0x12c. AI lateral offset from the racing line (also a HUD rival-gap slot)
         float rivalGapAhead; // 0x130. signed progress gap to the rival ahead (AI rubber-band + splitscreen catchup)
         float rivalGapBehind;// 0x134. signed progress gap to the rival behind

--- a/src/types.h
+++ b/src/types.h
@@ -521,9 +521,13 @@ extern "C"
         float boostChargeTimer; // 0x214
         float engineTemp; // 0x218
         float gravityTubeAngle;
-        float zeroGPitchRate; // 0x220. zero-g secondary (pitch) turn rate, ramped toward zeroGPitchRateTarget at turnResponse while ZON; X-axis rotation rate in swrRace_UpdateSplineOrientation
-        float zeroGPitchRateTarget; // 0x224. target for the above, from pitch input in zero-g (0 otherwise)
-        int unk10_3; // 0x228. float bits: set to 3.0f on the ZOn->ZOff spline-follow transition (swrRace_UpdateSurfaceTag); reader unknown
+        float zeroGPitchRate; // 0x220. zero-g pitch rate about the pod's lateral axis (transform.vA). Slewed toward
+                              // zeroGPitchRateTarget at podStats.turnResponse in swrObjTest_UpdateControlAndMove, then
+                              // applied (x1.5, like turnRate's yaw) as a local-X rotation in swrRace_UpdateSplineOrientation
+        float zeroGPitchRateTarget; // 0x224. Target for zeroGPitchRate, set from the squared pitch input scaled by
+                                    // podStats.maxTurnRate in swrRace_UpdatePlayerControl, which then zeroes the normal
+                                    // pitch path -- in zero-g the stick pitches the pod instead of trimming it
+        int unk10_3; // 0x228. float bits: set to 3.0f on the ZOn->ZOff spline-follow transition (swrRace_UpdateSurfaceTag); no reader in the binary
         float paceMultiplier; // 0x22c. Applied speed multiplier this frame; for AI, the smoothed value swrRace_AI ramps toward aiSpeedTarget
         float aiSpeedTarget;    // 0x230. AI target speed multiplier (base swrRace_AILevel, modulated by rank/spread)
         float aiDecisionTimer;  // 0x234. AI countdown to the next target-rank reroll

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -74,15 +74,21 @@ typedef enum GameSettingFlag
 // (swrRace_Init/swrRace_AI/swrObjTest_F0/F4) and annodue's Test entity RE.
 typedef enum swrObjTest_FLAG0
 {
+    // The low nibble (& STATE_MASK) is a small state field, not independent bits:
+    // 0 = inert / pre-race (countdown), 1 = post-race coast, 2 = actively racing.
+    // Values 4/8 are never written in retail.
+    swrObjTest_FLAG0_STATE_MASK = 0xf,
+    swrObjTest_FLAG0_STATE_POSTRACE = 0x1, // post-race / finished coast (set per pod by swrObjJdge_StartPostRaceSequence)
     swrObjTest_FLAG0_RACING = 0x2, // actively racing (low nibble == 2, set on the 'Go!!' event)
-    swrObjTest_FLAG0_UNDER_POWER_Maybe = 0x10, // set while the pod is under engine power (accelerating);
-    // gates the engine-damage steering pull in swrRace_UpdatePlayerControl; latched for AI/remote racers
-    // once the start timer (unk12_1) expires. Cleared on reset. Best-guess name.
+    swrObjTest_FLAG0_THROTTLE_SETTLED = 0x10, // wallHitCooldown expired since the last hard wall impact
+    // (ApplyWallCollision clears it and arms the 0.1s cooldown); autopilot picks full throttle on it and
+    // it gates the engine-damage steering pull in swrRace_UpdatePlayerControl.
     swrObjTest_FLAG0_LOCAL = 0x20, // 'Locl' racer (local human)
     swrObjTest_FLAG0_REMOTE = 0x40, // 'REMO' racer (remote/network)
     swrObjTest_FLAG0_AI = 0x80, // 'AAII' racer (computer)
     swrObjTest_FLAG0_AI_SIMPLE = 0x100, // simplified AI path (set from score->flag & 0x20)
     swrObjTest_FLAG0_BRAKING = 0x200, // is braking
+    swrObjTest_FLAG0_REPAIRING = 0x400, // repair input held / AI post-finish auto-repair (swrRace_Repair pins repairTimer = 0.1 while set)
     swrObjTest_FLAG0_RESET = 0x800, // 'reset pod' requested (death-snap)
     swrObjTest_FLAG0_RESPAWN = 0x1000, // 'respawn pod' requested
     swrObjTest_FLAG0_RESPAWN_INVINC = 0x2000, // respawn invincibility
@@ -90,19 +96,23 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_AI_RIVAL_AHEAD = 0x8000, // AI pacing to the rival ahead
     swrObjTest_FLAG0_AI_RIVAL_BEHIND = 0x10000, // AI pacing to the rival behind
     swrObjTest_FLAG0_TP_TO_SPLINE = 0x20000, // teleport to spline point requested
+    swrObjTest_FLAG0_WALL_IMPACT_CLAMP = 0x40000, // one-shot from a strong wall impact (ApplyWallCollision); UpdatePhysicsContact consumes it to clamp accelThrust
     swrObjTest_FLAG0_POD_HIDDEN = 0x80000, // hide the pod in its OWN camera view (first-person /
     // bumper cam, and demo mode). swrRace_PoddAnimateEngines clears the pod root node's visible
     // flag when this is set (and DEAD is clear); vanilla re-shows the pod to the OTHER viewport in
     // swrViewport_Render. Cleared each frame in swrObjTest_F0.
-    swrObjTest_FLAG0_INPUT_STATE_Maybe = 0x100000, // per-frame input-derived state set in
-    // swrRace_UpdatePlayerControl (from in-race input bitset3 bit 0x8 / the analog control config);
-    // consumer not yet identified. Cleared on reset. Best-guess name.
-    swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost
+    swrObjTest_FLAG0_LOOK_BACK = 0x100000, // rear-view / look-back input held (in-race input bitset3 bit 0x8);
+    // the camera manager reads it to flip the chase/first-person camera basis, then clears it.
+    swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost (speed > 0.75 * maxSpeed, alive)
     swrObjTest_FLAG0_BOOSTING = 0x800000, // boost active
     swrObjTest_FLAG0_HIT_BOTTOM = 0x1000000, // hard-landing debounce ('HittBotm' event)
     swrObjTest_FLAG0_ZON = 0x2000000, // zero-g ON / orbit
     swrObjTest_FLAG0_ZOFF = 0x4000000, // zero-g OFF transition
+    swrObjTest_FLAG0_GUIDE_ARROW = 0x8000000, // HUD spline guide arrow shown (set/cleared by swrObjJdge_UpdatePlayerHUD; read by swrObjcMan_UpdateSplineGuideMarker)
+    swrObjTest_FLAG0_SCRAPE_SPARK_R = 0x10000000, // scrape-spark emitter active on partNodes[0x41] (SetupScrapeSpray side 1; self-clears in UpdateScrapeSparks)
+    swrObjTest_FLAG0_SCRAPE_SPARK_L = 0x20000000, // scrape-spark emitter active on partNodes[0x42]
     swrObjTest_FLAG0_WAS_BOOSTING = 0x40000000, // was boosting last frame
+    // 0x80000000 is cleared every frame by UpdatePlayerControl but never set or read (vestigial).
 } swrObjTest_FLAG0;
 
 // swrRace (swrObjTest) flags1 @ +0x64. The ON_* terrain bits are derived from
@@ -113,7 +123,7 @@ typedef enum swrObjTest_FLAG1
     swrObjTest_FLAG1_SPLINE_SNAP = 0x2, // pending snap to spline point
     swrObjTest_FLAG1_NOT_ACCEL = 0x4, // not accelerating
     swrObjTest_FLAG1_SLIDING = 0x8, // sliding
-    swrObjTest_FLAG1_SLIDE_LOCK = 0x10, // freezes the slide2 easing
+    swrObjTest_FLAG1_SLIDE_LOCK = 0x10, // a contactSteerKick (wall scrape / Smok blast push) is decaying; pins slide2 = 0.25 while set
     swrObjTest_FLAG1_ON_SIDE = 0x20, // Side terrain
     swrObjTest_FLAG1_ON_MIRR = 0x40, // Mirr terrain
     swrObjTest_FLAG1_FULL_RAYCAST = 0x80, // skip cached terrain-mesh raycast (behavior unk1 & 0x10)
@@ -130,6 +140,7 @@ typedef enum swrObjTest_FLAG1
     swrObjTest_FLAG1_ON_SOFT = 0x100000, // Soft terrain
     swrObjTest_FLAG1_FLAT_CACHE = 0x400000, // flat-ground raycast cache valid
     swrObjTest_FLAG1_ON_FLAT = 0x800000, // Flat terrain
+    swrObjTest_FLAG1_RESPAWN_RELIGHT = 0x200000, // one-shot when respawn invincibility expires; cMan reloads terrain lighting/fog, then clears it
     swrObjTest_FLAG1_FINISHED = 0x2000000, // race complete
     swrObjTest_FLAG1_FORCE_GROUND = 0x4000000, // gates the full ground/spline update
     swrObjTest_FLAG1_GROUNDED = 0x8000000, // grounded

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -104,6 +104,8 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_LOOK_BACK = 0x100000, // rear-view / look-back input held (in-race input bitset3 bit 0x8);
     // the camera manager reads it to flip the chase/first-person camera basis, then clears it.
     swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost (speed > 0.75 * maxSpeed, alive)
+    // 0x400000: read by UpdatePlayerControl (pins throttle 1.2 during boost charge) and cleared by
+    // BoostCharge, but no setter exists in the retail binary - dead code, left unnamed.
     swrObjTest_FLAG0_BOOSTING = 0x800000, // boost active
     swrObjTest_FLAG0_HIT_BOTTOM = 0x1000000, // hard-landing debounce ('HittBotm' event)
     swrObjTest_FLAG0_ZON = 0x2000000, // zero-g ON / orbit

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -96,8 +96,10 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_RESPAWN = 0x1000, // 'respawn pod' requested
     swrObjTest_FLAG0_RESPAWN_INVINC = 0x2000, // respawn invincibility
     swrObjTest_FLAG0_DEAD = 0x4000, // dead / spun out
-    swrObjTest_FLAG0_AI_RIVAL_AHEAD = 0x8000, // AI pacing to the rival ahead
-    swrObjTest_FLAG0_AI_RIVAL_BEHIND = 0x10000, // AI pacing to the rival behind
+    swrObjTest_FLAG0_AI_TETHER_LOCAL1 = 0x8000, // one of the 1-2 AI nearest to local player 1: swrRace_AI
+    // paces it directly on gapToLocalPlayer1 (the rubberband tether). Retagged every frame in
+    // swrObjJdge_UpdateStandings.
+    swrObjTest_FLAG0_AI_TETHER_LOCAL2 = 0x10000, // same, tethered to local player 2 (splitscreen only)
     swrObjTest_FLAG0_TP_TO_SPLINE = 0x20000, // teleport to spline point requested
     swrObjTest_FLAG0_WALL_IMPACT_CLAMP = 0x40000, // one-shot from a strong wall impact (ApplyWallCollision); UpdatePhysicsContact consumes it to clamp accelThrust
     swrObjTest_FLAG0_POD_HIDDEN = 0x80000, // hide the pod in its OWN camera view (first-person /

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -107,8 +107,10 @@ typedef enum swrObjTest_FLAG0
     swrObjTest_FLAG0_LOOK_BACK = 0x100000, // rear-view / look-back input held (in-race input bitset3 bit 0x8);
     // the camera manager reads it to flip the chase/first-person camera basis, then clears it.
     swrObjTest_FLAG0_CAN_CHARGE_BOOST = 0x200000, // eligible to charge boost (speed > 0.75 * maxSpeed, alive)
-    // 0x400000: read by UpdatePlayerControl (pins throttle 1.2 during boost charge) and cleared by
-    // BoostCharge, but no setter exists in the retail binary - dead code, left unnamed.
+    swrObjTest_FLAG0_BOOST_OVERDRIVE = 0x400000, // overdrive throttle floor (1.2): while set, throttle can't drop
+                                                 // below 120%. Read by swrRace_UpdatePlayerControl, cleared by
+                                                 // swrRace_BoostCharge when not boost-eligible; never set in retail
+                                                 // (cut companion to the boost mechanic - read+cleared only).
     swrObjTest_FLAG0_BOOSTING = 0x800000, // boost active
     swrObjTest_FLAG0_HIT_BOTTOM = 0x1000000, // hard-landing debounce ('HittBotm' event)
     swrObjTest_FLAG0_ZON = 0x2000000, // zero-g ON / orbit


### PR DESCRIPTION
Reimplements the AI steering/control side of the racer brain, plus the corrections that fell out of verifying how the rubberband actually works.

**Stacks on #281** (which now stacks on #264; #280 has merged) — the first ten commits here are theirs; please review/merge those first, bottom-up. This diff narrows to just the autopilot commit once they land; until then review only `48bc0c0`.

Restacked because the two PRs were duplicating each other: #281 declares `swrRace_CheckResetInput` / `swrRace_ApplyPodProximityForce` / `swrRace_UpdateAutopilotControl` as `HANG("TODO")` stubs and this one implements them, and both retyped `swrRace_DebugFlag` char -> int in data_symbols.syms. Independently they'd have collided on that line and, worse, produced two definitions of each of those three functions. Stacked, this layer just un-stubs them; the `DebugFlag` retype now comes from #281 alone. (Same reasoning either way: the original XORs/clears the full dword at 0x50c048, so the char define made every mask above bit 7 read 0 — including the already-merged IFLY check in `swrRace_UpdateSurfaceTag` and the debug-`Snap` path here.)

**New bodies**
- `swrEvent_FindNearestObjects` (0x450e70) - k-nearest object query; was declaration-only, so anything calling it couldn't link
- `swrRace_UpdateAIGlidePitch` (0x46aec0) - glide-dive pitch; also fixed its header prototype, which was `(int, float, int, int)`
- `swrRace_AutopilotSteer` (0x46af20) - throttle, spline-fork branch choice (per-frame coin flip + the six `ai_track_script` lap-fraction windows), adaptive look-ahead, heading P-controller with a throttle lift on big corrections
- `swrRace_ApplyPodProximityForce` (0x46b430) - pod avoidance; when the lone nearby pod is a local human closing from behind the sign flips and the AI blocks. This is the "AI wiggles in front of you" behavior - it's player-only
- `swrRace_UpdateAutopilotControl` (0x46bb70) - AI control dispatch; calls `swrRace_CheckResetInput`, which stays a stub from #281

**Fixes that fell out of verification**
- `swrObjJdge_UpdateStandings` stored the gap fields through `(int)` casts, but the original uses plain float FSTPs - sub-lap gaps were truncated to 0, which would have flattened the AI pacing if the reimpl went live. The no-local-player sentinel is float `-100.0`, and `unk128` is a float (gap to the leader).

**Renames** (the old names described what the fields turned out not to be): `gapToLeader` / `gapToPacer` / `gapToLocalPlayer1/2` / `aiPaceOffsetTarget`, and `FLAG0_AI_RIVAL_AHEAD/BEHIND` -> `FLAG0_AI_TETHER_LOCAL1/2`. The gaps are race-progress in laps, measured against the local players and the track-favorite "pacer" pod - comments in types.h spell out the units and writers.

Full dinput.dll build + link clean on the stacked branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



