### PR TITLE
Crash logger: stamp the build a report came from

### DIFF
--- a/cmake/GenerateBuildId.cmake
+++ b/cmake/GenerateBuildId.cmake
@@ -1,7 +1,6 @@
-# Regenerates build_id.h with the current git revision. Run at BUILD time (not configure time)
-# so the stamp cannot go stale after a commit. Writes through configure_file, which leaves the
-# file untouched when the contents are unchanged, so this does not force a rebuild every time.
-#
+# Regenerates build_id.h with the current git revision. Runs at BUILD time, not configure time,
+# so the stamp cannot go stale after a commit; configure_file keeps the header byte-identical when
+# nothing changed, so this does not force a rebuild.
 # Expects: SRC_DIR (repo root), IN_FILE (template), OUT_FILE (generated header).
 
 set(SWR_BUILD_COMMIT "unknown")
@@ -32,7 +31,7 @@ if(GIT_FOUND)
         set(SWR_BUILD_BRANCH "${_branch}")
     endif()
 
-    # Uncommitted changes to tracked files: the stamp alone would not describe the binary.
+    # Uncommitted tracked changes: the revision alone no longer describes the binary.
     execute_process(
         COMMAND "${GIT_EXECUTABLE}" diff --quiet HEAD
         WORKING_DIRECTORY "${SRC_DIR}"

--- a/cmake/GenerateBuildId.cmake
+++ b/cmake/GenerateBuildId.cmake
@@ -1,0 +1,46 @@
+# Regenerates build_id.h with the current git revision. Run at BUILD time (not configure time)
+# so the stamp cannot go stale after a commit. Writes through configure_file, which leaves the
+# file untouched when the contents are unchanged, so this does not force a rebuild every time.
+#
+# Expects: SRC_DIR (repo root), IN_FILE (template), OUT_FILE (generated header).
+
+set(SWR_BUILD_COMMIT "unknown")
+set(SWR_BUILD_BRANCH "unknown")
+set(SWR_BUILD_DIRTY 0)
+
+find_package(Git QUIET)
+if(GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
+        WORKING_DIRECTORY "${SRC_DIR}"
+        OUTPUT_VARIABLE _commit
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _commit_result)
+    if(_commit_result EQUAL 0 AND _commit)
+        set(SWR_BUILD_COMMIT "${_commit}")
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" rev-parse --abbrev-ref HEAD
+        WORKING_DIRECTORY "${SRC_DIR}"
+        OUTPUT_VARIABLE _branch
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _branch_result)
+    if(_branch_result EQUAL 0 AND _branch)
+        set(SWR_BUILD_BRANCH "${_branch}")
+    endif()
+
+    # Uncommitted changes to tracked files: the stamp alone would not describe the binary.
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" diff --quiet HEAD
+        WORKING_DIRECTORY "${SRC_DIR}"
+        RESULT_VARIABLE _dirty_result
+        ERROR_QUIET)
+    if(NOT _dirty_result EQUAL 0)
+        set(SWR_BUILD_DIRTY 1)
+    endif()
+endif()
+
+configure_file("${IN_FILE}" "${OUT_FILE}" @ONLY)

--- a/cmake/build_id.h.in
+++ b/cmake/build_id.h.in
@@ -1,0 +1,9 @@
+#pragma once
+
+// Generated at build time by cmake/GenerateBuildId.cmake -- do not edit or commit.
+// Identifies the exact source revision a binary was produced from, so a crash report
+// shared by a player can be tied to a build without guessing.
+
+#define SWR_BUILD_COMMIT "@SWR_BUILD_COMMIT@"
+#define SWR_BUILD_BRANCH "@SWR_BUILD_BRANCH@"
+#define SWR_BUILD_DIRTY @SWR_BUILD_DIRTY@

--- a/cmake/build_id.h.in
+++ b/cmake/build_id.h.in
@@ -1,8 +1,6 @@
 #pragma once
 
 // Generated at build time by cmake/GenerateBuildId.cmake -- do not edit or commit.
-// Identifies the exact source revision a binary was produced from, so a crash report
-// shared by a player can be tied to a build without guessing.
 
 #define SWR_BUILD_COMMIT "@SWR_BUILD_COMMIT@"
 #define SWR_BUILD_BRANCH "@SWR_BUILD_BRANCH@"

--- a/dinput_hook/CMakeLists.txt
+++ b/dinput_hook/CMakeLists.txt
@@ -52,11 +52,7 @@ add_custom_command(
 )
 add_custom_target(generate_embedded_shaders ALL DEPENDS ${EMBEDDED_SHADERS_HEADER})
 
-# Build-identity stamp compiled into the crash logger, so a report shared by a player names the
-# exact build it came from instead of having to be identified by disassembling candidate DLLs.
-# Regenerated on every build (not just at configure time) so the stamp cannot go stale after a
-# commit; the generator writes through configure_file, which leaves the header byte-identical when
-# nothing changed, so this does not force a rebuild.
+# Build-identity stamp compiled into the crash logger (see cmake/GenerateBuildId.cmake).
 set(BUILD_ID_HEADER ${CMAKE_CURRENT_BINARY_DIR}/generated/build_id.h)
 add_custom_target(generate_build_id ALL
     COMMAND ${CMAKE_COMMAND}

--- a/dinput_hook/CMakeLists.txt
+++ b/dinput_hook/CMakeLists.txt
@@ -52,6 +52,23 @@ add_custom_command(
 )
 add_custom_target(generate_embedded_shaders ALL DEPENDS ${EMBEDDED_SHADERS_HEADER})
 
+# Build-identity stamp compiled into the crash logger, so a report shared by a player names the
+# exact build it came from instead of having to be identified by disassembling candidate DLLs.
+# Regenerated on every build (not just at configure time) so the stamp cannot go stale after a
+# commit; the generator writes through configure_file, which leaves the header byte-identical when
+# nothing changed, so this does not force a rebuild.
+set(BUILD_ID_HEADER ${CMAKE_CURRENT_BINARY_DIR}/generated/build_id.h)
+add_custom_target(generate_build_id ALL
+    COMMAND ${CMAKE_COMMAND}
+            -DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/..
+            -DIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/../cmake/build_id.h.in
+            -DOUT_FILE=${BUILD_ID_HEADER}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/GenerateBuildId.cmake
+    BYPRODUCTS ${BUILD_ID_HEADER}
+    COMMENT "Stamping build identity (git revision)"
+    VERBATIM
+)
+
 if (NOT USE_RELEASE_HOOK)
     file(GLOB HOOK_SOURCES *.c *.cpp *.h game_deltas/*.c game_deltas/*.cpp game_deltas/*.h nv_dds/*.h nv_dds/*.cpp)
     add_library(dinput_hook SHARED
@@ -59,7 +76,7 @@ if (NOT USE_RELEASE_HOOK)
         ${EMBEDDED_SHADERS_HEADER}
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/generated/hook_generated.c
     )
-    add_dependencies(dinput_hook generate_embedded_shaders)
+    add_dependencies(dinput_hook generate_embedded_shaders generate_build_id)
     target_include_directories(dinput_hook PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated)
     target_compile_definitions(dinput_hook PRIVATE ENABLE_GLFW_INPUT_HANDLING=0)
     target_compile_definitions(dinput_hook PRIVATE ENABLE_GAMEPAD_NAV=1)

--- a/dinput_hook/crash_logger.cpp
+++ b/dinput_hook/crash_logger.cpp
@@ -7,6 +7,7 @@
 #include <io.h>// _get_osfhandle / _fileno
 
 #include "hook_helper.h"// hook_log
+#include "build_id.h"    // SWR_BUILD_* (generated at build time)
 
 // Render-thread must make progress at least this often once frames start; a longer stall is
 // treated as a hang. Log-only, so a rare false trip during a legitimately long stall just leaves
@@ -73,6 +74,31 @@ static void write_env_line(HANDLE out) {
     write_fmt(out, "  environment: Wine %s on %s %s\n", ver ? ver : "?", sysname, release);
 }
 
+// Stamp which build produced this report. Without it, identifying the binary from a shared report
+// means resolving its DINPUT.dll offsets against candidate DLLs one at a time -- offsets alone are
+// ambiguous, since the same offset can land inside the same function in two different builds.
+// The git revision names the source; the PE timestamp the linker wrote additionally separates two
+// builds of the same commit, and still identifies a binary when git was unavailable at build time
+// (which leaves the revision "unknown").
+static void write_build_line(HANDLE out) {
+    unsigned long pe_stamp = 0;
+    HMODULE self = nullptr;
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           (LPCSTR) &write_build_line, &self) &&
+        self) {
+        const IMAGE_DOS_HEADER *dos = (const IMAGE_DOS_HEADER *) self;
+        if (dos->e_magic == IMAGE_DOS_SIGNATURE) {
+            const IMAGE_NT_HEADERS *nt =
+                (const IMAGE_NT_HEADERS *) ((const char *) self + dos->e_lfanew);
+            if (nt->Signature == IMAGE_NT_SIGNATURE)
+                pe_stamp = nt->FileHeader.TimeDateStamp;
+        }
+    }
+    write_fmt(out, "  build: %s @ %s%s (pe %08lx)\n", SWR_BUILD_BRANCH, SWR_BUILD_COMMIT,
+              SWR_BUILD_DIRTY ? "-dirty" : "", pe_stamp);
+}
+
 static void log_addr(HANDLE out, void *addr) {
     HMODULE mod = nullptr;
     if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
@@ -122,6 +148,7 @@ static void write_exception_report(HANDLE out, const EXCEPTION_RECORD *er, UINT_
     write_fmt(out, "*** unhandled exception: code=0x%08lx addr=%p ***\n", er->ExceptionCode,
               er->ExceptionAddress);
     write_env_line(out);
+    write_build_line(out);
     write_fmt(out, "  last stage: %s\n", g_last_stage);
     if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
         write_fmt(out, "    access %s at %p\n", er->ExceptionInformation[0] ? "write" : "read",
@@ -250,6 +277,7 @@ static void capture_hang(HANDLE thread, const char *kind, const char *headline, 
     if (cf != INVALID_HANDLE_VALUE) {
         write_fmt(cf, headline, seconds);
         write_env_line(cf);
+        write_build_line(cf);
         write_fmt(cf, "  last stage: %s\n", g_last_stage);
         write_fmt(cf, "  frozen instruction:\n");
         log_addr(cf, (void *) (UINT_PTR) ctx.Eip);

--- a/dinput_hook/crash_logger.cpp
+++ b/dinput_hook/crash_logger.cpp
@@ -74,12 +74,9 @@ static void write_env_line(HANDLE out) {
     write_fmt(out, "  environment: Wine %s on %s %s\n", ver ? ver : "?", sysname, release);
 }
 
-// Stamp which build produced this report. Without it, identifying the binary from a shared report
-// means resolving its DINPUT.dll offsets against candidate DLLs one at a time -- offsets alone are
-// ambiguous, since the same offset can land inside the same function in two different builds.
-// The git revision names the source; the PE timestamp the linker wrote additionally separates two
-// builds of the same commit, and still identifies a binary when git was unavailable at build time
-// (which leaves the revision "unknown").
+// Stamp which build produced this report; DINPUT.dll offsets alone are ambiguous across builds.
+// The PE timestamp separates two builds of the same commit, and still identifies a binary when
+// git was unavailable at build time (revision "unknown").
 static void write_build_line(HANDLE out) {
     unsigned long pe_stamp = 0;
     HMODULE self = nullptr;

--- a/dinput_hook/debug_ui.cpp
+++ b/dinput_hook/debug_ui.cpp
@@ -9,6 +9,8 @@
 #include <windows.h>
 #include <imgui.h>
 
+#include "build_id.h"// SWR_BUILD_* (generated at build time)
+
 // show_imgui (the F5 overlay toggle) and settings_ini_path() come from imgui_utils.h.
 
 bool debug_ui_show_dev_panels = false;
@@ -127,6 +129,20 @@ void debug_ui_render() {
         help_marker("F5 shows / hides this overlay.\n"
                     "Turn on 'Developer mode' (bottom) for the dev-only sections.\n"
                     "Type in the filter to find a section by name.");
+
+        // Same build stamp the crash reports carry, so a player can read it off the screen and
+        // quote it without having to reproduce the crash first. Click to copy.
+        static const char *build_text =
+            SWR_BUILD_DIRTY ? (SWR_BUILD_BRANCH " @ " SWR_BUILD_COMMIT "-dirty")
+                            : (SWR_BUILD_BRANCH " @ " SWR_BUILD_COMMIT);
+        ImGui::TextDisabled("build: %s", build_text);
+        if (ImGui::IsItemClicked())
+            ImGui::SetClipboardText(build_text);
+        if (ImGui::BeginItemTooltip()) {
+            ImGui::TextUnformatted("The build this dinput.dll was compiled from -- the same stamp");
+            ImGui::TextUnformatted("written into crash reports. Click to copy.");
+            ImGui::EndTooltip();
+        }
 
         // Rolling FPS sparkline (auto-scaled), most recent sample on the right.
         static float fps_history[120] = {};


### PR DESCRIPTION
Crash and hang reports carry no build identity, so a report shared by a player can only be tied to a binary by resolving its `DINPUT.dll` offsets against candidate DLLs one at a time. That is slow and genuinely ambiguous — the same offset can land inside the same function in two different builds, and telling them apart needs instruction-level disassembly at the reported offset.

Hit this triaging a 2026-08-29 multiplayer session: 20+ reports across three different builds, and working out which report came from which binary took two symbol tables and a disassembly pass before any actual debugging could start.

Adds a `build:` line next to the existing environment line in both report headers:

```
*** unhandled exception: code=0xc0000005 addr=... ***
  environment: native Windows
  build: fix/mp-leave-crashes @ c84840e (pe 68b1c2a3)
  last stage: running (first frame)
```

- The git revision names the source.
- The PE timestamp, written by the linker, additionally separates two builds of the same commit and still identifies a binary when git was unavailable at build time (revision `unknown`).
- A build with uncommitted changes to tracked files is marked `-dirty`, since the revision alone would not describe it.

The stamp is regenerated on every build rather than at configure time so it cannot go stale after a commit; the generator writes through `configure_file`, which leaves the header byte-identical when nothing changed, so this does not force a rebuild. Missing git degrades to `unknown` instead of failing the build.

Split out of #276, where it was written — it is unrelated to the multiplayer fixes and useful on its own.