### PR TITLE
fix(renderer): drop dead n64 shader helpers that broke compilation on some drivers

### DIFF
--- a/assets/shaders/n64_shader.frag
+++ b/assets/shaders/n64_shader.frag
@@ -30,32 +30,6 @@ uniform float alphaCutoff;
 // real alpha (coverage source) instead of forcing surviving pixels opaque.
 uniform int alphaToCoverage;
 
-vec3 HSV_to_RGB(float h, float s, float v) {
-    h = fract(h) * 6.0;
-    int i = int(h);
-    float f = h - float(i);
-    float p = v * (1.0 - s);
-    float q = v * (1.0 - s * f);
-    float t = v * (1.0 - s * (1.0 - f));
-
-    switch(i) {
-        case 0: return vec3(v, t, p);
-        case 1: return vec3(q, v, p);
-        case 2: return vec3(p, v, t);
-        case 3: return vec3(p, q, v);
-        case 4: return vec3(t, p, v);
-
-        default:
-        break;
-    }
-    return vec3(v, p, q);
-}
-
-vec3 identifying_color(uint index) {
-    float f = index * 0.618033988749895;
-    return HSV_to_RGB(f - 1.0 * floor(f), 0.5, 1.0);
-}
-
 out vec4 color;
 void main() {
     if (ivec2(gl_FragCoord.xy) == mousePosition) {

--- a/dinput_hook/game_deltas/stdDisplay_delta.c
+++ b/dinput_hook/game_deltas/stdDisplay_delta.c
@@ -12,6 +12,28 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
+// Driver identification, logged once the GL entry points are loaded. Shader compile failures and
+// framebuffer errors are driver-specific, and a hook.log without these strings cannot tell us which
+// GL implementation produced them.
+static void logGLDriverInfo(void) {
+    static const GLenum queries[] = {GL_VENDOR, GL_RENDERER, GL_VERSION,
+                                     GL_SHADING_LANGUAGE_VERSION};
+    static const char *const names[] = {"vendor", "renderer", "version", "glsl"};
+
+    // stdDisplay_Open runs again on every resolution change; the strings don't change with it, so
+    // log them once rather than repeating the block through the log.
+    static bool logged = false;
+    if (logged)
+        return;
+    logged = true;
+
+    for (unsigned int i = 0; i < ARRAYSIZE(queries); i++) {
+        const GLubyte *value = glGetString(queries[i]);
+        fprintf(hook_log, "[GL] %s: %s\n", names[i], value ? (const char *) value : "(null)");
+    }
+    fflush(hook_log);
+}
+
 // 0x00487d20
 int stdDisplay_Startup_delta(void) {
     if (stdDisplay_bStartup)
@@ -50,6 +72,7 @@ int stdDisplay_Open_delta(int deviceNum) {
     stdDisplay_pcurDevice = &stdDisplay_aDisplayDevices[deviceNum];
     glfwSwapInterval(1);
     gladLoadGLLoader((GLADloadproc) glfwGetProcAddress);
+    logGLDriverInfo();
 
     int w, h;
     glfwGetFramebufferSize(glfwGetCurrentContext(), &w, &h);


### PR DESCRIPTION
A user couldn't boot the mod at all -- no window, no error dialog. Their hook.log ended with:

```
Generating n64 shader with defines:
...
fragment shader: 0(48) : error C1020: invalid operands to "*"
```

Line 48 is `identifying_color()`, which does `index * 0.618033988749895` -- a `uint` times a float literal. GLSL 4.00+ allows that implicit conversion but not every driver front-end does, and when the fragment shader fails to compile `get_or_compile_color_combine_shader()` calls `std::abort()`. So one rejected multiply kills the process before it can draw anything.

`identifying_color()` and the `HSV_to_RGB()` helper it calls were both unreachable -- nothing in the shader or the delta layer referenced either -- so I deleted them instead of adding a cast. Dead code shouldn't be able to take the renderer down.

Second commit adds `[GL] vendor/renderer/version/glsl` to hook.log. Diagnosing this meant guessing at the reporter's GPU from the error format, which we shouldn't have to do again. Logged once, after glad loads.

Verified: full build links clean, and in-game 9 combiner variants compile with 0 shader errors. The reporter confirms the build boots for them now.

Heads up for anyone testing: shaders are read from disk at runtime and the build only deploys dinput.dll, so `assets/shaders/` has to be copied over too or this fix does nothing.