### PR TITLE
feat(reimpl): runtime hook-mode switch + differential verification harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ file(GLOB SOURCES
     src/swr.c
     src/stdPlatform.c
     src/FUN.c
+    src/hook_mode.c
     # specifics
     src/Dss/*c
     src/Engine/*.c

--- a/assets/reimpl_config.example.txt
+++ b/assets/reimpl_config.example.txt
@@ -1,0 +1,39 @@
+# Which reimplementations actually run.
+#
+# Copy this next to SWEP1RCR.EXE as `reimpl_config.txt`. With no such file every
+# reimplementation stays dormant, which is the shipped behaviour: the bodies in src/
+# compile and link, but each one is redirected to its retail counterpart and never
+# executes. That is the safe default and should stay the default.
+#
+# Grammar, one directive per line, '#' starts a comment:
+#
+#   original <pattern>   redirect our body to retail -- the reimplementation is dormant
+#   reimpl   <pattern>   redirect retail to our body -- the reimplementation takes over
+#   both     <pattern>   redirect neither, leaving both bodies callable for comparison
+#   verify               run the differential self-test once at startup
+#
+# A pattern may end in '*' to match a prefix; '*' alone matches everything. Later
+# rules win, so a broad rule followed by narrow exceptions reads top to bottom.
+#
+# Modes compose per function, which is what makes a failure attributable. A function
+# in `reimpl` mode whose callees are all `original` runs our code against otherwise
+# untouched surroundings, so a behaviour change can only have come from that one body.
+
+# ---------------------------------------------------------------------------
+# Differential verification: compare our stdMath against retail and log the
+# result to reimpl_verify.log. Nothing is redirected, so the game still runs
+# entirely on retail code -- this is safe to leave enabled.
+# ---------------------------------------------------------------------------
+both stdMath_*
+both rdVector_*
+both rdMath_*
+both rdMatrix_*
+both stdHashtbl_*
+verify
+
+# ---------------------------------------------------------------------------
+# Bringing a reimplementation live. Do this one subsystem at a time, and only
+# after its functions pass verification.
+# ---------------------------------------------------------------------------
+# reimpl stdMath_*
+# reimpl swrRace_CalcTargetTurnRate

--- a/dinput_hook/reimpl_verify.cpp
+++ b/dinput_hook/reimpl_verify.cpp
@@ -1,0 +1,1239 @@
+#include "reimpl_verify.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+#include <General/stdMath.h>
+#include <General/stdHashTable.h>
+#include <Primitives/rdMath.h>
+#include <Primitives/rdMatrix.h>
+#include <Primitives/rdVector.h>
+#include <globals.h>
+#include <hook_mode.h>
+}
+
+#define REIMPL_VERIFY_LOG_FILE "reimpl_verify.log"
+
+// Iterations per case: enough to walk a domain finely without stalling startup.
+#define VERIFY_ITERATIONS 20000
+
+namespace {
+
+    FILE *verify_log = nullptr;
+
+    int cases_run = 0;
+    int cases_passed = 0;
+    int cases_skipped = 0;
+
+    // Deterministic generator, so a reported failing input can always be reproduced.
+    uint32_t rng_state = 0x13579bdfu;
+
+    uint32_t next_u32() {
+        rng_state ^= rng_state << 13;
+        rng_state ^= rng_state >> 17;
+        rng_state ^= rng_state << 5;
+        return rng_state;
+    }
+
+    float next_float(float lo, float hi) {
+        // 24 bits of mantissa is the whole of a float's precision.
+        const float unit = (float) (next_u32() >> 8) / (float) (1u << 24);
+        return lo + (hi - lo) * unit;
+    }
+
+    // Values that historically break range-reduction and clamping: domain edges, the
+    // branch constants in stdMath's polynomial approximations, and the sign boundaries.
+    const float interesting[] = {
+        0.0f,      -0.0f,      1.0f,       -1.0f,       0.5f,   -0.5f,   0.999999f, -0.999999f,
+        1.000001f, -1.000001f, 0.7071068f, -0.7071068f, 0.001f, -0.001f, 0.0001f,   -0.0001f,
+        90.0f,     -90.0f,     180.0f,     -180.0f,     270.0f, 360.0f,  -360.0f,   720.0f,
+        -720.0f,   1e-20f,     -1e-20f,    1e20f,       -1e20f,
+    };
+    const int interesting_count = (int) (sizeof(interesting) / sizeof(interesting[0]));
+
+    // Walk the interesting values first, then random samples across the domain.
+    //
+    // An interesting value outside [lo, hi] is skipped rather than forced through: a
+    // slerp does not take t = 270 and a rotation builder does not take 1e20 degrees, and
+    // feeding those in produces failures that say nothing about whether the
+    // reimplementation matches for inputs the game can actually generate. Widen the
+    // caller's range when out-of-domain behaviour is what you want to pin down.
+    float sample(int i, float lo, float hi) {
+        if (i < interesting_count) {
+            const float v = interesting[i];
+            if (v >= lo && v <= hi)
+                return v;
+        }
+        return next_float(lo, hi);
+    }
+
+    struct Stats {
+        const char *name;
+        int total;
+        int exact;
+        int tolerated;
+        int mismatch;
+        int worst_ulp;
+        char first_fail[256];
+    };
+
+    void stats_init(Stats &s, const char *name) {
+        s.name = name;
+        s.total = 0;
+        s.exact = 0;
+        s.tolerated = 0;
+        s.mismatch = 0;
+        s.worst_ulp = 0;
+        s.first_fail[0] = '\0';
+    }
+
+    // Distance in representable floats. Same-sign IEEE-754 bit patterns are monotonic, so
+    // subtracting them counts the steps between two values.
+    int ulp_diff(float a, float b) {
+        if (a == b)
+            return 0;
+        if (std::isnan(a) && std::isnan(b))
+            return 0;
+        if (std::isnan(a) != std::isnan(b))
+            return INT32_MAX;
+
+        int32_t ia, ib;
+        std::memcpy(&ia, &a, sizeof(ia));
+        std::memcpy(&ib, &b, sizeof(ib));
+        if ((ia < 0) != (ib < 0))
+            return INT32_MAX;
+
+        const int64_t d = (int64_t) ia - (int64_t) ib;
+        const int64_t abs_d = d < 0 ? -d : d;
+        return abs_d > INT32_MAX ? INT32_MAX : (int) abs_d;
+    }
+
+    // Record one float comparison. `tolerance` is a ULP budget, and every case currently
+    // passes 0 -- bit-identical to retail, across all 54 of them. Keep it that way. A
+    // budget is only defensible with evidence that the two genuinely cannot agree, and
+    // every divergence investigated so far turned out to be a real defect rather than an
+    // unavoidable rounding difference. Widening this to turn a red case green hides bugs.
+    void record(Stats &s, float ours, float retail, int tolerance, const char *input_desc) {
+        s.total++;
+        const int ulp = ulp_diff(ours, retail);
+
+        if (ulp == 0) {
+            s.exact++;
+            return;
+        }
+        if (ulp > s.worst_ulp)
+            s.worst_ulp = ulp;
+        if (ulp <= tolerance) {
+            s.tolerated++;
+            return;
+        }
+        s.mismatch++;
+        if (s.first_fail[0] == '\0') {
+            std::snprintf(s.first_fail, sizeof(s.first_fail),
+                          "%s -> ours=%.9g (0x%08x) retail=%.9g (0x%08x) ulp=%d", input_desc, ours,
+                          *(const uint32_t *) &ours, retail, *(const uint32_t *) &retail, ulp);
+        }
+    }
+
+    void record_int(Stats &s, int ours, int retail, const char *input_desc) {
+        s.total++;
+        if (ours == retail) {
+            s.exact++;
+            return;
+        }
+        s.mismatch++;
+        if (s.first_fail[0] == '\0') {
+            std::snprintf(s.first_fail, sizeof(s.first_fail), "%s -> ours=%d retail=%d", input_desc,
+                          ours, retail);
+        }
+    }
+
+    void report(const Stats &s) {
+        const bool passed = s.mismatch == 0;
+        cases_run++;
+        if (passed)
+            cases_passed++;
+
+        std::fprintf(verify_log, "  %-36s %-6s %6d cases", s.name, passed ? "PASS" : "FAIL",
+                     s.total);
+        if (s.tolerated > 0)
+            std::fprintf(verify_log, ", %d within tolerance", s.tolerated);
+        if (s.worst_ulp > 0)
+            std::fprintf(verify_log, ", worst %d ulp", s.worst_ulp);
+        if (!passed)
+            std::fprintf(verify_log, ", %d MISMATCH\n    first: %s", s.mismatch, s.first_fail);
+        std::fprintf(verify_log, "\n");
+        std::fflush(verify_log);
+    }
+
+    // Detours rewrites a target's prologue with a jump. If the delta layer has
+    // forward-hooked this function -- as renderer_hook.cpp does for the whole GL
+    // takeover surface -- then hook_retail_ptr() no longer reaches retail code, it
+    // reaches the replacement, and a comparison against it says nothing about
+    // equivalence with the original.
+    // LIMITATION: this inspects the entry of the function under test, not its callees. A
+    // retail function whose own prologue is clean can still call inward to something the
+    // delta layer replaced -- rdMatrix_PreRotate34 reaches rdMatrix_PreMultiply34 that
+    // way -- and those cases compare a hybrid rather than pure retail. Catching them
+    // properly needs the call graph, so for now such a case is only as trustworthy as the
+    // delta it routes through.
+    bool retail_entry_redirected(const uint8_t *entry) {
+        if (entry[0] == 0xe9 || entry[0] == 0xeb)// jmp rel32 / rel8
+            return true;
+        if (entry[0] == 0xff && entry[1] == 0x25)// jmp dword ptr [mem]
+            return true;
+        return false;
+    }
+
+    // A case is only meaningful when both bodies are reachable and are the ones we mean.
+    // Two ways that fails: our symbol is detoured to retail (any mode but `both`), which
+    // would compare retail against itself; or retail's entry is detoured to a delta.
+    // Both produce a pass that proves nothing, so refuse them and say why.
+    bool testable(const char *name, uint32_t retail_addr) {
+        if (hook_mode_for(name) != HOOK_MODE_BOTH) {
+            cases_skipped++;
+            std::fprintf(verify_log, "  %-36s SKIP   not in `both` mode (add `both %s` to %s)\n",
+                         name, name, HOOK_MODE_CONFIG_FILE);
+            std::fflush(verify_log);
+            return false;
+        }
+        if (retail_entry_redirected(hook_retail_ptr(retail_addr))) {
+            cases_skipped++;
+            std::fprintf(verify_log,
+                         "  %-36s SKIP   retail entry is hooked by the delta layer, so there is no "
+                         "original body left to compare against\n",
+                         name);
+            std::fflush(verify_log);
+            return false;
+        }
+        return true;
+    }
+
+    using F_f = float (*)(float);
+    using F_ff = float (*)(float, float);
+    using I_f = int (*)(float);
+    using F_fi = float (*)(float, int);
+    using V_fpp = void (*)(float, float *, float *);
+    using V_pffff = void (*)(float *, float, float, float, float);
+    using V_pffii = void (*)(int *, float, float, int, int);
+
+    // rdVector3 shapes. `out` is always the first parameter and the inputs are const, so
+    // these can be driven the same way as the scalar cases: fill the inputs, poison the
+    // output, call each side, compare all three components plus any return value.
+    using F_v = float (*)(const rdVector3 *);
+    using F_vv = float (*)(const rdVector3 *, const rdVector3 *);
+    using F_vacc = float (*)(rdVector3 *);
+    using V_vvv = void (*)(rdVector3 *, const rdVector3 *, const rdVector3 *);
+    using V_vfv = void (*)(rdVector3 *, float, const rdVector3 *);
+    using V_vvfv = void (*)(rdVector3 *, const rdVector3 *, float, const rdVector3 *);
+
+    rdVector3 random_vec3(int i, float lo, float hi) {
+        rdVector3 v;
+        v.x = sample(i, lo, hi);
+        v.y = sample(i + 3, lo, hi);
+        v.z = sample(i + 11, lo, hi);
+        return v;
+    }
+
+    // rdVector3/4 and rdMatrix34/44 are all just runs of floats, so every structured
+    // output can be compared the same way: element by element, with the index reported
+    // so a failure names the component that diverged.
+    void record_floats(Stats &s, const float *ours, const float *retail, int count, int tolerance,
+                       const char *input_desc) {
+        for (int k = 0; k < count; k++) {
+            char desc[240];
+            std::snprintf(desc, sizeof(desc), "%s[%d]", input_desc, k);
+            record(s, ours[k], retail[k], tolerance, desc);
+        }
+    }
+
+    void record_vec3(Stats &s, const rdVector3 &ours, const rdVector3 &retail, int tolerance,
+                     const char *input_desc) {
+        record_floats(s, &ours.x, &retail.x, 3, tolerance, input_desc);
+    }
+
+    void describe_vec3(char *out, size_t n, const rdVector3 &a) {
+        std::snprintf(out, n, "(%.9g, %.9g, %.9g)", a.x, a.y, a.z);
+    }
+
+    void run_f_v(const char *name, uint32_t retail_addr, F_v ours, float lo, float hi,
+                 int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_v retail = (F_v) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector3 a = random_vec3(i, lo, hi);
+            char desc[96];
+            describe_vec3(desc, sizeof(desc), a);
+            record(s, ours(&a), retail(&a), tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_f_vv(const char *name, uint32_t retail_addr, F_vv ours, float lo, float hi,
+                  int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_vv retail = (F_vv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector3 a = random_vec3(i, lo, hi);
+            const rdVector3 b = random_vec3(i + 23, lo, hi);
+            char desc[200];
+            char sa[96], sb[96];
+            describe_vec3(sa, sizeof(sa), a);
+            describe_vec3(sb, sizeof(sb), b);
+            std::snprintf(desc, sizeof(desc), "%s, %s", sa, sb);
+            record(s, ours(&a, &b), retail(&a, &b), tolerance, desc);
+        }
+        report(s);
+    }
+
+    // Normalize-in-place: the return value AND the mutated vector both matter.
+    void run_f_vacc(const char *name, uint32_t retail_addr, F_vacc ours, float lo, float hi,
+                    int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_vacc retail = (F_vacc) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector3 seed = random_vec3(i, lo, hi);
+            rdVector3 our_v = seed;
+            rdVector3 ret_v = seed;
+            const float our_r = ours(&our_v);
+            const float ret_r = retail(&ret_v);
+
+            char desc[112];
+            describe_vec3(desc, sizeof(desc), seed);
+            std::strncat(desc, "[ret]", sizeof(desc) - std::strlen(desc) - 1);
+            record(s, our_r, ret_r, tolerance, desc);
+
+            describe_vec3(desc, sizeof(desc), seed);
+            record_vec3(s, our_v, ret_v, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_vvv(const char *name, uint32_t retail_addr, V_vvv ours, float lo, float hi,
+                   int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_vvv retail = (V_vvv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector3 a = random_vec3(i, lo, hi);
+            const rdVector3 b = random_vec3(i + 23, lo, hi);
+            rdVector3 our_out = {-12345.0f, -12345.0f, -12345.0f};
+            rdVector3 ret_out = our_out;
+            ours(&our_out, &a, &b);
+            retail(&ret_out, &a, &b);
+
+            char desc[200], sa[96], sb[96];
+            describe_vec3(sa, sizeof(sa), a);
+            describe_vec3(sb, sizeof(sb), b);
+            std::snprintf(desc, sizeof(desc), "%s, %s", sa, sb);
+            record_vec3(s, our_out, ret_out, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_vfv(const char *name, uint32_t retail_addr, V_vfv ours, float lo, float hi,
+                   int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_vfv retail = (V_vfv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float scale = sample(i, -100.0f, 100.0f);
+            const rdVector3 a = random_vec3(i + 23, lo, hi);
+            rdVector3 our_out = {-12345.0f, -12345.0f, -12345.0f};
+            rdVector3 ret_out = our_out;
+            ours(&our_out, scale, &a);
+            retail(&ret_out, scale, &a);
+
+            char desc[160], sa[96];
+            describe_vec3(sa, sizeof(sa), a);
+            std::snprintf(desc, sizeof(desc), "%.9g * %s", scale, sa);
+            record_vec3(s, our_out, ret_out, tolerance, desc);
+        }
+        report(s);
+    }
+
+    // ---- rdMath: normals, planes, quaternions ----
+    using V_v4vvv = void (*)(rdVector4 *, rdVector3 *, rdVector3 *, rdVector3 *);
+    using V_vvvv = void (*)(rdVector3 *, rdVector3 *, rdVector3 *, rdVector3 *);
+    using F_vvv = float (*)(rdVector3 *, rdVector3 *, rdVector3 *);
+    using I_vvv = int (*)(rdVector3 *, rdVector3 *, rdVector3 *);
+    using V_vf_acc = void (*)(rdVector3 *, float);
+    using V_slerp = void (*)(const rdVector4 *, const rdVector4 *, float, rdVector4 *);
+    using V_v4v4 = void (*)(rdVector4 *, const rdVector4 *);
+
+    rdVector4 random_vec4(int i, float lo, float hi) {
+        rdVector4 v;
+        v.x = sample(i, lo, hi);
+        v.y = sample(i + 3, lo, hi);
+        v.z = sample(i + 11, lo, hi);
+        v.w = sample(i + 17, lo, hi);
+        return v;
+    }
+
+    void describe3(char *out, size_t n, const rdVector3 &a, const rdVector3 &b,
+                   const rdVector3 &c) {
+        char sa[96], sb[96], sc[96];
+        describe_vec3(sa, sizeof(sa), a);
+        describe_vec3(sb, sizeof(sb), b);
+        describe_vec3(sc, sizeof(sc), c);
+        std::snprintf(out, n, "%s, %s, %s", sa, sb, sc);
+    }
+
+    void run_v4vvv(const char *name, uint32_t retail_addr, V_v4vvv ours, float lo, float hi,
+                   int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_v4vvv retail = (V_v4vvv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdVector3 a = random_vec3(i, lo, hi);
+            rdVector3 b = random_vec3(i + 23, lo, hi);
+            rdVector3 c = random_vec3(i + 41, lo, hi);
+            rdVector4 our_out = {-12345.0f, -12345.0f, -12345.0f, -12345.0f};
+            rdVector4 ret_out = our_out;
+            ours(&our_out, &a, &b, &c);
+            retail(&ret_out, &a, &b, &c);
+
+            char desc[304];
+            describe3(desc, sizeof(desc), a, b, c);
+            record_floats(s, &our_out.x, &ret_out.x, 4, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_vvvv(const char *name, uint32_t retail_addr, V_vvvv ours, float lo, float hi,
+                  int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_vvvv retail = (V_vvvv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdVector3 a = random_vec3(i, lo, hi);
+            rdVector3 b = random_vec3(i + 23, lo, hi);
+            rdVector3 c = random_vec3(i + 41, lo, hi);
+            rdVector3 our_out = {-12345.0f, -12345.0f, -12345.0f};
+            rdVector3 ret_out = our_out;
+            ours(&our_out, &a, &b, &c);
+            retail(&ret_out, &a, &b, &c);
+
+            char desc[304];
+            describe3(desc, sizeof(desc), a, b, c);
+            record_vec3(s, our_out, ret_out, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_f_vvv(const char *name, uint32_t retail_addr, F_vvv ours, float lo, float hi,
+                   int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_vvv retail = (F_vvv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdVector3 a = random_vec3(i, lo, hi);
+            rdVector3 b = random_vec3(i + 23, lo, hi);
+            rdVector3 c = random_vec3(i + 41, lo, hi);
+            char desc[304];
+            describe3(desc, sizeof(desc), a, b, c);
+            record(s, ours(&a, &b, &c), retail(&a, &b, &c), tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_i_vvv(const char *name, uint32_t retail_addr, I_vvv ours, float lo, float hi) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const I_vvv retail = (I_vvv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdVector3 a = random_vec3(i, lo, hi);
+            rdVector3 b = random_vec3(i + 23, lo, hi);
+            // Every third case feeds a genuinely collinear triple, otherwise the
+            // "is collinear" branch would essentially never be exercised.
+            rdVector3 c = (i % 3 == 0)
+                              ? rdVector3{a.x + (b.x - a.x) * 2.0f, a.y + (b.y - a.y) * 2.0f,
+                                          a.z + (b.z - a.z) * 2.0f}
+                              : random_vec3(i + 41, lo, hi);
+            char desc[304];
+            describe3(desc, sizeof(desc), a, b, c);
+            record_int(s, ours(&a, &b, &c), retail(&a, &b, &c), desc);
+        }
+        report(s);
+    }
+
+    void run_v_vf_acc(const char *name, uint32_t retail_addr, V_vf_acc ours, float lo, float hi,
+                      int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_vf_acc retail = (V_vf_acc) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector3 seed = random_vec3(i, lo, hi);
+            const float limit = sample(i + 7, -10.0f, 10.0f);
+            rdVector3 our_v = seed;
+            rdVector3 ret_v = seed;
+            ours(&our_v, limit);
+            retail(&ret_v, limit);
+
+            char desc[160], sa[96];
+            describe_vec3(sa, sizeof(sa), seed);
+            std::snprintf(desc, sizeof(desc), "%s, %.9g", sa, limit);
+            record_vec3(s, our_v, ret_v, tolerance, desc);
+        }
+        report(s);
+    }
+
+    // Slerp is the one here whose out-param comes last.
+    void run_slerp(const char *name, uint32_t retail_addr, V_slerp ours, int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_slerp retail = (V_slerp) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            // Unit quaternions, since that is the only input the callers produce and the
+            // shortest-arc logic is only meaningful for them.
+            rdVector4 a = random_vec4(i, -1.0f, 1.0f);
+            rdVector4 b = random_vec4(i + 29, -1.0f, 1.0f);
+            const float la = std::sqrt(a.x * a.x + a.y * a.y + a.z * a.z + a.w * a.w);
+            const float lb = std::sqrt(b.x * b.x + b.y * b.y + b.z * b.z + b.w * b.w);
+            if (la > 1e-6f) {
+                a.x /= la;
+                a.y /= la;
+                a.z /= la;
+                a.w /= la;
+            }
+            if (lb > 1e-6f) {
+                b.x /= lb;
+                b.y /= lb;
+                b.z /= lb;
+                b.w /= lb;
+            }
+            const float t = sample(i + 13, 0.0f, 1.0f);
+
+            rdVector4 our_out = {-12345.0f, -12345.0f, -12345.0f, -12345.0f};
+            rdVector4 ret_out = our_out;
+            ours(&a, &b, t, &our_out);
+            retail(&a, &b, t, &ret_out);
+
+            char desc[256];
+            std::snprintf(desc, sizeof(desc),
+                          "(%.9g,%.9g,%.9g,%.9g) -> (%.9g,%.9g,%.9g,%.9g) @ t=%.9g", a.x, a.y, a.z,
+                          a.w, b.x, b.y, b.z, b.w, t);
+            record_floats(s, &our_out.x, &ret_out.x, 4, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v4v4(const char *name, uint32_t retail_addr, V_v4v4 ours, float lo, float hi,
+                  int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_v4v4 retail = (V_v4v4) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector4 a = random_vec4(i, lo, hi);
+            rdVector4 our_out = {-12345.0f, -12345.0f, -12345.0f, -12345.0f};
+            rdVector4 ret_out = our_out;
+            ours(&our_out, &a);
+            retail(&ret_out, &a);
+
+            char desc[160];
+            std::snprintf(desc, sizeof(desc), "(%.9g, %.9g, %.9g, %.9g)", a.x, a.y, a.z, a.w);
+            record_floats(s, &our_out.x, &ret_out.x, 4, tolerance, desc);
+        }
+        report(s);
+    }
+
+    // ---- stdHashtbl: integer helpers ----
+    using U_si = unsigned int (*)(char *, int);
+    using I_i = int (*)(int);
+
+    void run_u_si(const char *name, uint32_t retail_addr, U_si ours) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const U_si retail = (U_si) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            char buf[24];
+            const int len = (int) (next_u32() % (sizeof(buf) - 1));
+            for (int k = 0; k < len; k++)
+                buf[k] = (char) (0x20 + (next_u32() % 0x5f));// printable ASCII
+            buf[len] = '\0';
+            // hashSize divides, so it must never be zero.
+            const int hash_size = (int) (next_u32() % 1024u) + 1;
+
+            char desc[96];
+            std::snprintf(desc, sizeof(desc), "\"%s\", %d", buf, hash_size);
+            record_int(s, (int) ours(buf, hash_size), (int) retail(buf, hash_size), desc);
+        }
+        report(s);
+    }
+
+    void run_i_i(const char *name, uint32_t retail_addr, I_i ours, int lo, int hi) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const I_i retail = (I_i) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const int x = lo + (int) (next_u32() % (unsigned) (hi - lo + 1));
+            char desc[48];
+            std::snprintf(desc, sizeof(desc), "f(%d)", x);
+            record_int(s, ours(x), retail(x), desc);
+        }
+        report(s);
+    }
+
+    // ---- rdMatrix ----
+    using V_m44 = void (*)(rdMatrix44 *);
+    using V_m44fff = void (*)(rdMatrix44 *, float, float, float);
+    using V_m44ffff = void (*)(rdMatrix44 *, float, float, float, float);
+    using V_m44m44 = void (*)(rdMatrix44 *, rdMatrix44 *);
+    using V_m44m34 = void (*)(rdMatrix44 *, const rdMatrix34 *);
+    using V_m34v = void (*)(rdMatrix34 *, rdVector3 *);
+    using V_m44iv = void (*)(rdMatrix44 *, int, rdVector3 *);
+
+    rdMatrix44 random_mat44(int i, float lo, float hi) {
+        rdMatrix44 m;
+        float *f = &m.vA.x;
+        for (int k = 0; k < 16; k++)
+            f[k] = sample(i + k * 7, lo, hi);
+        return m;
+    }
+
+    rdMatrix34 random_mat34(int i, float lo, float hi) {
+        rdMatrix34 m;
+        float *f = &m.rvec.x;
+        for (int k = 0; k < 12; k++)
+            f[k] = sample(i + k * 7, lo, hi);
+        return m;
+    }
+
+    void run_v_m44(const char *name, uint32_t retail_addr, V_m44 ours, int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m44 retail = (V_m44) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdMatrix44 our_m = random_mat44(i, -100.0f, 100.0f);
+            rdMatrix44 ret_m = our_m;
+            ours(&our_m);
+            retail(&ret_m);
+            char desc[32];
+            std::snprintf(desc, sizeof(desc), "case %d", i);
+            record_floats(s, &our_m.vA.x, &ret_m.vA.x, 16, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_m44fff(const char *name, uint32_t retail_addr, V_m44fff ours, float lo, float hi,
+                      int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m44fff retail = (V_m44fff) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float a = sample(i, lo, hi);
+            const float b = sample(i + 5, lo, hi);
+            const float c = sample(i + 9, lo, hi);
+            rdMatrix44 our_m = random_mat44(i, -100.0f, 100.0f);
+            rdMatrix44 ret_m = our_m;
+            ours(&our_m, a, b, c);
+            retail(&ret_m, a, b, c);
+            char desc[112];
+            std::snprintf(desc, sizeof(desc), "(%.9g, %.9g, %.9g)", a, b, c);
+            record_floats(s, &our_m.vA.x, &ret_m.vA.x, 16, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_m44ffff(const char *name, uint32_t retail_addr, V_m44ffff ours, float lo, float hi,
+                       int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m44ffff retail = (V_m44ffff) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float angle = sample(i, -720.0f, 720.0f);
+            const float x = sample(i + 5, lo, hi);
+            const float y = sample(i + 9, lo, hi);
+            const float z = sample(i + 13, lo, hi);
+            rdMatrix44 our_m = random_mat44(i, -100.0f, 100.0f);
+            rdMatrix44 ret_m = our_m;
+            ours(&our_m, angle, x, y, z);
+            retail(&ret_m, angle, x, y, z);
+            char desc[144];
+            std::snprintf(desc, sizeof(desc), "angle=%.9g axis=(%.9g, %.9g, %.9g)", angle, x, y, z);
+            record_floats(s, &our_m.vA.x, &ret_m.vA.x, 16, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_m44m44(const char *name, uint32_t retail_addr, V_m44m44 ours, int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m44m44 retail = (V_m44m44) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdMatrix44 in = random_mat44(i, -100.0f, 100.0f);
+            rdMatrix44 our_out = random_mat44(i + 3, -1.0f, 1.0f);
+            rdMatrix44 ret_out = our_out;
+            ours(&our_out, &in);
+            retail(&ret_out, &in);
+            char desc[32];
+            std::snprintf(desc, sizeof(desc), "case %d", i);
+            record_floats(s, &our_out.vA.x, &ret_out.vA.x, 16, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_m44m34(const char *name, uint32_t retail_addr, V_m44m34 ours, int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m44m34 retail = (V_m44m34) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdMatrix34 in = random_mat34(i, -100.0f, 100.0f);
+            rdMatrix44 our_out = random_mat44(i + 3, -1.0f, 1.0f);
+            rdMatrix44 ret_out = our_out;
+            ours(&our_out, &in);
+            retail(&ret_out, &in);
+            char desc[32];
+            std::snprintf(desc, sizeof(desc), "case %d", i);
+            record_floats(s, &our_out.vA.x, &ret_out.vA.x, 16, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_m34v(const char *name, uint32_t retail_addr, V_m34v ours, float lo, float hi,
+                    int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m34v retail = (V_m34v) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdVector3 v = random_vec3(i, lo, hi);
+            rdMatrix34 our_m = random_mat34(i + 3, -100.0f, 100.0f);
+            rdMatrix34 ret_m = our_m;
+            ours(&our_m, &v);
+            retail(&ret_m, &v);
+            char desc[112];
+            describe_vec3(desc, sizeof(desc), v);
+            record_floats(s, &our_m.rvec.x, &ret_m.rvec.x, 12, tolerance, desc);
+        }
+        report(s);
+    }
+
+    // Gram-Schmidt the basis into a real rotation. A random rdMatrix34 is not orthonormal,
+    // and the angle-extraction path returns NaN for one that is not -- so without this the
+    // case would only ever compare garbage.
+    void orthonormalize34(rdMatrix34 &m) {
+        rdVector_Normalize3Acc(&m.rvec);
+        const float d = rdVector_Dot3(&m.lvec, &m.rvec);
+        m.lvec.x -= m.rvec.x * d;
+        m.lvec.y -= m.rvec.y * d;
+        m.lvec.z -= m.rvec.z * d;
+        if (rdVector_Len3(&m.lvec) < 1e-4f)
+            m.lvec = rdVector3{m.rvec.y, -m.rvec.x, m.rvec.z};
+        rdVector_Normalize3Acc(&m.lvec);
+        rdVector_Cross3(&m.uvec, &m.rvec, &m.lvec);
+        rdVector_Normalize3Acc(&m.uvec);
+    }
+
+    // rdMatrix_ExtractAngles34 shares the (rdMatrix34*, rdVector3*) shape with the
+    // builders but runs the other way: the matrix is input and the vector is the result.
+    // Comparing the matrix here would pass unconditionally without testing anything.
+    void run_v_m34_outv(const char *name, uint32_t retail_addr, V_m34v ours, float lo, float hi,
+                        int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m34v retail = (V_m34v) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            rdMatrix34 in = random_mat34(i, lo, hi);
+            orthonormalize34(in);
+            rdVector3 our_out = {-12345.0f, -12345.0f, -12345.0f};
+            rdVector3 ret_out = our_out;
+            rdMatrix34 our_in = in;
+            rdMatrix34 ret_in = in;
+            ours(&our_in, &our_out);
+            retail(&ret_in, &ret_out);
+
+            char desc[48];
+            std::snprintf(desc, sizeof(desc), "case %d", i);
+            record_vec3(s, our_out, ret_out, tolerance, desc);
+        }
+        report(s);
+    }
+
+    // Column accessors take an index; only 0..3 are in range for a 4x4.
+    void run_v_m44iv(const char *name, uint32_t retail_addr, V_m44iv ours, bool writes_matrix,
+                     int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_m44iv retail = (V_m44iv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const int n = (int) (next_u32() % 4u);
+            rdVector3 v = random_vec3(i, -100.0f, 100.0f);
+            rdMatrix44 our_m = random_mat44(i + 3, -100.0f, 100.0f);
+            rdMatrix44 ret_m = our_m;
+            rdVector3 our_v = v;
+            rdVector3 ret_v = v;
+            ours(&our_m, n, &our_v);
+            retail(&ret_m, n, &ret_v);
+
+            char desc[128], sv[96];
+            describe_vec3(sv, sizeof(sv), v);
+            std::snprintf(desc, sizeof(desc), "col %d, %s", n, sv);
+            if (writes_matrix)
+                record_floats(s, &our_m.vA.x, &ret_m.vA.x, 16, tolerance, desc);
+            else
+                record_vec3(s, our_v, ret_v, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_vvfv(const char *name, uint32_t retail_addr, V_vvfv ours, float lo, float hi,
+                    int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_vvfv retail = (V_vvfv) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const rdVector3 a = random_vec3(i, lo, hi);
+            const float scale = sample(i + 5, -100.0f, 100.0f);
+            const rdVector3 b = random_vec3(i + 23, lo, hi);
+            rdVector3 our_out = {-12345.0f, -12345.0f, -12345.0f};
+            rdVector3 ret_out = our_out;
+            ours(&our_out, &a, scale, &b);
+            retail(&ret_out, &a, scale, &b);
+
+            char desc[224], sa[96], sb[96];
+            describe_vec3(sa, sizeof(sa), a);
+            describe_vec3(sb, sizeof(sb), b);
+            std::snprintf(desc, sizeof(desc), "%s + %.9g * %s", sa, scale, sb);
+            record_vec3(s, our_out, ret_out, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_f_f(const char *name, uint32_t retail_addr, F_f ours, float lo, float hi,
+                 int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_f retail = (F_f) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float x = sample(i, lo, hi);
+            char desc[64];
+            std::snprintf(desc, sizeof(desc), "f(%.9g)", x);
+            record(s, ours(x), retail(x), tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_f_ff(const char *name, uint32_t retail_addr, F_ff ours, float lo, float hi,
+                  int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_ff retail = (F_ff) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float a = sample(i, lo, hi);
+            const float b = sample(i + 7, lo, hi);
+            char desc[96];
+            std::snprintf(desc, sizeof(desc), "f(%.9g, %.9g)", a, b);
+            record(s, ours(a, b), retail(a, b), tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_i_f(const char *name, uint32_t retail_addr, I_f ours, float lo, float hi) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const I_f retail = (I_f) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float x = sample(i, lo, hi);
+            char desc[64];
+            std::snprintf(desc, sizeof(desc), "f(%.9g)", x);
+            record_int(s, ours(x), retail(x), desc);
+        }
+        report(s);
+    }
+
+    void run_f_fi(const char *name, uint32_t retail_addr, F_fi ours, float lo, float hi,
+                  int max_exp, int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const F_fi retail = (F_fi) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float x = sample(i, lo, hi);
+            const int e = (int) (next_u32() % (uint32_t) (max_exp + 1));
+            char desc[80];
+            std::snprintf(desc, sizeof(desc), "f(%.9g, %d)", x, e);
+            record(s, ours(x, e), retail(x, e), tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_fpp(const char *name, uint32_t retail_addr, V_fpp ours, float lo, float hi,
+                   int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_fpp retail = (V_fpp) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float x = sample(i, lo, hi);
+            // Poison the out-params so a function that fails to write one is caught.
+            float our_a = -12345.0f, our_b = -12345.0f;
+            float ret_a = -12345.0f, ret_b = -12345.0f;
+            ours(x, &our_a, &our_b);
+            retail(x, &ret_a, &ret_b);
+
+            char desc[80];
+            std::snprintf(desc, sizeof(desc), "f(%.9g)[out0]", x);
+            record(s, our_a, ret_a, tolerance, desc);
+            std::snprintf(desc, sizeof(desc), "f(%.9g)[out1]", x);
+            record(s, our_b, ret_b, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_pffff(const char *name, uint32_t retail_addr, V_pffff ours, float lo, float hi,
+                     int tolerance) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_pffff retail = (V_pffff) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const float seed = sample(i, lo, hi);
+            const float value = next_float(lo, hi);
+            const float multiplier = next_float(-4.0f, 4.0f);
+            float min = next_float(lo, hi);
+            float max = next_float(lo, hi);
+            if (max < min) {
+                const float t = min;
+                min = max;
+                max = t;
+            }
+
+            float our_io = seed;
+            float ret_io = seed;
+            ours(&our_io, value, multiplier, min, max);
+            retail(&ret_io, value, multiplier, min, max);
+
+            char desc[176];
+            std::snprintf(desc, sizeof(desc), "f(inout=%.9g, %.9g, %.9g, [%.9g, %.9g])", seed,
+                          value, multiplier, min, max);
+            record(s, our_io, ret_io, tolerance, desc);
+        }
+        report(s);
+    }
+
+    void run_v_pffii(const char *name, uint32_t retail_addr, V_pffii ours) {
+        if (!testable(name, retail_addr))
+            return;
+
+        const V_pffii retail = (V_pffii) hook_retail_ptr(retail_addr);
+        Stats s;
+        stats_init(s, name);
+
+        for (int i = 0; i < VERIFY_ITERATIONS; i++) {
+            const int seed = (int) (next_u32() % 4000u) - 2000;
+            // Fractional values matter here: the product is accumulated at x87 register
+            // precision and only the final sum is truncated, so a scaled add that lands
+            // just either side of an integer is exactly where the two can disagree.
+            const float value = next_float(-2000.0f, 2000.0f);
+            const float multiplier = next_float(-4.0f, 4.0f);
+            int min = (int) (next_u32() % 2000u) - 1000;
+            int max = (int) (next_u32() % 2000u) - 1000;
+            if (max < min) {
+                const int t = min;
+                min = max;
+                max = t;
+            }
+
+            int our_io = seed;
+            int ret_io = seed;
+            ours(&our_io, value, multiplier, min, max);
+            retail(&ret_io, value, multiplier, min, max);
+
+            char desc[160];
+            std::snprintf(desc, sizeof(desc), "f(inout=%d, %.9g, %.9g, [%d, %d])", seed, value,
+                          multiplier, min, max);
+            record_int(s, our_io, ret_io, desc);
+        }
+        report(s);
+    }
+
+    // The table-driven trig helpers interpolate a quarter wave baked into .data. If that
+    // table were empty both implementations would agree on zero and the case would pass
+    // without testing anything, so confirm it holds real data first.
+    bool trig_tables_populated() {
+        for (int i = 0; i < 4096; i++) {
+            if (stdMath_SinTable[i] != 0.0f)
+                return true;
+        }
+        return false;
+    }
+
+}// namespace
+
+extern "C" void reimpl_verify_run(FILE *hook_log) {
+    verify_log = std::fopen(REIMPL_VERIFY_LOG_FILE, "w");
+    if (verify_log == nullptr) {
+        std::fprintf(hook_log, "[reimpl_verify] could not open %s\n", REIMPL_VERIFY_LOG_FILE);
+        std::fflush(hook_log);
+        return;
+    }
+
+    std::fprintf(verify_log,
+                 "Differential verification of reimplemented functions against retail.\n"
+                 "%d cases per function, deterministic inputs (seed 0x%08x).\n"
+                 "A case passes only when every single result is bit-identical to retail.\n\n",
+                 VERIFY_ITERATIONS, 0x13579bdfu);
+
+    std::fprintf(verify_log, "stdMath\n");
+
+    // Thin wrappers over the CRT. Retail used the MSVC CRT and we use MinGW's, so a
+    // 1 ULP budget records that difference rather than pretending it is absent.
+    run_f_f("stdMath_Sqrt", stdMath_Sqrt_ADDR, stdMath_Sqrt, 0.0f, 1.0e6f, 0);
+    run_f_f("stdMath_Sqrt_2", stdMath_Sqrt_2_ADDR, stdMath_Sqrt_2, 0.0f, 1.0e6f, 0);
+    run_f_f("stdMath_fround", stdMath_fround_ADDR, stdMath_fround, -1.0e6f, 1.0e6f, 0);
+    run_i_f("stdMath_FRoundInt", stdMath_FRoundInt_ADDR, stdMath_FRoundInt, -1.0e6f, 1.0e6f);
+
+    // Pure arithmetic, no library calls: these must be bit-identical.
+    run_f_f("stdMath_NormalizeAngle", stdMath_NormalizeAngle_ADDR, stdMath_NormalizeAngle, -2000.0f,
+            2000.0f, 0);
+    run_f_f("stdMath_NormalizeAngleAcute", stdMath_NormalizeAngleAcute_ADDR,
+            stdMath_NormalizeAngleAcute, -2000.0f, 2000.0f, 0);
+    run_f_ff("stdMath_Decelerator", stdMath_Decelerator_ADDR, stdMath_Decelerator, -100.0f, 100.0f,
+             0);
+    run_f_fi("stdMath_FlexPower", stdMath_FlexPower_ADDR, stdMath_FlexPower, -10.0f, 10.0f, 8, 0);
+    run_v_pffff("stdMath_MultiplyAddClamped", stdMath_MultiplyAddClamped_ADDR,
+                stdMath_MultiplyAddClamped, -1000.0f, 1000.0f, 0);
+    run_v_pffii("stdMath_AddScaledValueAndClamp_i32", stdMath_AddScaledValueAndClamp_i32_ADDR,
+                stdMath_AddScaledValueAndClamp_i32);
+
+    // Polynomial approximations. Every coefficient came out of the decompile, so these
+    // are the reimplementations most worth pinning down exactly.
+    run_f_f("stdMath_ArcSin", stdMath_ArcSin_ADDR, stdMath_ArcSin, -1.2f, 1.2f, 0);
+    run_f_f("stdMath_ArcCos", stdMath_ArcCos_ADDR, stdMath_ArcCos, -1.2f, 1.2f, 0);
+    run_f_f("stdMath_ArcSin3", stdMath_ArcSin3_ADDR, stdMath_ArcSin3, -1.0f, 1.0f, 0);
+    run_f_ff("stdMath_ArcTan2", stdMath_ArcTan2_ADDR, stdMath_ArcTan2, -1000.0f, 1000.0f, 0);
+
+    // sin/cos through the CRT, so allow the same rounding budget as sqrt.
+    run_v_fpp("stdMath_SinCos", stdMath_SinCos_ADDR, stdMath_SinCos, -1000.0f, 1000.0f, 0);
+    run_f_f("stdMath_Tan", stdMath_Tan_ADDR, stdMath_Tan, -1000.0f, 1000.0f, 0);
+
+    if (trig_tables_populated()) {
+        run_v_fpp("stdMath_SinCosFast", stdMath_SinCosFast_ADDR, stdMath_SinCosFast, -2000.0f,
+                  2000.0f, 0);
+        run_f_f("stdMath_FastTan", stdMath_FastTan_ADDR, stdMath_FastTan, -2000.0f, 2000.0f, 0);
+    } else {
+        cases_skipped += 2;
+        std::fprintf(verify_log, "  %-36s SKIP   stdMath_SinTable is empty this early in startup\n",
+                     "stdMath_SinCosFast/FastTan");
+    }
+
+    // rdVector3 is the pod flight model's arithmetic, so a silent divergence here would
+    // move the physics. All of these are plain float expressions with no library calls,
+    // so bit-identical is the only acceptable result -- except where they route through
+    // stdMath_Sqrt and inherit its CRT rounding.
+    std::fprintf(verify_log, "\nrdVector\n");
+    run_v_vvv("rdVector_Add3", rdVector_Add3_ADDR, (V_vvv) rdVector_Add3, -1000.0f, 1000.0f, 0);
+    run_v_vvv("rdVector_Sub3", rdVector_Sub3_ADDR, (V_vvv) rdVector_Sub3, -1000.0f, 1000.0f, 0);
+    run_v_vvv("rdVector_Cross3", rdVector_Cross3_ADDR, rdVector_Cross3, -1000.0f, 1000.0f, 0);
+    run_v_vfv("rdVector_Scale3", rdVector_Scale3_ADDR, (V_vfv) rdVector_Scale3, -1000.0f, 1000.0f,
+              0);
+    run_v_vvfv("rdVector_Scale3Add3", rdVector_Scale3Add3_ADDR, rdVector_Scale3Add3, -1000.0f,
+               1000.0f, 0);
+    run_f_vv("rdVector_Dot3", rdVector_Dot3_ADDR, rdVector_Dot3, -1000.0f, 1000.0f, 0);
+    // 1 ULP budget, deliberately: retail narrows dx and dy to 32-bit mid-computation but
+    // not dz (see rdVector_DistSquared3). That is the x87-intermediate question, not a
+    // defect in the expression, so it is recorded rather than hidden.
+    run_f_vv("rdVector_DistSquared3", rdVector_DistSquared3_ADDR, rdVector_DistSquared3, -1000.0f,
+             1000.0f, 0);
+    run_f_v("rdVector_Len3", rdVector_Len3_ADDR, rdVector_Len3, -1000.0f, 1000.0f, 0);
+    run_f_vv("rdVector_Dist3", rdVector_Dist3_ADDR, rdVector_Dist3, -1000.0f, 1000.0f, 0);
+    run_f_vacc("rdVector_Normalize3Acc", rdVector_Normalize3Acc_ADDR, rdVector_Normalize3Acc,
+               -1000.0f, 1000.0f, 0);
+    run_f_vacc("rdVector_Normalize3Acc_2", rdVector_Normalize3Acc_2_ADDR, rdVector_Normalize3Acc_2,
+               -1000.0f, 1000.0f, 0);
+
+    // rdMath feeds collision and animation: surface normals decide face orientation and
+    // the quaternion helpers drive interpolated transforms.
+    std::fprintf(verify_log, "\nrdMath\n");
+    run_v4vvv("rdMath_CalcSurfaceNormal2", rdMath_CalcSurfaceNormal2_ADDR,
+              rdMath_CalcSurfaceNormal2, -100.0f, 100.0f, 0);
+    run_vvvv("rdMath_CalcSurfaceNormal", rdMath_CalcSurfaceNormal_ADDR, rdMath_CalcSurfaceNormal,
+             -100.0f, 100.0f, 0);
+    run_f_vvv("rdMath_DistancePointToPlane", rdMath_DistancePointToPlane_ADDR,
+              rdMath_DistancePointToPlane, -100.0f, 100.0f, 0);
+    run_i_vvv("rdMath_PointsCollinear", rdMath_PointsCollinear_ADDR, rdMath_PointsCollinear,
+              -100.0f, 100.0f);
+    run_v_vf_acc("rdMath_ClampVector", rdMath_ClampVector_ADDR, rdMath_ClampVector, -10.0f, 10.0f,
+                 0);
+    run_slerp("rdMath_SlerpQuaternions", rdMath_SlerpQuaternions_ADDR, rdMath_SlerpQuaternions, 0);
+    run_v4v4("rdMath_QuaternionToAxisAngle", rdMath_QuaternionToAxisAngle_ADDR,
+             rdMath_QuaternionToAxisAngle, -1.0f, 1.0f, 0);
+    run_v4v4("rdMath_AxisAngleToQuaternion", rdMath_AxisAngleToQuaternion_ADDR,
+             rdMath_AxisAngleToQuaternion, -1.0f, 1.0f, 0);
+
+    // Pure integer arithmetic, so these must match exactly. isPrime trial-divides up to
+    // its argument, so keep the range small enough that 20000 cases stay quick.
+    std::fprintf(verify_log, "\nstdHashtbl\n");
+    run_u_si("stdHashtbl_CalculateHash", stdHashtbl_CalculateHash_ADDR, stdHashtbl_CalculateHash);
+    run_i_i("stdHashtbl_isPrime", stdHashtbl_isPrime_ADDR, stdHashtbl_isPrime, -50, 400);
+    run_i_i("stdHashtbl_nextPrime", stdHashtbl_nextPrime_ADDR, stdHashtbl_nextPrime, -50, 400);
+
+    // rdMatrix is every transform in the game. The rotation builders route through
+    // stdMath_SinCos, hence the 1 ULP budget on those; the rest is plain assignment and
+    // arithmetic that has to match bit for bit.
+    std::fprintf(verify_log, "\nrdMatrix\n");
+    run_v_m44("rdMatrix_SetIdentity44", rdMatrix_SetIdentity44_ADDR, rdMatrix_SetIdentity44, 0);
+    run_v_m44fff("rdMatrix_SetDiagonal44", rdMatrix_SetDiagonal44_ADDR, rdMatrix_SetDiagonal44,
+                 -100.0f, 100.0f, 0);
+    run_v_m44fff("rdMatrix_SetTranslation44", rdMatrix_SetTranslation44_ADDR,
+                 rdMatrix_SetTranslation44, -100.0f, 100.0f, 0);
+    run_v_m44fff("rdMatrix_BuildRotation44", rdMatrix_BuildRotation44_ADDR,
+                 rdMatrix_BuildRotation44, -720.0f, 720.0f, 0);
+    run_v_m44fff("rdMatrix_SetRotation44", rdMatrix_SetRotation44_ADDR, rdMatrix_SetRotation44,
+                 -720.0f, 720.0f, 0);
+    run_v_m44ffff("rdMatrix_BuildFromVectorAngle44", rdMatrix_BuildFromVectorAngle44_ADDR,
+                  rdMatrix_BuildFromVectorAngle44, -1.0f, 1.0f, 0);
+    run_v_m44m44("rdMatrix_BuildViewMatrix", rdMatrix_BuildViewMatrix_ADDR,
+                 rdMatrix_BuildViewMatrix, 0);
+    run_v_m44m34("rdMatrix_Copy44_34", rdMatrix_Copy44_34_ADDR, rdMatrix_Copy44_34, 0);
+    run_v_m34v("rdMatrix_BuildRotate34", rdMatrix_BuildRotate34_ADDR, rdMatrix_BuildRotate34,
+               -720.0f, 720.0f, 0);
+    run_v_m34v("rdMatrix_PreRotate34", rdMatrix_PreRotate34_ADDR, rdMatrix_PreRotate34, -720.0f,
+               720.0f, 0);
+    run_v_m34v("rdMatrix_PostTranslate34", rdMatrix_PostTranslate34_ADDR, rdMatrix_PostTranslate34,
+               -100.0f, 100.0f, 0);
+    run_v_m34_outv("rdMatrix_ExtractAngles34", rdMatrix_ExtractAngles34_ADDR,
+                   rdMatrix_ExtractAngles34, -1.0f, 1.0f, 0);
+    run_v_m44iv("rdMatrix_SetColumn", rdMatrix_SetColumn_ADDR, rdMatrix_SetColumn, true, 0);
+    run_v_m44iv("rdMatrix_GetColumn", rdMatrix_GetColumn_ADDR, rdMatrix_GetColumn, false, 0);
+
+    std::fprintf(verify_log, "\n%d cases run, %d passed, %d failed, %d skipped\n", cases_run,
+                 cases_passed, cases_run - cases_passed, cases_skipped);
+    std::fclose(verify_log);
+    verify_log = nullptr;
+
+    std::fprintf(hook_log, "[reimpl_verify] %d cases run, %d passed, %d failed, %d skipped -> %s\n",
+                 cases_run, cases_passed, cases_run - cases_passed, cases_skipped,
+                 REIMPL_VERIFY_LOG_FILE);
+    std::fflush(hook_log);
+}
+
+extern "C" void reimpl_verify_tick(FILE *hook_log) {
+    static bool already_run = false;
+
+    if (already_run)
+        return;
+    already_run = true;
+
+    if (hook_verify_requested())
+        reimpl_verify_run(hook_log);
+}

--- a/dinput_hook/reimpl_verify.cpp
+++ b/dinput_hook/reimpl_verify.cpp
@@ -17,7 +17,6 @@ extern "C" {
 
 #define REIMPL_VERIFY_LOG_FILE "reimpl_verify.log"
 
-// Iterations per case: enough to walk a domain finely without stalling startup.
 #define VERIFY_ITERATIONS 20000
 
 namespace {
@@ -28,7 +27,7 @@ namespace {
     int cases_passed = 0;
     int cases_skipped = 0;
 
-    // Deterministic generator, so a reported failing input can always be reproduced.
+    // Deterministic, so a reported failing input can be reproduced.
     uint32_t rng_state = 0x13579bdfu;
 
     uint32_t next_u32() {
@@ -39,13 +38,12 @@ namespace {
     }
 
     float next_float(float lo, float hi) {
-        // 24 bits of mantissa is the whole of a float's precision.
         const float unit = (float) (next_u32() >> 8) / (float) (1u << 24);
         return lo + (hi - lo) * unit;
     }
 
-    // Values that historically break range-reduction and clamping: domain edges, the
-    // branch constants in stdMath's polynomial approximations, and the sign boundaries.
+    // Values that break range-reduction and clamping: domain edges, the branch constants in
+    // stdMath's polynomial approximations, and the sign boundaries.
     const float interesting[] = {
         0.0f,      -0.0f,      1.0f,       -1.0f,       0.5f,   -0.5f,   0.999999f, -0.999999f,
         1.000001f, -1.000001f, 0.7071068f, -0.7071068f, 0.001f, -0.001f, 0.0001f,   -0.0001f,
@@ -54,13 +52,9 @@ namespace {
     };
     const int interesting_count = (int) (sizeof(interesting) / sizeof(interesting[0]));
 
-    // Walk the interesting values first, then random samples across the domain.
-    //
-    // An interesting value outside [lo, hi] is skipped rather than forced through: a
-    // slerp does not take t = 270 and a rotation builder does not take 1e20 degrees, and
-    // feeding those in produces failures that say nothing about whether the
-    // reimplementation matches for inputs the game can actually generate. Widen the
-    // caller's range when out-of-domain behaviour is what you want to pin down.
+    // Interesting values first, then random samples. An interesting value outside [lo, hi] is
+    // SKIPPED, not forced through -- out-of-domain failures say nothing about the inputs the game
+    // can actually generate. Widen the caller's range to pin down out-of-domain behaviour.
     float sample(int i, float lo, float hi) {
         if (i < interesting_count) {
             const float v = interesting[i];
@@ -90,8 +84,7 @@ namespace {
         s.first_fail[0] = '\0';
     }
 
-    // Distance in representable floats. Same-sign IEEE-754 bit patterns are monotonic, so
-    // subtracting them counts the steps between two values.
+    // Same-sign IEEE-754 bit patterns are monotonic, so subtracting them counts ULPs.
     int ulp_diff(float a, float b) {
         if (a == b)
             return 0;
@@ -111,11 +104,9 @@ namespace {
         return abs_d > INT32_MAX ? INT32_MAX : (int) abs_d;
     }
 
-    // Record one float comparison. `tolerance` is a ULP budget, and every case currently
-    // passes 0 -- bit-identical to retail, across all 54 of them. Keep it that way. A
-    // budget is only defensible with evidence that the two genuinely cannot agree, and
-    // every divergence investigated so far turned out to be a real defect rather than an
-    // unavoidable rounding difference. Widening this to turn a red case green hides bugs.
+    // `tolerance` is a ULP budget. Every case currently passes at 0 (bit-identical to retail);
+    // widening one to turn a case green hides a defect -- every divergence investigated so far was
+    // a real bug, not unavoidable rounding.
     void record(Stats &s, float ours, float retail, int tolerance, const char *input_desc) {
         s.total++;
         const int ulp = ulp_diff(ours, retail);
@@ -169,17 +160,12 @@ namespace {
         std::fflush(verify_log);
     }
 
-    // Detours rewrites a target's prologue with a jump. If the delta layer has
-    // forward-hooked this function -- as renderer_hook.cpp does for the whole GL
-    // takeover surface -- then hook_retail_ptr() no longer reaches retail code, it
-    // reaches the replacement, and a comparison against it says nothing about
-    // equivalence with the original.
-    // LIMITATION: this inspects the entry of the function under test, not its callees. A
-    // retail function whose own prologue is clean can still call inward to something the
-    // delta layer replaced -- rdMatrix_PreRotate34 reaches rdMatrix_PreMultiply34 that
-    // way -- and those cases compare a hybrid rather than pure retail. Catching them
-    // properly needs the call graph, so for now such a case is only as trustworthy as the
-    // delta it routes through.
+    // Detours rewrites a target's prologue with a jump, so if the delta layer forward-hooked this
+    // function, hook_retail_ptr() reaches the replacement rather than retail code.
+    // LIMITATION: only the entry of the function under test is inspected, not its callees. A clean
+    // prologue can still call inward to something the delta replaced (rdMatrix_PreRotate34 reaches
+    // rdMatrix_PreMultiply34 that way), so such a case compares a hybrid. Catching that needs the
+    // call graph.
     bool retail_entry_redirected(const uint8_t *entry) {
         if (entry[0] == 0xe9 || entry[0] == 0xeb)// jmp rel32 / rel8
             return true;
@@ -188,10 +174,9 @@ namespace {
         return false;
     }
 
-    // A case is only meaningful when both bodies are reachable and are the ones we mean.
-    // Two ways that fails: our symbol is detoured to retail (any mode but `both`), which
-    // would compare retail against itself; or retail's entry is detoured to a delta.
-    // Both produce a pass that proves nothing, so refuse them and say why.
+    // Both bodies must be reachable and be the ones we mean: our symbol detoured to retail (any
+    // mode but `both`) compares retail against itself, and retail detoured to a delta compares the
+    // delta. Both would pass while proving nothing.
     bool testable(const char *name, uint32_t retail_addr) {
         if (hook_mode_for(name) != HOOK_MODE_BOTH) {
             cases_skipped++;
@@ -220,9 +205,8 @@ namespace {
     using V_pffff = void (*)(float *, float, float, float, float);
     using V_pffii = void (*)(int *, float, float, int, int);
 
-    // rdVector3 shapes. `out` is always the first parameter and the inputs are const, so
-    // these can be driven the same way as the scalar cases: fill the inputs, poison the
-    // output, call each side, compare all three components plus any return value.
+    // rdVector3 shapes: `out` is always the first parameter and the inputs are const, so these
+    // drive the same way as the scalar cases.
     using F_v = float (*)(const rdVector3 *);
     using F_vv = float (*)(const rdVector3 *, const rdVector3 *);
     using F_vacc = float (*)(rdVector3 *);
@@ -238,9 +222,8 @@ namespace {
         return v;
     }
 
-    // rdVector3/4 and rdMatrix34/44 are all just runs of floats, so every structured
-    // output can be compared the same way: element by element, with the index reported
-    // so a failure names the component that diverged.
+    // rdVector3/4 and rdMatrix34/44 are all runs of floats, so one element-by-element compare
+    // covers every structured output; the index is reported so a failure names the component.
     void record_floats(Stats &s, const float *ours, const float *retail, int count, int tolerance,
                        const char *input_desc) {
         for (int k = 0; k < count; k++) {
@@ -299,7 +282,7 @@ namespace {
         report(s);
     }
 
-    // Normalize-in-place: the return value AND the mutated vector both matter.
+    // In-place: the return value AND the mutated vector both matter.
     void run_f_vacc(const char *name, uint32_t retail_addr, F_vacc ours, float lo, float hi,
                     int tolerance) {
         if (!testable(name, retail_addr))
@@ -378,7 +361,6 @@ namespace {
         report(s);
     }
 
-    // ---- rdMath: normals, planes, quaternions ----
     using V_v4vvv = void (*)(rdVector4 *, rdVector3 *, rdVector3 *, rdVector3 *);
     using V_vvvv = void (*)(rdVector3 *, rdVector3 *, rdVector3 *, rdVector3 *);
     using F_vvv = float (*)(rdVector3 *, rdVector3 *, rdVector3 *);
@@ -486,8 +468,7 @@ namespace {
         for (int i = 0; i < VERIFY_ITERATIONS; i++) {
             rdVector3 a = random_vec3(i, lo, hi);
             rdVector3 b = random_vec3(i + 23, lo, hi);
-            // Every third case feeds a genuinely collinear triple, otherwise the
-            // "is collinear" branch would essentially never be exercised.
+            // Every third case is collinear, or that branch is essentially never exercised.
             rdVector3 c = (i % 3 == 0)
                               ? rdVector3{a.x + (b.x - a.x) * 2.0f, a.y + (b.y - a.y) * 2.0f,
                                           a.z + (b.z - a.z) * 2.0f}
@@ -524,7 +505,7 @@ namespace {
         report(s);
     }
 
-    // Slerp is the one here whose out-param comes last.
+    // Slerp's out-param comes last, unlike the rest.
     void run_slerp(const char *name, uint32_t retail_addr, V_slerp ours, int tolerance) {
         if (!testable(name, retail_addr))
             return;
@@ -534,8 +515,8 @@ namespace {
         stats_init(s, name);
 
         for (int i = 0; i < VERIFY_ITERATIONS; i++) {
-            // Unit quaternions, since that is the only input the callers produce and the
-            // shortest-arc logic is only meaningful for them.
+            // Unit quaternions: the only input the callers produce, and the only one for which
+            // the shortest-arc logic is meaningful.
             rdVector4 a = random_vec4(i, -1.0f, 1.0f);
             rdVector4 b = random_vec4(i + 29, -1.0f, 1.0f);
             const float la = std::sqrt(a.x * a.x + a.y * a.y + a.z * a.z + a.w * a.w);
@@ -591,7 +572,6 @@ namespace {
         report(s);
     }
 
-    // ---- stdHashtbl: integer helpers ----
     using U_si = unsigned int (*)(char *, int);
     using I_i = int (*)(int);
 
@@ -636,7 +616,6 @@ namespace {
         report(s);
     }
 
-    // ---- rdMatrix ----
     using V_m44 = void (*)(rdMatrix44 *);
     using V_m44fff = void (*)(rdMatrix44 *, float, float, float);
     using V_m44ffff = void (*)(rdMatrix44 *, float, float, float, float);
@@ -794,9 +773,8 @@ namespace {
         report(s);
     }
 
-    // Gram-Schmidt the basis into a real rotation. A random rdMatrix34 is not orthonormal,
-    // and the angle-extraction path returns NaN for one that is not -- so without this the
-    // case would only ever compare garbage.
+    // Gram-Schmidt into a real rotation: a random rdMatrix34 is not orthonormal, and the
+    // angle-extraction path returns NaN for one that is not.
     void orthonormalize34(rdMatrix34 &m) {
         rdVector_Normalize3Acc(&m.rvec);
         const float d = rdVector_Dot3(&m.lvec, &m.rvec);
@@ -810,9 +788,8 @@ namespace {
         rdVector_Normalize3Acc(&m.uvec);
     }
 
-    // rdMatrix_ExtractAngles34 shares the (rdMatrix34*, rdVector3*) shape with the
-    // builders but runs the other way: the matrix is input and the vector is the result.
-    // Comparing the matrix here would pass unconditionally without testing anything.
+    // rdMatrix_ExtractAngles34 shares the (rdMatrix34*, rdVector3*) shape with the builders but
+    // runs the other way, so the VECTOR is the result -- comparing the matrix would always pass.
     void run_v_m34_outv(const char *name, uint32_t retail_addr, V_m34v ours, float lo, float hi,
                         int tolerance) {
         if (!testable(name, retail_addr))
@@ -839,7 +816,7 @@ namespace {
         report(s);
     }
 
-    // Column accessors take an index; only 0..3 are in range for a 4x4.
+    // Only columns 0..3 are in range for a 4x4.
     void run_v_m44iv(const char *name, uint32_t retail_addr, V_m44iv ours, bool writes_matrix,
                      int tolerance) {
         if (!testable(name, retail_addr))
@@ -1040,9 +1017,8 @@ namespace {
 
         for (int i = 0; i < VERIFY_ITERATIONS; i++) {
             const int seed = (int) (next_u32() % 4000u) - 2000;
-            // Fractional values matter here: the product is accumulated at x87 register
-            // precision and only the final sum is truncated, so a scaled add that lands
-            // just either side of an integer is exactly where the two can disagree.
+            // The product accumulates at x87 register precision and only the final sum is
+            // truncated, so a scaled add landing either side of an integer is where they diverge.
             const float value = next_float(-2000.0f, 2000.0f);
             const float multiplier = next_float(-4.0f, 4.0f);
             int min = (int) (next_u32() % 2000u) - 1000;
@@ -1066,9 +1042,8 @@ namespace {
         report(s);
     }
 
-    // The table-driven trig helpers interpolate a quarter wave baked into .data. If that
-    // table were empty both implementations would agree on zero and the case would pass
-    // without testing anything, so confirm it holds real data first.
+    // The table-driven trig helpers interpolate a quarter wave baked into .data; an empty table
+    // would make both sides agree on zero and pass without testing anything.
     bool trig_tables_populated() {
         for (int i = 0; i < 4096; i++) {
             if (stdMath_SinTable[i] != 0.0f)
@@ -1095,8 +1070,7 @@ extern "C" void reimpl_verify_run(FILE *hook_log) {
 
     std::fprintf(verify_log, "stdMath\n");
 
-    // Thin wrappers over the CRT. Retail used the MSVC CRT and we use MinGW's, so a
-    // 1 ULP budget records that difference rather than pretending it is absent.
+    // Retail used the MSVC CRT and this build uses MinGW's, hence the 1 ULP budget.
     run_f_f("stdMath_Sqrt", stdMath_Sqrt_ADDR, stdMath_Sqrt, 0.0f, 1.0e6f, 0);
     run_f_f("stdMath_Sqrt_2", stdMath_Sqrt_2_ADDR, stdMath_Sqrt_2, 0.0f, 1.0e6f, 0);
     run_f_f("stdMath_fround", stdMath_fround_ADDR, stdMath_fround, -1.0e6f, 1.0e6f, 0);
@@ -1115,14 +1089,13 @@ extern "C" void reimpl_verify_run(FILE *hook_log) {
     run_v_pffii("stdMath_AddScaledValueAndClamp_i32", stdMath_AddScaledValueAndClamp_i32_ADDR,
                 stdMath_AddScaledValueAndClamp_i32);
 
-    // Polynomial approximations. Every coefficient came out of the decompile, so these
-    // are the reimplementations most worth pinning down exactly.
+    // Polynomial approximations; every coefficient came out of the decompile.
     run_f_f("stdMath_ArcSin", stdMath_ArcSin_ADDR, stdMath_ArcSin, -1.2f, 1.2f, 0);
     run_f_f("stdMath_ArcCos", stdMath_ArcCos_ADDR, stdMath_ArcCos, -1.2f, 1.2f, 0);
     run_f_f("stdMath_ArcSin3", stdMath_ArcSin3_ADDR, stdMath_ArcSin3, -1.0f, 1.0f, 0);
     run_f_ff("stdMath_ArcTan2", stdMath_ArcTan2_ADDR, stdMath_ArcTan2, -1000.0f, 1000.0f, 0);
 
-    // sin/cos through the CRT, so allow the same rounding budget as sqrt.
+    // sin/cos through the CRT: same rounding budget as sqrt.
     run_v_fpp("stdMath_SinCos", stdMath_SinCos_ADDR, stdMath_SinCos, -1000.0f, 1000.0f, 0);
     run_f_f("stdMath_Tan", stdMath_Tan_ADDR, stdMath_Tan, -1000.0f, 1000.0f, 0);
 
@@ -1136,10 +1109,8 @@ extern "C" void reimpl_verify_run(FILE *hook_log) {
                      "stdMath_SinCosFast/FastTan");
     }
 
-    // rdVector3 is the pod flight model's arithmetic, so a silent divergence here would
-    // move the physics. All of these are plain float expressions with no library calls,
-    // so bit-identical is the only acceptable result -- except where they route through
-    // stdMath_Sqrt and inherit its CRT rounding.
+    // rdVector3 is the pod flight model's arithmetic, so a divergence here moves the physics.
+    // Plain float expressions, so bit-identical -- except where they route through stdMath_Sqrt.
     std::fprintf(verify_log, "\nrdVector\n");
     run_v_vvv("rdVector_Add3", rdVector_Add3_ADDR, (V_vvv) rdVector_Add3, -1000.0f, 1000.0f, 0);
     run_v_vvv("rdVector_Sub3", rdVector_Sub3_ADDR, (V_vvv) rdVector_Sub3, -1000.0f, 1000.0f, 0);
@@ -1149,9 +1120,8 @@ extern "C" void reimpl_verify_run(FILE *hook_log) {
     run_v_vvfv("rdVector_Scale3Add3", rdVector_Scale3Add3_ADDR, rdVector_Scale3Add3, -1000.0f,
                1000.0f, 0);
     run_f_vv("rdVector_Dot3", rdVector_Dot3_ADDR, rdVector_Dot3, -1000.0f, 1000.0f, 0);
-    // 1 ULP budget, deliberately: retail narrows dx and dy to 32-bit mid-computation but
-    // not dz (see rdVector_DistSquared3). That is the x87-intermediate question, not a
-    // defect in the expression, so it is recorded rather than hidden.
+    // 1 ULP deliberately: retail narrows dx and dy to 32-bit mid-computation but not dz (see
+    // rdVector_DistSquared3). An x87-intermediate artifact, not a defect in the expression.
     run_f_vv("rdVector_DistSquared3", rdVector_DistSquared3_ADDR, rdVector_DistSquared3, -1000.0f,
              1000.0f, 0);
     run_f_v("rdVector_Len3", rdVector_Len3_ADDR, rdVector_Len3, -1000.0f, 1000.0f, 0);
@@ -1161,8 +1131,6 @@ extern "C" void reimpl_verify_run(FILE *hook_log) {
     run_f_vacc("rdVector_Normalize3Acc_2", rdVector_Normalize3Acc_2_ADDR, rdVector_Normalize3Acc_2,
                -1000.0f, 1000.0f, 0);
 
-    // rdMath feeds collision and animation: surface normals decide face orientation and
-    // the quaternion helpers drive interpolated transforms.
     std::fprintf(verify_log, "\nrdMath\n");
     run_v4vvv("rdMath_CalcSurfaceNormal2", rdMath_CalcSurfaceNormal2_ADDR,
               rdMath_CalcSurfaceNormal2, -100.0f, 100.0f, 0);
@@ -1180,16 +1148,15 @@ extern "C" void reimpl_verify_run(FILE *hook_log) {
     run_v4v4("rdMath_AxisAngleToQuaternion", rdMath_AxisAngleToQuaternion_ADDR,
              rdMath_AxisAngleToQuaternion, -1.0f, 1.0f, 0);
 
-    // Pure integer arithmetic, so these must match exactly. isPrime trial-divides up to
-    // its argument, so keep the range small enough that 20000 cases stay quick.
+    // Pure integer arithmetic -> exact. isPrime trial-divides up to its argument, so keep the
+    // range small enough that 20000 cases stay quick.
     std::fprintf(verify_log, "\nstdHashtbl\n");
     run_u_si("stdHashtbl_CalculateHash", stdHashtbl_CalculateHash_ADDR, stdHashtbl_CalculateHash);
     run_i_i("stdHashtbl_isPrime", stdHashtbl_isPrime_ADDR, stdHashtbl_isPrime, -50, 400);
     run_i_i("stdHashtbl_nextPrime", stdHashtbl_nextPrime_ADDR, stdHashtbl_nextPrime, -50, 400);
 
-    // rdMatrix is every transform in the game. The rotation builders route through
-    // stdMath_SinCos, hence the 1 ULP budget on those; the rest is plain assignment and
-    // arithmetic that has to match bit for bit.
+    // The rotation builders route through stdMath_SinCos, hence the 1 ULP budget on those; the
+    // rest is plain assignment and arithmetic.
     std::fprintf(verify_log, "\nrdMatrix\n");
     run_v_m44("rdMatrix_SetIdentity44", rdMatrix_SetIdentity44_ADDR, rdMatrix_SetIdentity44, 0);
     run_v_m44fff("rdMatrix_SetDiagonal44", rdMatrix_SetDiagonal44_ADDR, rdMatrix_SetDiagonal44,

--- a/dinput_hook/reimpl_verify.h
+++ b/dinput_hook/reimpl_verify.h
@@ -3,28 +3,21 @@
 
 #include <stdio.h>
 
-// Differential self-test for reimplemented functions.
+// Differential self-test for reimplemented functions: run our body and the retail body over the
+// same inputs and compare. Only possible under HOOK_MODE_BOTH, where neither is redirected -- any
+// other mode leaves one of the two unreachable, so those cases are skipped and reported as such.
 //
-// A reimplementation and its retail counterpart are two implementations of the same
-// contract, so the cheapest proof of equivalence is to run both over the same inputs
-// and compare. That is only possible for functions configured HOOK_MODE_BOTH, where
-// neither body has been redirected -- every other mode leaves exactly one of the two
-// reachable. Cases whose function is not in that mode are skipped and reported as
-// such, because comparing retail against itself would report a meaningless pass.
+// Enabled by a bare `verify` line in reimpl_config.txt. Results land in reimpl_verify.log next to
+// the game, with a one-line summary in hook.log.
 //
-// Enabled by a bare `verify` line in reimpl_config.txt. Results land in
-// reimpl_verify.log next to the game, with a one-line summary in hook.log.
-//
-// Timing matters. This cannot run from init_hooks(): several retail math helpers open
-// with `FLDCW [0x00ec8c8x]`, loading the x87 control word from globals the game fills
-// in during startup. Called that early they install a garbage control word and the
-// next floating-point instruction faults. So the run is driven from the first rendered
-// frame instead, by which point the CRT and the game's own init have both completed.
+// Cannot run from init_hooks(): several retail math helpers open with `FLDCW [0x00ec8c8x]`, loading
+// the x87 control word from globals the game fills in during startup, so called that early they
+// install garbage and the next FP instruction faults. Driven from the first rendered frame.
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Run every case now. Prefer reimpl_verify_tick() unless you know the game is up.
+// Prefer reimpl_verify_tick() unless you know the game is up.
 void reimpl_verify_run(FILE *hook_log);
 
 // Call once per frame. Runs the suite on the first call and does nothing afterwards.

--- a/dinput_hook/reimpl_verify.h
+++ b/dinput_hook/reimpl_verify.h
@@ -1,0 +1,37 @@
+#ifndef REIMPL_VERIFY_H
+#define REIMPL_VERIFY_H
+
+#include <stdio.h>
+
+// Differential self-test for reimplemented functions.
+//
+// A reimplementation and its retail counterpart are two implementations of the same
+// contract, so the cheapest proof of equivalence is to run both over the same inputs
+// and compare. That is only possible for functions configured HOOK_MODE_BOTH, where
+// neither body has been redirected -- every other mode leaves exactly one of the two
+// reachable. Cases whose function is not in that mode are skipped and reported as
+// such, because comparing retail against itself would report a meaningless pass.
+//
+// Enabled by a bare `verify` line in reimpl_config.txt. Results land in
+// reimpl_verify.log next to the game, with a one-line summary in hook.log.
+//
+// Timing matters. This cannot run from init_hooks(): several retail math helpers open
+// with `FLDCW [0x00ec8c8x]`, loading the x87 control word from globals the game fills
+// in during startup. Called that early they install a garbage control word and the
+// next floating-point instruction faults. So the run is driven from the first rendered
+// frame instead, by which point the CRT and the game's own init have both completed.
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Run every case now. Prefer reimpl_verify_tick() unless you know the game is up.
+void reimpl_verify_run(FILE *hook_log);
+
+// Call once per frame. Runs the suite on the first call and does nothing afterwards.
+void reimpl_verify_tick(FILE *hook_log);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif// REIMPL_VERIFY_H

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -5,6 +5,7 @@
 #include "hook_helper.h"
 #include "node_utils.h"
 #include "imgui_utils.h"
+#include "reimpl_verify.h"
 #include "renderer_utils.h"
 #include "replacements.h"
 #include "stb_image.h"
@@ -1321,6 +1322,10 @@ static void limit_framerate(int target_fps) {
 }
 
 extern "C" int stdDisplay_Update_Hook() {
+    // Earliest frame boundary where the game's own init has finished, which the
+    // differential harness needs -- see reimpl_verify.h. No-op unless configured.
+    reimpl_verify_tick(hook_log);
+
     if (swrDisplay_SkipNextFrameUpdate == 1) {
         swrDisplay_SkipNextFrameUpdate = 0;
         return 0;

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1322,8 +1322,7 @@ static void limit_framerate(int target_fps) {
 }
 
 extern "C" int stdDisplay_Update_Hook() {
-    // Earliest frame boundary where the game's own init has finished, which the
-    // differential harness needs -- see reimpl_verify.h. No-op unless configured.
+    // Earliest frame boundary where the game's own init has finished (see reimpl_verify.h).
     reimpl_verify_tick(hook_log);
 
     if (swrDisplay_SkipNextFrameUpdate == 1) {

--- a/scripts/GenerateHooks.py
+++ b/scripts/GenerateHooks.py
@@ -44,7 +44,7 @@ hooks_blacklist = [
     "rdMatrix_ScaleBasis44",
     "rdMatrix_Multiply34",
     "rdMatrix_PreMultiply34",
-    "rdMatrix_PostMultiply34"
+    "rdMatrix_PostMultiply34",
     "rdMatrix_TransformVector34",
     "rdMatrix_TransformPoint34",
     # std3D
@@ -140,8 +140,10 @@ function_match = re.compile(r"(\w+)(?=\()")
 comment_match = re.compile(r"^\s*(//|\/\*)")
 
 h_files = [h[4:] if h.startswith("src\\") else h for h in h_files ]
+# the template includes this one itself, so keep it out of the generated include block
+h_files = [h for h in h_files if os.path.basename(h) != "hook_mode.h"]
 
-ccode = {"hook_complete_msg": "", "functions": [], "headers": h_files}
+ccode = {"functions": [], "headers": h_files}
 hook_count = 0
 total_count = 0
 hook_address = ""
@@ -151,7 +153,10 @@ for source in c_files:
     with open(source, "r") as sourcefile:
         lines = sourcefile.readlines()
         for line in lines:
-            function = {"message": "", "hook_addr": "", "hook_dst": ""}
+            # Both annotations emit the same pair (our body, the retail address); only
+            # `HOOK` forces the redirect to point at our body. Which way an unforced
+            # entry is wired is a runtime decision -- see src/hook_mode.h.
+            function = {"reimpl_addr": "", "retail_addr": "", "force_reimpl": 0}
             if next_line_is_hooked:
                 next_line_is_hooked = False
                 # check if function is commented out
@@ -164,10 +169,10 @@ for source in c_files:
                     function_name = f.group(1)
                     if (function_name in hooks_blacklist):
                         continue
-                    function["message"] = "\"\t[Replace] " + function_name + " -> " + hook_address + "\\n\"";
                     function["name"] = function_name
-                    function["hook_addr"] = hook_address
-                    function["hook_dst"] = function_name
+                    function["reimpl_addr"] = function_name
+                    function["retail_addr"] = hook_address
+                    function["force_reimpl"] = 1
                     ccode["functions"].append(function)
                     hook_count += 1
                     total_count += 1
@@ -183,10 +188,10 @@ for source in c_files:
                     function_name = f.group(1)
                     if (function_name in hooks_blacklist):
                         continue
-                    function["message"] = "\"\t[Original] " + function_name + " <- " + hook_address + "\\n\"";
                     function["name"] = function_name
-                    function["hook_addr"] = function_name
-                    function["hook_dst"] = hook_address
+                    function["reimpl_addr"] = function_name
+                    function["retail_addr"] = hook_address
+                    function["force_reimpl"] = 0
                     ccode["functions"].append(function)
                     total_count += 1
                 continue
@@ -202,10 +207,12 @@ for source in c_files:
                 continue
 
 if (total_count > 0):
-    percent = float(hook_count)/float(total_count) * 100.0
-    ccode["hook_complete_msg"]  = "\"Hooked [" + str(hook_count) + "/" + str(total_count) + "] functions (" + str(round(percent,2)) + "%%)\\n\"" # double %% is to escape %
+    # The runtime counts are what actually matter now (hook_mode_log_summary writes
+    # them to hook.log); this is just the codegen-time tally for the build output.
+    print(f"{total_count} reimplementations, {hook_count} force-hooked, "
+          f"{total_count - hook_count} runtime-configurable")
 else:
-    ccode["hook_complete_msg"]  = "\"Total Hook Count is 0 ! Something is wrong in GenerateHooks.py\""
+    print("Total Hook Count is 0 ! Something is wrong in GenerateHooks.py")
 
 # write out using a jinja template
 template_file_c = "/src/templates/hook_generated.c.j2"

--- a/src/General/stdMath.c
+++ b/src/General/stdMath.c
@@ -24,8 +24,19 @@ void stdMath_MultiplyAddClamped(float* res_inout, float value, float multiplier,
 }
 
 // 0x00429d90
-void stdMath_AddScaledValueAndClamp_i32(int* res_inout, int value, float multiplier, int min, int max)
+void stdMath_AddScaledValueAndClamp_i32(int* res_inout, float value, float multiplier, int min, int max)
 {
+    // Retail is FLD multiplier / FMUL value / FILD *res_inout / FADDP / __ftol, so the
+    // whole accumulate happens on the x87 stack: the product is formed at register
+    // precision, the running total arrives exactly via FILD, and only the final result
+    // is truncated toward zero. Double intermediates reproduce that -- float ones would
+    // round the product down to 24 bits of mantissa before the add.
+    //
+    // `value` is a float, not an int: retail reads it with FMUL m32fp, and the sole
+    // caller (swrRace_DebugSetGameValue) hands its own float parameter straight through.
+    // The scaled add was missing here entirely, so this only ever clamped.
+    *res_inout = (int)((double)multiplier * (double)value + (double)*res_inout);
+
     if (*res_inout < min)
     {
         *res_inout = min;
@@ -61,22 +72,28 @@ float stdMath_ArcSin(float angle)
     float fVar3;
     float fVar4;
     float fVar5;
-    float local_4;
+    float original_angle;
 
-    if (0.999999 < angle)
+    // Every literal below is a float32 constant in .rdata (0x004ac660..0x004ac698) except
+    // the final 1/pi, which really is stored as a double at 0x004ac6a0. Ghidra prints
+    // float32 constants as shortened decimals that do not always round-trip, so these
+    // come from the stored bits: 0x004ac670 is 0.70710677f, not the 0.7071068 that was
+    // here, and 0x004ac68c is -0.16666667f, not -0.1666667. Dropping the `f` suffix makes
+    // each one a third, different value again.
+    if (0.999999f < angle)
     {
-        return 90.0;
+        return 90.0f;
     }
-    if (angle < -0.999999)
+    if (angle < -0.999999f)
     {
-        return -90.0;
+        return -90.0f;
     }
-    if ((0.7071068 <= angle) || (angle <= -0.7071068))
+    if ((0.70710677f <= angle) || (angle <= -0.70710677f))
     {
-        local_4 = angle;
+        original_angle = angle;
         bVar2 = true;
-        fVar1 = 1.0 - angle * angle;
-        if (0.0 <= angle)
+        fVar1 = 1.0f - angle * angle;
+        if (0.0f <= angle)
         {
             fVar3 = stdMath_Sqrt(fVar1);
         }
@@ -91,26 +108,32 @@ float stdMath_ArcSin(float angle)
     {
         bVar2 = false;
     }
-    if ((0.001 <= angle) || (angle <= -0.001))
+    if ((0.001f <= angle) || (angle <= -0.001f))
     {
         fVar1 = angle * angle;
         fVar3 = angle * angle * angle;
         fVar4 = fVar3 * fVar1;
         fVar5 = fVar4 * fVar1;
-        fVar3 = angle - ((float)fVar5 * -0.04464286 + fVar4 * -0.075 + fVar3 * -0.1666667 + fVar5 * fVar1 * -0.047446);
+        // Term order follows retail's FADDP sequence, which accumulates
+        // ((x9 + x3) + x5) + x7 rather than the x7-first order the decompiler emitted.
+        //
+        // Kept as a single expression through to the degree conversion for the same
+        // reason: retail runs FSUBR / FMUL 180.0f / FMUL 1-over-pi back to back with
+        // nothing spilled between them, so `angle - sum` is never rounded to 32 bits on
+        // the way through. Both details mirror the original's data flow.
+        fVar3 = (angle - (fVar5 * fVar1 * -0.047446f + fVar3 * -0.16666667f + fVar4 * -0.075f + (float)fVar5 * -0.04464286f)) * 180.0f * 0.3183098861837907;
     }
     else
     {
-        fVar3 = angle;
+        fVar3 = angle * 180.0f * 0.3183098861837907;
     }
-    fVar3 = fVar3 * 180.0 * 0.3183098861837907;
     if (bVar2)
     {
-        if (local_4 < 0.0)
+        if (original_angle < 0.0f)
         {
-            return -90.0 - fVar3;
+            return -90.0f - fVar3;
         }
-        fVar3 = 90.0 - fVar3;
+        fVar3 = 90.0f - fVar3;
     }
     return fVar3;
 }
@@ -119,7 +142,7 @@ float stdMath_ArcSin(float angle)
 float stdMath_ArcCos(float angle)
 
 {
-    return 90.0 - stdMath_ArcSin(angle);
+    return 90.0f - stdMath_ArcSin(angle);
 }
 
 // 0x0042f560
@@ -133,17 +156,23 @@ float stdMath_ArcTan2(float x1, float x2)
     float fVar6;
     float fVar7;
 
-    if ((0.0001 <= x2) || (x2 < -0.0001))
+    // The 0.0001 thresholds are float32 constants at 0x004ac6a8 / 0x004ac6ac, whose value
+    // is 9.999999747e-05 -- strictly LESS than the double 0.0001. That difference decides a
+    // branch, not just a rounding: at x2 == 0.0001f retail compares equal and evaluates the
+    // polynomial, while a double 0.0001 compares greater and takes the 90-degree early-out,
+    // which is where the 751 ULP divergence came from. Polynomial coefficients are the
+    // exact float32 values from 0x004ac6b0..0x004ac6bc; only the trailing 1/pi is a double.
+    if ((0.0001f <= x2) || (x2 < -0.0001f))
     {
-        if ((0.0001 <= x1) || (x1 < -0.0001))
+        if ((0.0001f <= x1) || (x1 < -0.0001f))
         {
             fVar2 = x1;
-            if (x1 < 0.0)
+            if (x1 < 0.0f)
             {
                 fVar2 = -x1;
             }
             fVar4 = x2;
-            if (x2 < 0.0)
+            if (x2 < 0.0f)
             {
                 fVar4 = -x2;
             }
@@ -155,37 +184,37 @@ float stdMath_ArcTan2(float x1, float x2)
                 fVar3 = fVar4;
             }
             fVar3 = fVar3 / fVar1;
-            if ((0.0001 <= fVar3) || (fVar3 < -0.0001))
+            if ((0.0001f <= fVar3) || (fVar3 < -0.0001f))
             {
                 fVar1 = fVar3 * fVar3;
                 fVar5 = fVar3 * fVar3 * fVar3;
                 fVar6 = fVar5 * fVar1;
                 fVar7 = fVar6 * fVar1;
-                fVar5 = ((((fVar3 - fVar5 * 0.3333333) - fVar6 * -0.2) - fVar7 * 0.1428571) - fVar7 * fVar1 * -0.063235) * 180.0 * 0.3183098861837907;
+                fVar5 = ((((fVar3 - fVar5 * 0.33333334f) - fVar6 * -0.2f) - fVar7 * 0.14285715f) - fVar7 * fVar1 * -0.063235f) * 180.0f * 0.3183098861837907;
             }
             else
             {
-                fVar5 = 0.0;
+                fVar5 = 0.0f;
             }
             if (fVar4 < fVar2)
             {
-                fVar5 = 90.0 - fVar5;
+                fVar5 = 90.0f - fVar5;
             }
         }
         else
         {
-            fVar5 = 0.0;
+            fVar5 = 0.0f;
         }
     }
     else
     {
-        fVar5 = 90.0;
+        fVar5 = 90.0f;
     }
-    if (x2 < -0.0001)
+    if (x2 < -0.0001f)
     {
-        fVar5 = 180.0 - fVar5;
+        fVar5 = 180.0f - fVar5;
     }
-    if (x1 < -0.0001)
+    if (x1 < -0.0001f)
     {
         fVar5 = -fVar5;
     }
@@ -195,7 +224,12 @@ float stdMath_ArcTan2(float x1, float x2)
 // 0x00480650
 float stdMath_Decelerator(float deceleration, float time)
 {
-    return 1.0 - (time * 33.33334) / (time * 33.33334 + deceleration);
+    // 33.333336f is the exact float32 at 0x004adf9c (bits 0x42055556). Ghidra prints it
+    // as "33.33334", which does NOT round-trip -- float("33.33334") is 0x42055557, one
+    // ULP away -- and written without the `f` suffix it becomes a double constant, which
+    // is a third distinct value. All three disagree, so the literal has to come from the
+    // stored bits rather than the decompiler's text.
+    return 1.0f - (time * 33.333336f) / (time * 33.333336f + deceleration);
 }
 
 // 0x00480670
@@ -236,7 +270,17 @@ float stdMath_NormalizeAngle(float angle)
 // 0x0048c8f0
 float stdMath_fround(float f)
 {
-    return roundf(f);
+    // Rounds toward negative infinity, not to nearest. Retail brackets its FRNDINT
+    // with `FLDCW [0x00ec8c82]` / `FLDCW [0x00ec8c80]`, loading a control word whose
+    // rounding-control field selects round-down: 0.5 comes back 0 and -0.5 comes back
+    // -1, which is floor rather than either roundf() or truncf().
+    //
+    // roundf() here was wrong for every input with a fractional part of 0.5 or more
+    // (~47% of them), and the error propagated into stdMath_NormalizeAngle,
+    // stdMath_SinCosFast and stdMath_FastTan, which all index off this result. Those
+    // three only ever pass positive values, where floor and trunc agree, so they alone
+    // cannot distinguish the two -- negative inputs here are what pin it down.
+    return floorf(f);
 }
 
 // 0x0048c910
@@ -355,7 +399,11 @@ void stdMath_SinCosFast(float angle, float* pSinOut, float* pCosOut)
 // 0x0048cd30
 int stdMath_FRoundInt(float f)
 {
-    return (int)roundf(f);
+    // Unlike stdMath_fround this one does NOT touch the control word, so its FRNDINT
+    // runs in the ambient mode -- round half to even. rintf() is the same deal: it
+    // honours the current mode rather than imposing one. roundf() rounds halves away
+    // from zero instead, which differed on every exact .5 input.
+    return (int)rintf(f);
 }
 
 // 0x0048cd50
@@ -461,7 +509,10 @@ float stdMath_ArcSin3(float x_)
     float x;
     float expansion;
 
-    if (0.0 <= x_)
+    // Exact float32 constants from 0x004af6c8..0x004af704. The degrees-per-radian factor
+    // is 57.295784f (0x004af6f4), not the 57.29578 Ghidra printed, and the split point is
+    // 0.70710677f rather than 0.7071068.
+    if (0.0f <= x_)
     {
         x = x_;
     }
@@ -469,23 +520,23 @@ float stdMath_ArcSin3(float x_)
     {
         x = -x_;
     }
-    if (x <= 0.7071068)
+    if (x <= 0.70710677f)
     {
         taylor_4 = stdMath_FlexPower(x, 3);
         taylor_1 = stdMath_FlexPower(x, 5);
         taylor_3 = stdMath_FlexPower(x, 7);
-        expansion = (taylor_3 * 0.066797 + taylor_1 * 0.075 + taylor_4 / 6.0 + x) * 57.29578;
+        expansion = (taylor_3 * 0.066797f + taylor_1 * 0.075f + taylor_4 / 6.0f + x) * 57.295784f;
     }
     else
     {
-        res = stdMath_Sqrt_2(1.0 - x * x);
+        res = stdMath_Sqrt_2(1.0f - x * x);
         taylor_4 = res;
         taylor_1 = stdMath_FlexPower(taylor_4, 3);
         taylor_3 = stdMath_FlexPower(taylor_4, 5);
         taylor_2 = stdMath_FlexPower(taylor_4, 7);
-        expansion = 90.0 - (taylor_2 * 0.066797 + taylor_3 * 0.075 + taylor_1 / 6.0 + taylor_4) * 57.29578;
+        expansion = 90.0f - (taylor_2 * 0.066797f + taylor_3 * 0.075f + taylor_1 / 6.0f + taylor_4) * 57.295784f;
     }
-    if (0.0 <= x_)
+    if (0.0f <= x_)
     {
         res = expansion;
     }

--- a/src/General/stdMath.h
+++ b/src/General/stdMath.h
@@ -35,7 +35,7 @@
 #define stdMath_ArcSin3_ADDR (0x0048d010)
 
 void stdMath_MultiplyAddClamped(float* res_inout, float value, float multiplier, float min, float max);
-void stdMath_AddScaledValueAndClamp_i32(int* res_inout, int value, float multiplier, int min, int max);
+void stdMath_AddScaledValueAndClamp_i32(int* res_inout, float value, float multiplier, int min, int max);
 
 void stdMath_SinCos(float angle_degrees, float* pSinOut, float* pCosOut);
 float stdMath_Tan(float angle_degrees);

--- a/src/Primitives/rdMath.c
+++ b/src/Primitives/rdMath.c
@@ -163,16 +163,21 @@ void rdMath_SlerpQuaternions(const rdVector4* a, const rdVector4* b, float t, rd
 // 0x00481520
 void rdMath_QuaternionToAxisAngle(rdVector4* axis_angle, const rdVector4* q)
 {
-    // TODO: this function is somehow broken but i cant find the error.
-
-    float l = q->x * q->x + q->y * q->z + q->z * q->z;
-    if (l >= 0.0000099999997 || l <= -0.0000099999997)
+    // The squared length had `q->y * q->z` where it needs `q->y * q->y` -- that typo was
+    // the "somehow broken" this function used to be marked with. Retail is unambiguous:
+    // FMUL of q->y by itself, then q->z by itself, then q->x by itself, accumulated as
+    // (y*y + z*z) + x*x, which is the order kept below.
+    //
+    // The thresholds are float32 constants at 0x004adff8 / 0x004adffc (1e-05f, whose value
+    // is 9.999999747e-06), not the double 0.0000099999997 that was written here.
+    float l = q->y * q->y + q->z * q->z + q->x * q->x;
+    if (l >= 1e-05f || l <= -1e-05f)
     {
         float angle = stdMath_ArcCos(q->w);
         float sin_angle, cos_angle;
         stdMath_SinCos(angle, &sin_angle, &cos_angle);
 
-        if (sin_angle >= 0.0000099999997 || sin_angle <= -0.0000099999997)
+        if (sin_angle >= 1e-05f || sin_angle <= -1e-05f)
         {
             *axis_angle = (rdVector4){
                 q->x / sin_angle,

--- a/src/Primitives/rdMatrix.c
+++ b/src/Primitives/rdMatrix.c
@@ -498,9 +498,11 @@ void rdMatrix_BuildFromVectorAngle44(rdMatrix44* mat, float angle, float x, floa
     float angleRad_sin[8]; // 8 items is a compilation artifact ?
 
     stdMath_SinCos(angle, angleRad_sin, &angleRad_cos);
-    if (z < 0.999)
+    // 0.999f is the float32 at 0x004ac6cc (0.9990000128746033); as a bare double literal
+    // 0.999 is a slightly smaller number, and this is a branch threshold.
+    if (z < 0.999f)
     {
-        if (-0.999 < z)
+        if (-0.999f < z)
         {
             fVar4 = x * x;
             fVar1 = y * y;
@@ -793,9 +795,13 @@ void rdMatrix_BuildRotate34(rdMatrix34* out, rdVector3* rot)
 
     scale = &out->scale;
 
-    stdMath_SinCos(rot->x, &x_rad_sin, &x_rad_cos);
-    stdMath_SinCos(rot->y, &y_rad_sin, &y_rad_cos);
-    stdMath_SinCos(rot->z, &z_rad_sin, &z_rad_cos);
+    // Retail calls stdMath_SinCosFast (0x0048c950), the quarter-wave table with linear
+    // interpolation -- not the exact stdMath_SinCos. The table carries about 1e-5 of
+    // interpolation error, so using the precise version here made our rotation matrices
+    // *more* accurate than the game's and diverged from retail on ~74% of inputs.
+    stdMath_SinCosFast(rot->x, &x_rad_sin, &x_rad_cos);
+    stdMath_SinCosFast(rot->y, &y_rad_sin, &y_rad_cos);
+    stdMath_SinCosFast(rot->z, &z_rad_sin, &z_rad_cos);
     out->rvec.x = -(z_rad_sin * y_rad_sin) * x_rad_sin + (z_rad_cos * y_rad_cos);
     out->rvec.y = ((z_rad_sin * y_rad_cos) * x_rad_sin) + (z_rad_cos * y_rad_sin);
     out->rvec.z = -z_rad_sin * x_rad_cos;

--- a/src/Primitives/rdVector.c
+++ b/src/Primitives/rdVector.c
@@ -105,13 +105,19 @@ float rdVector_Len3(const rdVector3* v)
 // 0x0042f910
 float rdVector_DistSquared3(const rdVector3* v1, const rdVector3* v2)
 {
-    return (v1->z - v2->z) * (v1->z - v2->z) + (v1->y - v2->y) * (v1->y - v2->y) + (v1->x - v2->x) * (v1->x - v2->x);
+    // Ordered x, y, z to match retail, which accumulates (dx*dx + dy*dy) + dz*dz. Retail
+    // also spills dx and dy through `FST dword` and multiplies each delta by its own
+    // 32-bit copy while leaving dz at register width; that asymmetry is not reproduced
+    // here, and measurably does not need to be -- this matches retail bit for bit.
+    return (v1->x - v2->x) * (v1->x - v2->x) + (v1->y - v2->y) * (v1->y - v2->y) + (v1->z - v2->z) * (v1->z - v2->z);
 }
 
 // 0x0042f950
 float rdVector_Dist3(const rdVector3* v1, const rdVector3* v2)
 {
-    return stdMath_Sqrt((v2->z - v1->z) * (v2->z - v1->z) + (v2->y - v1->y) * (v2->y - v1->y) + (v2->x - v1->x) * (v2->x - v1->x));
+    // Same accumulation order as rdVector_DistSquared3. Retail keeps the v2 - v1 operand
+    // order here, which this already matched.
+    return stdMath_Sqrt((v2->x - v1->x) * (v2->x - v1->x) + (v2->y - v1->y) * (v2->y - v1->y) + (v2->z - v1->z) * (v2->z - v1->z));
 }
 
 // 0x0042f9b0

--- a/src/hook_mode.c
+++ b/src/hook_mode.c
@@ -19,17 +19,15 @@ static int hook_mode_rule_count = 0;
 static int hook_mode_verify = 0;
 static int hook_mode_config_loaded = 0;
 
-// Counts of what hook_install() actually did, for the summary line.
 static int hook_mode_counts[3] = { 0, 0, 0 };
 
 static uint8_t* hook_mode_image_base = NULL;
 
 uint8_t* hook_retail_ptr(uint32_t retail_addr)
 {
-    // The retail EXE is not ASLR-aware, so in practice this resolves to 0x00400000
-    // and the rebase is a no-op. Going through GetModuleHandle keeps that an
-    // observation rather than an assumption, and keeps this translation unit
-    // independent of src/hook.c (which the default build does not compile).
+    // The retail EXE is not ASLR-aware, so this resolves to 0x00400000 and the rebase is a no-op;
+    // going through GetModuleHandle keeps that an observation rather than an assumption, and keeps
+    // this TU independent of src/hook.c (which the default build does not compile).
     if (hook_mode_image_base == NULL)
         hook_mode_image_base = (uint8_t*)GetModuleHandleA(NULL);
 
@@ -159,7 +157,7 @@ void hook_install(const char* function_name, uint32_t reimpl_addr, uint32_t reta
         hook_function(function_name, retail_addr, (uint8_t*)reimpl_addr);
         break;
     case HOOK_MODE_BOTH:
-        // Deliberately unredirected: both bodies stay intact so they can be compared.
+        // Deliberately unredirected so both bodies stay comparable.
         fprintf(hook_log, "\t[Both] %s <-> 0x%08x\n", function_name, retail_addr);
         break;
     }

--- a/src/hook_mode.c
+++ b/src/hook_mode.c
@@ -1,0 +1,178 @@
+#include "hook_mode.h"
+
+#include "hook.h"
+
+#include <string.h>
+#include <windows.h>
+
+#define HOOK_MODE_MAX_RULES 128
+#define HOOK_MODE_MAX_PATTERN 96
+
+typedef struct hook_mode_rule
+{
+    hook_mode mode;
+    char pattern[HOOK_MODE_MAX_PATTERN];
+} hook_mode_rule;
+
+static hook_mode_rule hook_mode_rules[HOOK_MODE_MAX_RULES];
+static int hook_mode_rule_count = 0;
+static int hook_mode_verify = 0;
+static int hook_mode_config_loaded = 0;
+
+// Counts of what hook_install() actually did, for the summary line.
+static int hook_mode_counts[3] = { 0, 0, 0 };
+
+static uint8_t* hook_mode_image_base = NULL;
+
+uint8_t* hook_retail_ptr(uint32_t retail_addr)
+{
+    // The retail EXE is not ASLR-aware, so in practice this resolves to 0x00400000
+    // and the rebase is a no-op. Going through GetModuleHandle keeps that an
+    // observation rather than an assumption, and keeps this translation unit
+    // independent of src/hook.c (which the default build does not compile).
+    if (hook_mode_image_base == NULL)
+        hook_mode_image_base = (uint8_t*)GetModuleHandleA(NULL);
+
+    return hook_mode_image_base + (retail_addr - SWR_BASE_ADDR_);
+}
+
+// Trailing '*' matches a prefix; a lone '*' matches everything; otherwise exact.
+static int hook_mode_pattern_match(const char* pattern, const char* name)
+{
+    size_t len = strlen(pattern);
+
+    if (len == 1 && pattern[0] == '*')
+        return 1;
+    if (len > 0 && pattern[len - 1] == '*')
+        return strncmp(pattern, name, len - 1) == 0;
+
+    return strcmp(pattern, name) == 0;
+}
+
+static int hook_mode_parse_mode(const char* token, hook_mode* out)
+{
+    if (strcmp(token, "original") == 0) {
+        *out = HOOK_MODE_ORIGINAL;
+        return 1;
+    }
+    if (strcmp(token, "reimpl") == 0) {
+        *out = HOOK_MODE_REIMPL;
+        return 1;
+    }
+    if (strcmp(token, "both") == 0) {
+        *out = HOOK_MODE_BOTH;
+        return 1;
+    }
+    return 0;
+}
+
+// Config grammar, one directive per line, '#' starts a comment:
+//   <mode> <pattern>   mode = original | reimpl | both; pattern may end in '*'
+//   verify             run the differential self-test once at startup
+// Later rules win, so `reimpl *` followed by `original swrSound_*` reads naturally.
+static void hook_mode_load_config(void)
+{
+    char line[256];
+    FILE* config;
+
+    hook_mode_config_loaded = 1;
+
+    config = fopen(HOOK_MODE_CONFIG_FILE, "r");
+    if (config == NULL)
+        return;
+
+    while (fgets(line, sizeof(line), config) != NULL) {
+        char* comment;
+        char* mode_token;
+        char* pattern_token;
+        hook_mode mode;
+
+        comment = strchr(line, '#');
+        if (comment != NULL)
+            *comment = '\0';
+
+        mode_token = strtok(line, " \t\r\n");
+        if (mode_token == NULL)
+            continue;
+
+        if (strcmp(mode_token, "verify") == 0) {
+            hook_mode_verify = 1;
+            continue;
+        }
+
+        if (!hook_mode_parse_mode(mode_token, &mode))
+            continue;
+
+        pattern_token = strtok(NULL, " \t\r\n");
+        if (pattern_token == NULL)
+            continue;
+        if (strlen(pattern_token) >= HOOK_MODE_MAX_PATTERN)
+            continue;
+        if (hook_mode_rule_count >= HOOK_MODE_MAX_RULES)
+            continue;
+
+        hook_mode_rules[hook_mode_rule_count].mode = mode;
+        strcpy(hook_mode_rules[hook_mode_rule_count].pattern, pattern_token);
+        hook_mode_rule_count++;
+    }
+
+    fclose(config);
+}
+
+hook_mode hook_mode_for(const char* function_name)
+{
+    hook_mode mode = HOOK_MODE_ORIGINAL;
+    int i;
+
+    if (!hook_mode_config_loaded)
+        hook_mode_load_config();
+
+    for (i = 0; i < hook_mode_rule_count; i++) {
+        if (hook_mode_pattern_match(hook_mode_rules[i].pattern, function_name))
+            mode = hook_mode_rules[i].mode;
+    }
+
+    return mode;
+}
+
+int hook_verify_requested(void)
+{
+    if (!hook_mode_config_loaded)
+        hook_mode_load_config();
+
+    return hook_mode_verify;
+}
+
+void hook_install(const char* function_name, uint32_t reimpl_addr, uint32_t retail_addr, int force_reimpl, FILE* hook_log)
+{
+    hook_mode mode = force_reimpl ? HOOK_MODE_REIMPL : hook_mode_for(function_name);
+
+    hook_mode_counts[mode]++;
+
+    switch (mode) {
+    case HOOK_MODE_ORIGINAL:
+        fprintf(hook_log, "\t[Original] %s <- 0x%08x\n", function_name, retail_addr);
+        hook_function(function_name, reimpl_addr, (uint8_t*)retail_addr);
+        break;
+    case HOOK_MODE_REIMPL:
+        fprintf(hook_log, "\t[Replace] %s -> 0x%08x\n", function_name, retail_addr);
+        hook_function(function_name, retail_addr, (uint8_t*)reimpl_addr);
+        break;
+    case HOOK_MODE_BOTH:
+        // Deliberately unredirected: both bodies stay intact so they can be compared.
+        fprintf(hook_log, "\t[Both] %s <-> 0x%08x\n", function_name, retail_addr);
+        break;
+    }
+}
+
+void hook_mode_log_summary(FILE* hook_log)
+{
+    int live = hook_mode_counts[HOOK_MODE_REIMPL];
+    int dormant = hook_mode_counts[HOOK_MODE_ORIGINAL];
+    int compared = hook_mode_counts[HOOK_MODE_BOTH];
+    int total = dormant + live + compared;
+    double percent = total > 0 ? (double)live * 100.0 / (double)total : 0.0;
+
+    fprintf(hook_log, "Hooked [%d/%d] functions (%.2f%%), %d left original, %d unredirected for comparison\n", live, total, percent, dormant, compared);
+    fflush(hook_log);
+}

--- a/src/hook_mode.h
+++ b/src/hook_mode.h
@@ -4,31 +4,24 @@
 #include <stdio.h>
 #include <stdint.h>
 
-// Which body actually runs for a reimplemented function.
-//
-// Every reimplementation is one half of a pair: our compiled body in src/, and the
-// retail body in SWEP1RCR.EXE. A single redirect decides which one the game reaches,
-// and the direction it points is what these modes select. GenerateHooks.py emits one
-// hook_install() call per reimplementation; this is what that call consults.
+// Which body runs for a reimplemented function: our compiled body in src/, or the retail body in
+// SWEP1RCR.EXE. One redirect decides, and its direction is what these modes select.
+// GenerateHooks.py emits one hook_install() call per reimplementation.
 typedef enum hook_mode
 {
-    // Redirect OUR body to retail. The reimplementation is dormant: it compiles and
-    // links but never executes. This is the default and the shipped behaviour --
-    // reimplementations stay reference material until proven equivalent.
+    // Redirect OUR body to retail: the reimplementation compiles and links but never executes.
+    // The default and shipped behaviour.
     HOOK_MODE_ORIGINAL = 0,
-    // Redirect RETAIL to our body. The reimplementation takes over, so every call
-    // site in the game reaches our code. Callees left at HOOK_MODE_ORIGINAL still
-    // resolve to their retail bodies, so one function can be brought live in
-    // isolation against otherwise-untouched surroundings.
+    // Redirect RETAIL to our body. Callees left at HOOK_MODE_ORIGINAL still resolve to their
+    // retail bodies, so one function can be brought live in isolation.
     HOOK_MODE_REIMPL = 1,
-    // Redirect neither, leaving both bodies intact and independently callable. The
-    // game keeps running retail code; a harness can call our symbol directly and
-    // reach retail through hook_retail_ptr(), and compare the two.
+    // Redirect neither: the game keeps running retail, and a harness can call our symbol directly
+    // and reach retail through hook_retail_ptr().
     HOOK_MODE_BOTH = 2,
 } hook_mode;
 
-// Read from the working directory (next to SWEP1RCR.EXE) at first use. Absent file
-// means every reimplementation stays dormant, i.e. exactly the shipped behaviour.
+// Read from the working directory at first use. An absent file leaves every reimplementation
+// dormant, i.e. the shipped behaviour.
 #define HOOK_MODE_CONFIG_FILE "reimpl_config.txt"
 
 // Translate a preferred-base retail address (0x004xxxxx) into a live pointer.
@@ -37,13 +30,11 @@ uint8_t* hook_retail_ptr(uint32_t retail_addr);
 // Resolve the configured mode for one function name. Loads the config on first call.
 hook_mode hook_mode_for(const char* function_name);
 
-// Non-zero when the config contains a bare `verify` line, asking for the
-// differential self-test to run once at startup.
+// Non-zero when the config contains a bare `verify` line.
 int hook_verify_requested(void);
 
-// Wire up one reimplementation according to its resolved mode. `force_reimpl` marks
-// functions annotated `// 0xADDR HOOK` -- deltas the GL renderer depends on rather
-// than equivalence candidates, so they go live regardless of configuration.
+// `force_reimpl` marks functions annotated `// 0xADDR HOOK` -- deltas the GL renderer depends on
+// rather than equivalence candidates, so they go live regardless of configuration.
 void hook_install(const char* function_name, uint32_t reimpl_addr, uint32_t retail_addr, int force_reimpl, FILE* hook_log);
 
 // Log what hook_install() actually did across the whole table.

--- a/src/hook_mode.h
+++ b/src/hook_mode.h
@@ -1,0 +1,52 @@
+#ifndef HOOK_MODE_H
+#define HOOK_MODE_H
+
+#include <stdio.h>
+#include <stdint.h>
+
+// Which body actually runs for a reimplemented function.
+//
+// Every reimplementation is one half of a pair: our compiled body in src/, and the
+// retail body in SWEP1RCR.EXE. A single redirect decides which one the game reaches,
+// and the direction it points is what these modes select. GenerateHooks.py emits one
+// hook_install() call per reimplementation; this is what that call consults.
+typedef enum hook_mode
+{
+    // Redirect OUR body to retail. The reimplementation is dormant: it compiles and
+    // links but never executes. This is the default and the shipped behaviour --
+    // reimplementations stay reference material until proven equivalent.
+    HOOK_MODE_ORIGINAL = 0,
+    // Redirect RETAIL to our body. The reimplementation takes over, so every call
+    // site in the game reaches our code. Callees left at HOOK_MODE_ORIGINAL still
+    // resolve to their retail bodies, so one function can be brought live in
+    // isolation against otherwise-untouched surroundings.
+    HOOK_MODE_REIMPL = 1,
+    // Redirect neither, leaving both bodies intact and independently callable. The
+    // game keeps running retail code; a harness can call our symbol directly and
+    // reach retail through hook_retail_ptr(), and compare the two.
+    HOOK_MODE_BOTH = 2,
+} hook_mode;
+
+// Read from the working directory (next to SWEP1RCR.EXE) at first use. Absent file
+// means every reimplementation stays dormant, i.e. exactly the shipped behaviour.
+#define HOOK_MODE_CONFIG_FILE "reimpl_config.txt"
+
+// Translate a preferred-base retail address (0x004xxxxx) into a live pointer.
+uint8_t* hook_retail_ptr(uint32_t retail_addr);
+
+// Resolve the configured mode for one function name. Loads the config on first call.
+hook_mode hook_mode_for(const char* function_name);
+
+// Non-zero when the config contains a bare `verify` line, asking for the
+// differential self-test to run once at startup.
+int hook_verify_requested(void);
+
+// Wire up one reimplementation according to its resolved mode. `force_reimpl` marks
+// functions annotated `// 0xADDR HOOK` -- deltas the GL renderer depends on rather
+// than equivalence candidates, so they go live regardless of configuration.
+void hook_install(const char* function_name, uint32_t reimpl_addr, uint32_t retail_addr, int force_reimpl, FILE* hook_log);
+
+// Log what hook_install() actually did across the whole table.
+void hook_mode_log_summary(FILE* hook_log);
+
+#endif // HOOK_MODE_H

--- a/src/templates/hook_generated.c.j2
+++ b/src/templates/hook_generated.c.j2
@@ -10,9 +10,8 @@
 // the cmake build, and will autogenerate any time any of the c files in
 // src are changed
 
-// Each entry pairs our reimplementation with its retail address. hook_install()
-// decides which of the two the game actually reaches -- see hook_mode.h. The last
-// argument marks functions annotated `// 0xADDR HOOK`, which are always forced live.
+// Each entry pairs our reimplementation with its retail address; hook_install() decides which the
+// game reaches (see hook_mode.h). The last argument marks `// 0xADDR HOOK` functions, always live.
 void hook_generated(FILE* hook_log)
 {
 {%- for f in functions %}

--- a/src/templates/hook_generated.c.j2
+++ b/src/templates/hook_generated.c.j2
@@ -1,4 +1,6 @@
 #include <stdio.h>
+
+#include "hook_mode.h"
 {% for header in headers %}
 #include "{{ header }}"
 {%- endfor %}
@@ -8,12 +10,14 @@
 // the cmake build, and will autogenerate any time any of the c files in
 // src are changed
 
+// Each entry pairs our reimplementation with its retail address. hook_install()
+// decides which of the two the game actually reaches -- see hook_mode.h. The last
+// argument marks functions annotated `// 0xADDR HOOK`, which are always forced live.
 void hook_generated(FILE* hook_log)
 {
 {%- for f in functions %}
-    fprintf(hook_log, {{f.message}});
-    hook_function("{{f.name}}", (uint32_t){{f.hook_addr}}, (uint8_t *){{f.hook_dst}});
+    hook_install("{{f.name}}", (uint32_t){{f.reimpl_addr}}, (uint32_t){{f.retail_addr}}, {{f.force_reimpl}}, hook_log);
 {% endfor -%}
-    fprintf(hook_log, {{hook_complete_msg}});
-    fflush(hook_log);
+    hook_mode_log_summary(hook_log);
 }
+


### PR DESCRIPTION
Stacked on #283 — that one first (this needs its corrected `AddScaledValueAndClamp_i32` signature to compile).

**The problem:** reimplementations never execute. `hook_generated.c` ends with a literal `Hooked [0/1112] functions (0.0%)` — every registration is a reverse hook, redirecting *our* body to the retail one, and `src/` has no `// 0xADDR HOOK` annotations at all. So everything in `src/` is compile-checked, link-checked reference material with no evidence behind it. Since you've said you don't want matching decompilation, behavioural equivalence testing seems like the substitute worth having.

**Runtime mode switch.** Direction is no longer baked at codegen time. `GenerateHooks.py` emits one `hook_install()` per function and `src/hook_mode.c` resolves the direction at startup from `reimpl_config.txt` next to the game:

```
original <pattern>   redirect ours to retail; dormant (the default)
reimpl   <pattern>   redirect retail to ours; takes over
both     <pattern>   redirect neither; both bodies callable
verify               run the differential self-test once at startup
```

With no config file everything resolves to `original`, which is byte-for-byte today's behaviour — verified as 1106 original / 0 replaced / 0 unredirected, no log written, game unaffected. `hook_function` is untouched, so the ~120 delta-layer call sites and both build configs keep working.

Modes compose per function, which is the useful part: a `reimpl` function whose callees are all `original` runs our code against otherwise untouched surroundings, so any behaviour change is attributable to that one body. That also gives #153's reversible-patch idea its primitive for free.

**The harness** runs each `both`-mode function against retail over deterministic inputs and compares bitwise. It refuses any case it can't trust — not in `both` mode (our symbol is detoured to retail, so it'd compare retail against itself), or retail's prologue already rewritten by the delta layer. 54 cases across stdMath, rdVector, rdMath, stdHashtbl and rdMatrix, **all passing at a tolerance of zero**: bit-identical over ~5.5M comparisons. Every budget is 0 on purpose — each divergence I chased turned out to be a real defect, not unavoidable rounding, so a non-zero tolerance would only hide the next one.

It can't run from `init_hooks()` (pre-`WinMain`; several retail math helpers `FLDCW` from globals the game hasn't filled in yet and the next FP instruction faults), so it runs from the frame-present hook and fires once.

Also fixes a missing comma in `hooks_blacklist` that concatenated `"rdMatrix_PostMultiply34"` with `"rdMatrix_TransformVector34"`, leaving neither blacklisted — both got a reverse hook generated while `renderer_hook.cpp` separately forward-hooked them to deltas.

Note the diff still shows #283's five files on top of this PR's nine; that's just how cross-fork stacking renders, and it drops out once #283 merges.

Suggested direction: merge it dormant. It changes nothing until someone writes a config file, and it turns the reimpl count from "code was written" into "code provably matches". The natural next step is a per-frame sim-state hash so whole-subsystem divergence can be bisected, which needs the fixed-timestep work in #194 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)