### PR TITLE
Input diagnostics: identify stuck / non-analog axes; throttle the empty-slot pad scan

### DIFF
--- a/dinput_hook/game_deltas/stdControl_delta.c
+++ b/dinput_hook/game_deltas/stdControl_delta.c
@@ -2,6 +2,7 @@
 
 #include "globals.h"
 
+#include <engine_config.h>
 #include <macros.h>
 
 #if ENABLE_GLFW_INPUT_HANDLING
@@ -87,8 +88,8 @@ void stdControl_SelectJoystickByIndex(int index) {
         return;
     stdControl_joystickDeviceIndex = index;
     swrConfig_joystickNbAxis = 0;
-    for (int i = 0; i < 6; i++) {
-        if (((int (*) (int)) stdControl_EnableAxis_ADDR)(i + index * 6))
+    for (int i = 0; i < STDCONTROL_AXES_PER_JOYSTICK; i++) {
+        if (((int (*) (int)) stdControl_EnableAxis_ADDR)(i + index * STDCONTROL_AXES_PER_JOYSTICK))
             swrConfig_joystickNbAxis++;
     }
     if (swrConfig_joystickNbAxis > 0) {

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
@@ -125,10 +125,8 @@ static void nav_load_xinput() {
 
 // Find the first connected pad. Rescans at most once a second so an unplugged /
 // late-plugged controller is picked up without polling every slot every frame.
-// The throttle has to apply while NO pad is connected too: XInputGetState on an empty
-// slot is markedly slower than on a live one, so probing all four every frame is a real
-// frame-time cost -- and "no pad connected" is exactly the state a player having
-// controller trouble sits in for as long as they have the game open.
+// The throttle applies while no pad is connected too: XInputGetState on an empty slot is markedly
+// slower than on a live one, so probing all four every frame costs real frame time.
 static void nav_refresh_pad(uint32_t now) {
     if (g_scannedOnce && (now - g_lastScanMs) < NAV_PAD_SCAN_INTERVAL_MS)
         return;

--- a/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
+++ b/dinput_hook/game_deltas/swrGamepadNav_delta.cpp
@@ -88,6 +88,7 @@ static const WORD NAV_BIT[4] = {XINPUT_GAMEPAD_DPAD_UP, XINPUT_GAMEPAD_DPAD_DOWN
                                 XINPUT_GAMEPAD_DPAD_LEFT, XINPUT_GAMEPAD_DPAD_RIGHT};
 static const uint32_t NAV_REPEAT_DELAY_MS = 400;// hold-to-repeat: delay before first repeat
 static const uint32_t NAV_REPEAT_RATE_MS = 110; // hold-to-repeat: interval between repeats
+static const uint32_t NAV_PAD_SCAN_INTERVAL_MS = 1000;// how often to look for a connected pad
 static uint32_t g_navNextFire[4] = {0, 0, 0, 0};
 static WORD g_navPrevHeld = 0;// d-pad directions we have an outstanding key-down for
 
@@ -97,6 +98,7 @@ static XInputGetState_t p_XInputGetState = nullptr;
 static bool g_xinputTried = false;
 static int g_padIndex = -1;       // currently connected pad (0..3), -1 = none
 static uint32_t g_lastScanMs = 0; // last time we scanned for a pad
+static bool g_scannedOnce = false;// so the first scan isn't held off by the rescan throttle
 
 // Latched controller state, refreshed once per present by swrGamepadNav_Poll.
 static WORD g_held = 0;   // buttons currently down
@@ -123,9 +125,14 @@ static void nav_load_xinput() {
 
 // Find the first connected pad. Rescans at most once a second so an unplugged /
 // late-plugged controller is picked up without polling every slot every frame.
+// The throttle has to apply while NO pad is connected too: XInputGetState on an empty
+// slot is markedly slower than on a live one, so probing all four every frame is a real
+// frame-time cost -- and "no pad connected" is exactly the state a player having
+// controller trouble sits in for as long as they have the game open.
 static void nav_refresh_pad(uint32_t now) {
-    if (g_padIndex >= 0 && (now - g_lastScanMs) < 1000)
+    if (g_scannedOnce && (now - g_lastScanMs) < NAV_PAD_SCAN_INTERVAL_MS)
         return;
+    g_scannedOnce = true;
     g_lastScanMs = now;
     for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
         XINPUT_STATE st;

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -1749,12 +1749,8 @@ static void diag_norm_bar(const char *label, float v, bool center) {
     diag_labeled_bar(label, "Steering", frac, overlay);
 }
 
-// What a raw axis slot has done since the readout was last reset. A bare bar cannot
-// tell "resting at centre" from "pinned at an extreme", and scaling it to the largest
-// value seen renders any constant non-zero slot as permanently full -- which reads as
-// a healthy axis at full deflection. Keeping the travel per slot lets the panel name
-// the two failures that actually strand players: a slot that never moves, and one that
-// only ever reports its endpoints (a digital or mis-read slot, not an analog axis).
+// Travel observed per raw axis slot since the last reset. Enough to distinguish the two failures
+// worth reporting: a slot that never moves, and one that only ever reports its endpoints.
 struct DiagAxisStat {
     int min;
     int max;
@@ -1769,8 +1765,7 @@ static void diag_reset_axis_stats(void) {
         g_diagAxis[i] = DiagAxisStat{};
 }
 
-// A slot has to travel at least this far before its shape carries any information;
-// below it every classification would just be describing an idle axis.
+// Below this travel every classification would just be describing an idle axis.
 static const int DIAG_AXIS_MIN_SPAN = 1000;
 
 // How a raw axis slot is behaving, worst last -- only DIAG_AXIS_BROKEN is worth reporting.
@@ -1794,20 +1789,16 @@ static void diag_update_axis_stat(int i, int v) {
         s.max = v;
     const int span = s.max - s.min;
     if (span >= DIAG_AXIS_MIN_SPAN) {
-        // "Mid" is the middle half of the travel seen so far. A real analog axis passes
-        // through it constantly; a slot that only reports its endpoints never will.
+        // Middle half of the travel seen so far: an endpoints-only slot never passes through it.
         if (v > s.min + span / 4 && v < s.max - span / 4)
             s.seenMid = true;
     }
 }
 
-// Classify a slot, and write the player-facing explanation for a broken one into out.
-//
-// deviceMoving says another slot on the same pad has travelled, which is what makes a
-// frozen slot meaningful: the game's axis range is not necessarily centred on 0, so a
-// healthy stick sitting at rest can read a constant non-zero value and would otherwise
-// be reported as stuck the instant the panel opens. Waiting for proof the device is
-// live costs nothing -- anyone diagnosing a controller is about to move it.
+// Classify a slot, writing the player-facing explanation for a broken one into out.
+// deviceMoving (another slot on the same pad has travelled) is what makes a frozen slot
+// meaningful: the axis range is not necessarily centred on 0, so a stick at rest can read a
+// constant non-zero value.
 static DiagAxisVerdict diag_axis_note(const DiagAxisStat &s, bool deviceMoving, char *out,
                                       size_t outSize) {
     out[0] = '\0';
@@ -1850,14 +1841,12 @@ static void panel_input_diagnostics() {
         }
     }
 
-    // Sample every slot once per frame, before anything renders, so the diagnosis line
-    // and the axis list below agree on the same observation.
+    // Sample once per frame before rendering, so the diagnosis line and the axis list agree.
     for (int i = 0; i < STDCONTROL_NUM_AXIS_SLOTS; i++)
         diag_update_axis_stat(i, stdControl_aAxisPos[i]);
 
-    // Only this band belongs to the pad the game is actually reading -- other devices'
-    // slots are not worth reporting on. Clamped because the band of the last device the
-    // table can hold is clipped, and because an unset device index is negative.
+    // The band belonging to the pad the game reads. Clamped: the last device's band is clipped by
+    // the table size, and an unset device index is negative.
     const int axisBandLo = stdControl_joystickDeviceIndex * STDCONTROL_AXES_PER_JOYSTICK;
     const int axisBandHi = axisBandLo + STDCONTROL_AXES_PER_JOYSTICK < STDCONTROL_NUM_AXIS_SLOTS
                                ? axisBandLo + STDCONTROL_AXES_PER_JOYSTICK
@@ -1891,16 +1880,13 @@ static void panel_input_diagnostics() {
     } else if (!joyEnabled) {
         diag_status(false, "Controller connected but disabled. Turn on 'Joystick enabled' below.");
     } else if (badAxes > 0) {
-        // Ahead of the "input is arriving" line below: a stuck or digital axis still
-        // counts as input arriving, so the reassuring message would otherwise win and
-        // hide the actual fault.
+        // Ahead of the "input is arriving" line: a stuck axis still counts as input arriving.
         diag_status(false, "A controller axis is not behaving like an analog axis "
                            "-- see 'Raw joystick axes' below.");
         ImGui::TextDisabled("Usually a driver or calibration problem outside the game. Check the "
                             "pad in Windows' joy.cpl ('Set up USB game controllers' > Properties); "
                             "if it misbehaves there too, recalibrate or reset it there.");
-        // Only raised alongside a real misbehaving axis: plenty of legitimate sticks and
-        // wheels report six axes, so the count on its own means nothing.
+        // Only alongside a real misbehaving axis -- plenty of legitimate wheels report six axes.
         if (swrConfig_joystickNbAxis == STDCONTROL_AXES_PER_JOYSTICK)
             ImGui::TextDisabled("This pad reports 6 axes. An Xbox controller on Microsoft's XUSB "
                                 "driver reports 5 (both triggers share one axis), so 6 usually "
@@ -1971,9 +1957,7 @@ static void panel_input_diagnostics() {
         ImGui::SameLine();
         ImGui::TextDisabled("(sweep every stick and trigger fully, then read the notes)");
 
-        // Each bar shows where the slot sits inside the travel observed so far, and the
-        // overlay prints that travel outright -- the raw calibrated range isn't known up
-        // front, and a bar alone cannot show that a slot never leaves its endpoints.
+        // Bars are relative to the travel observed so far; the raw calibrated range is unknown.
         for (int i = 0; i < STDCONTROL_NUM_AXIS_SLOTS; i++) {
             const int v = stdControl_aAxisPos[i];
             const DiagAxisStat &s = g_diagAxis[i];
@@ -1984,7 +1968,6 @@ static void panel_input_diagnostics() {
             char label[16];
             snprintf(label, sizeof(label), "Axis %2d", i);
 
-            // Dim the slots belonging to devices the game isn't reading.
             const bool inBand = i >= axisBandLo && i < axisBandHi;
             if (!inBand)
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include <Swr/swrObj.h>
 #include <Swr/swrEvent.h>
 #include <Swr/swrText.h>
+#include <engine_config.h>// axis-table geometry for the input diagnostics panel
 }
 
 extern rdVector3 debugCameraPos;
@@ -1748,6 +1749,85 @@ static void diag_norm_bar(const char *label, float v, bool center) {
     diag_labeled_bar(label, "Steering", frac, overlay);
 }
 
+// What a raw axis slot has done since the readout was last reset. A bare bar cannot
+// tell "resting at centre" from "pinned at an extreme", and scaling it to the largest
+// value seen renders any constant non-zero slot as permanently full -- which reads as
+// a healthy axis at full deflection. Keeping the travel per slot lets the panel name
+// the two failures that actually strand players: a slot that never moves, and one that
+// only ever reports its endpoints (a digital or mis-read slot, not an analog axis).
+struct DiagAxisStat {
+    int min;
+    int max;
+    bool seen;
+    bool seenMid;
+};
+
+static DiagAxisStat g_diagAxis[STDCONTROL_NUM_AXIS_SLOTS];
+
+static void diag_reset_axis_stats(void) {
+    for (int i = 0; i < STDCONTROL_NUM_AXIS_SLOTS; i++)
+        g_diagAxis[i] = DiagAxisStat{};
+}
+
+// A slot has to travel at least this far before its shape carries any information;
+// below it every classification would just be describing an idle axis.
+static const int DIAG_AXIS_MIN_SPAN = 1000;
+
+// How a raw axis slot is behaving, worst last -- only DIAG_AXIS_BROKEN is worth reporting.
+enum DiagAxisVerdict {
+    DIAG_AXIS_OK,    // moves, and passes through the middle of its travel
+    DIAG_AXIS_IDLE,  // nothing observed yet; no claim either way
+    DIAG_AXIS_BROKEN,// not usable as an analog axis
+};
+
+static void diag_update_axis_stat(int i, int v) {
+    DiagAxisStat &s = g_diagAxis[i];
+    if (!s.seen) {
+        s.seen = true;
+        s.min = v;
+        s.max = v;
+        return;
+    }
+    if (v < s.min)
+        s.min = v;
+    if (v > s.max)
+        s.max = v;
+    const int span = s.max - s.min;
+    if (span >= DIAG_AXIS_MIN_SPAN) {
+        // "Mid" is the middle half of the travel seen so far. A real analog axis passes
+        // through it constantly; a slot that only reports its endpoints never will.
+        if (v > s.min + span / 4 && v < s.max - span / 4)
+            s.seenMid = true;
+    }
+}
+
+// Classify a slot, and write the player-facing explanation for a broken one into out.
+//
+// deviceMoving says another slot on the same pad has travelled, which is what makes a
+// frozen slot meaningful: the game's axis range is not necessarily centred on 0, so a
+// healthy stick sitting at rest can read a constant non-zero value and would otherwise
+// be reported as stuck the instant the panel opens. Waiting for proof the device is
+// live costs nothing -- anyone diagnosing a controller is about to move it.
+static DiagAxisVerdict diag_axis_note(const DiagAxisStat &s, bool deviceMoving, char *out,
+                                      size_t outSize) {
+    out[0] = '\0';
+    if (!s.seen)
+        return DIAG_AXIS_IDLE;
+    const int span = s.max - s.min;
+    if (span == 0) {
+        if (s.min == 0 || !deviceMoving)
+            return DIAG_AXIS_IDLE;// untouched / unmapped slot, or nothing to compare against yet
+        snprintf(out, outSize, "Stuck at %d -- constant while other axes on this pad move.", s.min);
+        return DIAG_AXIS_BROKEN;
+    }
+    if (span >= DIAG_AXIS_MIN_SPAN && !s.seenMid) {
+        snprintf(out, outSize, "Not analog -- only ever reads %d or %d, nothing in between.", s.min,
+                 s.max);
+        return DIAG_AXIS_BROKEN;
+    }
+    return DIAG_AXIS_OK;
+}
+
 // Player-facing input troubleshooter. Walks the input pipeline top to bottom
 // (device -> raw axes -> bindings -> the values the pod receives) so a player can
 // see exactly where their controller stops being recognized -- the #1 community
@@ -1763,11 +1843,41 @@ static void panel_input_diagnostics() {
     const int mouseActions = diag_count_active(MouseButtonPressedInput);
 
     bool anyRawAxis = false;
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < STDCONTROL_NUM_AXIS_SLOTS; i++) {
         if (stdControl_aAxisPos[i] != 0) {
             anyRawAxis = true;
             break;
         }
+    }
+
+    // Sample every slot once per frame, before anything renders, so the diagnosis line
+    // and the axis list below agree on the same observation.
+    for (int i = 0; i < STDCONTROL_NUM_AXIS_SLOTS; i++)
+        diag_update_axis_stat(i, stdControl_aAxisPos[i]);
+
+    // Only this band belongs to the pad the game is actually reading -- other devices'
+    // slots are not worth reporting on. Clamped because the band of the last device the
+    // table can hold is clipped, and because an unset device index is negative.
+    const int axisBandLo = stdControl_joystickDeviceIndex * STDCONTROL_AXES_PER_JOYSTICK;
+    const int axisBandHi = axisBandLo + STDCONTROL_AXES_PER_JOYSTICK < STDCONTROL_NUM_AXIS_SLOTS
+                               ? axisBandLo + STDCONTROL_AXES_PER_JOYSTICK
+                               : STDCONTROL_NUM_AXIS_SLOTS;
+    const int axisBandStart = axisBandLo >= 0 ? axisBandLo : 0;
+
+    // Has anything on this pad actually travelled? Used to qualify a frozen slot below.
+    bool axisBandMoving = false;
+    for (int i = axisBandStart; i < axisBandHi; i++) {
+        if (g_diagAxis[i].max - g_diagAxis[i].min >= DIAG_AXIS_MIN_SPAN) {
+            axisBandMoving = true;
+            break;
+        }
+    }
+
+    int badAxes = 0;
+    for (int i = axisBandStart; i < axisBandHi; i++) {
+        char note[128];
+        if (diag_axis_note(g_diagAxis[i], axisBandMoving, note, sizeof(note)) == DIAG_AXIS_BROKEN)
+            badAxes++;
     }
 
     // Surface the single most likely problem first.
@@ -1780,6 +1890,22 @@ static void panel_input_diagnostics() {
         ImGui::TextDisabled("(keyboard still works)");
     } else if (!joyEnabled) {
         diag_status(false, "Controller connected but disabled. Turn on 'Joystick enabled' below.");
+    } else if (badAxes > 0) {
+        // Ahead of the "input is arriving" line below: a stuck or digital axis still
+        // counts as input arriving, so the reassuring message would otherwise win and
+        // hide the actual fault.
+        diag_status(false, "A controller axis is not behaving like an analog axis "
+                           "-- see 'Raw joystick axes' below.");
+        ImGui::TextDisabled("Usually a driver or calibration problem outside the game. Check the "
+                            "pad in Windows' joy.cpl ('Set up USB game controllers' > Properties); "
+                            "if it misbehaves there too, recalibrate or reset it there.");
+        // Only raised alongside a real misbehaving axis: plenty of legitimate sticks and
+        // wheels report six axes, so the count on its own means nothing.
+        if (swrConfig_joystickNbAxis == STDCONTROL_AXES_PER_JOYSTICK)
+            ImGui::TextDisabled("This pad reports 6 axes. An Xbox controller on Microsoft's XUSB "
+                                "driver reports 5 (both triggers share one axis), so 6 usually "
+                                "means it arrived on a generic HID path -- which shifts which "
+                                "physical control lands in each axis slot.");
     } else if (joyActions == 0 && !anyRawAxis) {
         diag_status(true, "Controller ready. Move a stick / press a button -- the bars should react.");
         ImGui::TextDisabled("If they stay flat while you move the stick, lower the deadzone or re-bind.");
@@ -1840,20 +1966,39 @@ static void panel_input_diagnostics() {
     ImGui::Text("Mouse %d", mouseActions);
 
     if (ImGui::TreeNodeEx("Raw joystick axes", ImGuiTreeNodeFlags_DefaultOpen)) {
-        // Auto-scale each bar to the largest magnitude seen so far, since the raw
-        // calibrated axis range isn't known up front.
-        static float axisMax[15] = {};
-        for (int i = 0; i < 15; i++) {
+        if (ImGui::SmallButton("Reset ranges"))
+            diag_reset_axis_stats();
+        ImGui::SameLine();
+        ImGui::TextDisabled("(sweep every stick and trigger fully, then read the notes)");
+
+        // Each bar shows where the slot sits inside the travel observed so far, and the
+        // overlay prints that travel outright -- the raw calibrated range isn't known up
+        // front, and a bar alone cannot show that a slot never leaves its endpoints.
+        for (int i = 0; i < STDCONTROL_NUM_AXIS_SLOTS; i++) {
             const int v = stdControl_aAxisPos[i];
-            const float a = (float) (v < 0 ? -v : v);
-            if (a > axisMax[i])
-                axisMax[i] = a;
-            const float frac = axisMax[i] > 1.0f ? a / axisMax[i] : 0.0f;
-            char overlay[24];
-            snprintf(overlay, sizeof(overlay), "%d", v);
+            const DiagAxisStat &s = g_diagAxis[i];
+            const int span = s.max - s.min;
+            const float frac = span > 0 ? (float) (v - s.min) / (float) span : 0.0f;
+            char overlay[48];
+            snprintf(overlay, sizeof(overlay), "%d   seen %d .. %d", v, s.min, s.max);
             char label[16];
             snprintf(label, sizeof(label), "Axis %2d", i);
+
+            // Dim the slots belonging to devices the game isn't reading.
+            const bool inBand = i >= axisBandLo && i < axisBandHi;
+            if (!inBand)
+                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
             diag_labeled_bar(label, "Axis 00", frac, overlay);
+            if (!inBand)
+                ImGui::PopStyleVar();
+
+            char note[128];
+            if (inBand &&
+                diag_axis_note(s, axisBandMoving, note, sizeof(note)) == DIAG_AXIS_BROKEN) {
+                ImGui::Indent();
+                diag_status(false, note);
+                ImGui::Unindent();
+            }
         }
         ImGui::TreePop();
     }

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -7,10 +7,9 @@
 // worst-case single face returned by it always fits before the next flush.
 #define RDCACHE_MIN_FREE_VERTICES (0x50)
 
-// Geometry of the stdControl axis table (stdControl_aAxisPos / stdControl_aJoysticks).
-// The engine reserves a fixed band of axis slots per joystick device, so device N's axes
-// occupy [N * STDCONTROL_AXES_PER_JOYSTICK, +STDCONTROL_AXES_PER_JOYSTICK). The table is
-// not a whole number of bands: the last device's band is clipped by the table size.
+// Geometry of the stdControl axis table (stdControl_aAxisPos / stdControl_aJoysticks): device N's
+// axes occupy [N * STDCONTROL_AXES_PER_JOYSTICK, +STDCONTROL_AXES_PER_JOYSTICK). The table is not a
+// whole number of bands -- the last device's band is clipped by the table size.
 #define STDCONTROL_NUM_AXIS_SLOTS (15)
 #define STDCONTROL_AXES_PER_JOYSTICK (6)
 

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -7,6 +7,13 @@
 // worst-case single face returned by it always fits before the next flush.
 #define RDCACHE_MIN_FREE_VERTICES (0x50)
 
+// Geometry of the stdControl axis table (stdControl_aAxisPos / stdControl_aJoysticks).
+// The engine reserves a fixed band of axis slots per joystick device, so device N's axes
+// occupy [N * STDCONTROL_AXES_PER_JOYSTICK, +STDCONTROL_AXES_PER_JOYSTICK). The table is
+// not a whole number of bands: the last device's band is clipped by the table size.
+#define STDCONTROL_NUM_AXIS_SLOTS (15)
+#define STDCONTROL_AXES_PER_JOYSTICK (6)
+
 // daAlloc arena allocator (stdMemory.c).
 #define DAALLOC_PAGE_SIZE (0x7c00)       // bytes per arena page, malloc'd on demand
 #define DAALLOC_ARENA_COUNT (0x421)      // number of daAlloc_struct arena slots (1057)


### PR DESCRIPTION
Follow-up to #218. Two independent input fixes.

**Draft: built and links clean, but not playtested yet** — I haven't confirmed in-game that a healthy pad classifies as healthy (no false "not analog" from a quick stick flick). Flipping to ready once I've done that.

### Stuck / non-analog axis detection

The panel from #218 auto-scaled each axis bar to the largest magnitude seen so far, which inverts the meaning of the worst case: a slot stuck at a constant non-zero value renders as a permanently *full* bar, so it reads as a healthy axis at full deflection.

Now each slot tracks its observed min/max plus whether it ever passes through the middle half of that travel. That's enough to name the two faults that actually strand players:

- **Stuck** — constant while other axes on the same pad move. Qualified on device-movement, because the game's axis range isn't necessarily centred on 0, so a resting stick can legitimately read a constant non-zero value and would otherwise get reported as stuck the moment the panel opens.
- **Not analog** — only ever reports its two endpoints, nothing in between (a digital or mis-read slot).

Supporting changes: the bar shows position within the observed travel with the range printed in the overlay, there's a "Reset ranges" button, slots outside the active device's band are dimmed, and a broken axis is surfaced in the top-line Diagnosis *ahead of* the "input is arriving" message — a stuck axis is still input arriving, so the reassuring line would otherwise mask the fault. Alongside a real fault it also points at joy.cpl recalibration and notes that a 6-axis count suggests a generic HID path rather than XUSB.

### Empty-slot pad scan throttle

The gamepad-nav bridge's 1s rescan throttle only applied once a pad had already been found, so with no controller connected it probed all four XInput slots every frame. `XInputGetState` on an empty slot is markedly slower than on a live one, and "no pad connected" is exactly the state a player with controller trouble sits in for as long as the game is open. Gated on "scanned at least once" instead, so the first scan stays immediate.

Also names the stdControl axis-table geometry in `engine_config.h` and reuses it in `stdControl_delta.c`, which had the same `6` open-coded twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
