### PR TITLE
fix(renderer): don't kill the game when a shader won't compile

### DIFF
--- a/dinput_hook/n64_shader.cpp
+++ b/dinput_hook/n64_shader.cpp
@@ -165,6 +165,87 @@ void set_render_mode(uint32_t mode) {
 }
 
 
+// Last-resort shader pair, used when the generated combiner shader will not compile. Kept
+// deliberately plain -- GLSL 3.30, no integer math, no combiner defines, no picking -- and built
+// into the DLL rather than read from assets/shaders, so it survives both the driver quirks that
+// reject the generated shader and a missing or stale shader file. Rendering is visibly wrong (no
+// color combiner, no lighting, no fog), but the game boots and stays playable, which is what lets
+// a user reach the options and the log instead of staring at a process that vanished.
+static const char *const kFallbackVertexShader = R"(#version 330 core
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec4 color;
+layout(location = 2) in vec2 uv;
+
+uniform mat4 projMatrix;
+uniform mat4 viewMatrix;
+uniform mat4 modelMatrix;
+uniform vec2 uvOffset;
+uniform vec2 uvScale;
+
+out vec4 passColor;
+out vec2 passUV;
+
+void main() {
+    gl_Position = projMatrix * viewMatrix * modelMatrix * vec4(position, 1);
+    passColor = color;
+    passUV = uv / (uvScale * 4096.0) + uvOffset;
+}
+)";
+
+static const char *const kFallbackFragmentShader = R"(#version 330 core
+in vec4 passColor;
+in vec2 passUV;
+
+uniform sampler2D diffuseTex;
+
+out vec4 color;
+
+void main() {
+    color = texture(diffuseTex, passUV) * passColor;
+}
+)";
+
+// Compiled at most once and shared by every combiner that fails to build.
+static std::optional<GLuint> get_fallback_program() {
+    static std::optional<GLuint> fallback;
+    static bool attempted = false;
+    if (!attempted) {
+        attempted = true;
+        const char *vertex_shader_source = kFallbackVertexShader;
+        const char *fragment_shader_source = kFallbackFragmentShader;
+        fallback = compileProgram(1, &vertex_shader_source, 1, &fragment_shader_source);
+    }
+    return fallback;
+}
+
+// Uniforms the fallback shader doesn't declare resolve to -1, and glUniform* on -1 is a documented
+// no-op, so the draw path needs no special case for it.
+static ColorCombineShader make_color_combine_shader(GLuint program) {
+    return ColorCombineShader{
+        .handle = program,
+        .proj_matrix_pos = glGetUniformLocation(program, "projMatrix"),
+        .view_matrix_pos = glGetUniformLocation(program, "viewMatrix"),
+        .model_matrix_pos = glGetUniformLocation(program, "modelMatrix"),
+        .uv_offset_pos = glGetUniformLocation(program, "uvOffset"),
+        .uv_scale_pos = glGetUniformLocation(program, "uvScale"),
+        .primitive_color_pos = glGetUniformLocation(program, "primitiveColor"),
+        .enable_gouraud_shading_pos = glGetUniformLocation(program, "enableGouraudShading"),
+        .ambient_color_pos = glGetUniformLocation(program, "ambientColor"),
+        .light_color_pos = glGetUniformLocation(program, "lightColor"),
+        .light_dir_pos = glGetUniformLocation(program, "lightDir"),
+        .fog_enabled_pos = glGetUniformLocation(program, "fogEnabled"),
+        .fog_start_pos = glGetUniformLocation(program, "fogStart"),
+        .fog_end_pos = glGetUniformLocation(program, "fogEnd"),
+        .fog_color_pos = glGetUniformLocation(program, "fogColor"),
+        .model_id_pos = glGetUniformLocation(program, "modelId"),
+        .mouse_position_pos = glGetUniformLocation(program, "mousePosition"),
+        .alpha_compare_mode_pos = glGetUniformLocation(program, "alphaCompareMode"),
+        .alpha_is_coverage_pos = glGetUniformLocation(program, "alphaIsCoverage"),
+        .alpha_cutoff_pos = glGetUniformLocation(program, "alphaCutoff"),
+        .alpha_to_coverage_pos = glGetUniformLocation(program, "alphaToCoverage"),
+    };
+}
+
 std::string CombineMode::to_string() const {
     const std::map<uint8_t, const char *> &s = is_alpha ? ac_mode_strings : cc_mode_strings;
     return std::format("({}-{})*{}+{}", s.at(a), s.at(b), s.at(c), s.at(d));
@@ -198,38 +279,27 @@ get_or_compile_color_combine_shader(ImGuiState &state,
 
     const char *fragment_sources[]{"#version 450 core\n", defines.c_str(), fragment_shader_source};
 
-    GLuint program;
-
     std::optional<GLuint> program_opt = compileProgram(
         1, &vertex_shader_source, std::size(fragment_sources), std::data(fragment_sources));
-    if (!program_opt.has_value())
-        std::abort();
-    program = program_opt.value();
+    if (!program_opt.has_value()) {
+        // compileProgram has already logged the driver's message and shown it to the user. Carry on
+        // with the built-in shader instead of killing the process: a wrong-looking game the user can
+        // navigate beats one that never opens a window.
+        fprintf(hook_log, "Combiner shader failed to compile, falling back to the built-in plain "
+                          "shader. Rendering will be incorrect.\n");
+        fflush(hook_log);
 
-    ColorCombineShader shader{
-        .handle = program,
-        .proj_matrix_pos = glGetUniformLocation(program, "projMatrix"),
-        .view_matrix_pos = glGetUniformLocation(program, "viewMatrix"),
-        .model_matrix_pos = glGetUniformLocation(program, "modelMatrix"),
-        .uv_offset_pos = glGetUniformLocation(program, "uvOffset"),
-        .uv_scale_pos = glGetUniformLocation(program, "uvScale"),
-        .primitive_color_pos = glGetUniformLocation(program, "primitiveColor"),
-        .enable_gouraud_shading_pos = glGetUniformLocation(program, "enableGouraudShading"),
-        .ambient_color_pos = glGetUniformLocation(program, "ambientColor"),
-        .light_color_pos = glGetUniformLocation(program, "lightColor"),
-        .light_dir_pos = glGetUniformLocation(program, "lightDir"),
-        .fog_enabled_pos = glGetUniformLocation(program, "fogEnabled"),
-        .fog_start_pos = glGetUniformLocation(program, "fogStart"),
-        .fog_end_pos = glGetUniformLocation(program, "fogEnd"),
-        .fog_color_pos = glGetUniformLocation(program, "fogColor"),
-        .model_id_pos = glGetUniformLocation(program, "modelId"),
-        .mouse_position_pos = glGetUniformLocation(program, "mousePosition"),
-        .alpha_compare_mode_pos = glGetUniformLocation(program, "alphaCompareMode"),
-        .alpha_is_coverage_pos = glGetUniformLocation(program, "alphaIsCoverage"),
-        .alpha_cutoff_pos = glGetUniformLocation(program, "alphaCutoff"),
-        .alpha_to_coverage_pos = glGetUniformLocation(program, "alphaToCoverage"),
-    };
+        program_opt = get_fallback_program();
+        if (!program_opt.has_value()) {
+            // Plain GLSL 3.30 won't compile either, so the context is unusable and there is nothing
+            // left to try. The user has seen the error by now.
+            fprintf(hook_log, "The built-in fallback shader failed to compile too, aborting.\n");
+            fflush(hook_log);
+            std::abort();
+        }
+    }
 
+    const ColorCombineShader shader = make_color_combine_shader(program_opt.value());
     shader_map.insert_or_assign(combiners, shader);
     return shader;
 }

--- a/dinput_hook/shaders_utils.cpp
+++ b/dinput_hook/shaders_utils.cpp
@@ -11,7 +11,39 @@
 #include <sstream>
 #include <cstring>
 
+#include <windows.h>
+
 extern "C" FILE *hook_log;
+
+// How much of the driver's compiler log to put in the modal. Enough to show the offending line and
+// message; the rest stays in hook.log.
+static constexpr size_t kMaxReportedShaderLogChars = 600;
+
+// Shader failures are driver-specific, and every caller treats them as fatal -- but they were also
+// invisible. The process died before a window existed, so the user saw the game fail to start with
+// no dialog and no hint that hook.log held the reason; one report cost a tester days of blaming
+// wrapper and driver settings. Put the driver's own message in front of them. Once only: the first
+// failure is the actionable one, and hook.log has the rest.
+static void reportShaderFailureOnce(const char *stage, const char *compiler_log) {
+    static bool reported = false;
+    if (reported)
+        return;
+    reported = true;
+
+    std::string excerpt(compiler_log ? compiler_log : "(no message from the driver)");
+    if (excerpt.size() > kMaxReportedShaderLogChars) {
+        excerpt.resize(kMaxReportedShaderLogChars);
+        excerpt += "\n[...]";
+    }
+
+    const std::string message =
+        "An OpenGL " + std::string(stage) + " failed to compile on this graphics driver.\n\n" +
+        excerpt +
+        "\n\nThe full message was written to hook.log next to the game executable. Please include "
+        "that file when reporting this.";
+    MessageBoxA(nullptr, message.c_str(), "Star Wars Episode I Racer - shader error",
+                MB_OK | MB_ICONERROR | MB_TOPMOST | MB_SETFOREGROUND);
+}
 
 std::optional<GLuint> compileProgram(GLsizei vertexCount, const GLchar **vertexShaderSource,
                                      GLsizei fragmentCount, const GLchar **fragmentShaderSource) {
@@ -32,6 +64,7 @@ std::optional<GLuint> compileProgram(GLsizei vertexCount, const GLchar **vertexS
         fprintf(hook_log, "vertex shader: %s\n", error.c_str());
         fflush(hook_log);
 
+        reportShaderFailureOnce("vertex shader", error.c_str());
         return std::nullopt;
     }
 
@@ -49,6 +82,7 @@ std::optional<GLuint> compileProgram(GLsizei vertexCount, const GLchar **vertexS
         fprintf(hook_log, "fragment shader: %s\n", error.c_str());
         fflush(hook_log);
 
+        reportShaderFailureOnce("fragment shader", error.c_str());
         return std::nullopt;
     }
 
@@ -66,6 +100,7 @@ std::optional<GLuint> compileProgram(GLsizei vertexCount, const GLchar **vertexS
 
         fprintf(hook_log, "shader linking: %s\n", error.c_str());
         fflush(hook_log);
+        reportShaderFailureOnce("shader program", error.c_str());
         return std::nullopt;
     }
 
@@ -89,7 +124,10 @@ std::string readFileAsString(const char *filepath) {
         }
         fprintf(hook_log, "Cannot open %s. Does the file exist ?\n", filepath);
         fflush(hook_log);
-        std::abort();
+        // Returning empty rather than aborting hands the problem to compileProgram, which reports
+        // it to the user and lets callers that have a fallback keep going. The line above is what
+        // actually names the missing file.
+        return "";
     }
     std::stringstream buffer;
     buffer << stream.rdbuf();


### PR DESCRIPTION
Follow-up to #287. That PR removed the specific shader code a user's driver rejected; this one fixes the reason it was so hard to diagnose.

A shader compile failure currently `abort()`s, and it happens before a window exists. So the user sees the game simply not launch -- no dialog, no window, nothing but a line at the end of hook.log. The reporter in #287 spent days on it, reasonably assuming their wrapper or driver settings were at fault.

Two changes:

**Tell the user.** `compileProgram()` now puts the driver's own compiler message in a modal, once per process. hook.log still gets everything. This covers all seven `abort()` call sites at once, since they all go through `compileProgram`. `readFileAsString()` also aborted when a shader was missing from both disk and the embedded copies -- it returns empty now and lets the same reporting path handle it.

**Keep running.** The combiner shader drives all world geometry, so failing it means no menu either -- and that matters, because the same reporter's *second* problem (forced AA via NVIDIA Inspector) was fixable from the in-game AA slider, which they could only reach because the game booted. So on failure we fall back to a minimal built-in shader pair: GLSL 3.30, no integer math, no combiner defines, compiled from string literals rather than `assets/shaders`, so it survives both a hostile driver and a missing or stale shader file. Compiled once, shared by every combiner that fails.

Rendering in that state is visibly wrong -- no combiner, no lighting, no fog -- and both the modal and hook.log say so. A wrong-looking game the user can navigate beats a process that vanished.

Verified by injecting a compile error into the deployed shader: the modal appears, the fallback compiles once, all 9 combiner variants use it, and the game boots to the intro crawl instead of dying. With the error removed, 12 variants compile and the fallback is never touched.

Not touched: the `abort()`s in `set_render_mode()` for unrecognized blend modes. Different failure class (unexpected game data, not driver behaviour) and worth its own look.