### PR TITLE
reimpl(swrObjHang): front-end holo-camera family + name its global cluster

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -340,6 +340,7 @@ swrTextFmtString2 0x004c3e48 char[8] = "~f%d%s\0\0"
 DAT_004c4000 0x004c4000 int
 
 maybeUICameraPlacements 0x004C4010 swrUICameraPlacement[40]
+swrObjHang_wattoCounterEyePos 0x004C4558 rdVector3 # base eye position for the jittered Watto-counter framing
 
 drawDistance 0x004c4a5c float
 
@@ -708,7 +709,9 @@ swrObjHang_menuTextPulsePhase 0x0050c8f4 float # selected menu-item text-color p
 swrUI_localPlayersInputDownBitset 0x0050C908 int[4]
 swrUI_localPlayersInputPressedBitset 0x0050C918 int[4]
 
-DAT_0050c930 0x0050c930 int
+swrObjHang_cameraMoveMode 0x0050c930 short # front-end camera transition mode; every access is 16-bit, so 0x0050c932 stays free
+swrObjHang_cameraMoveParity 0x0050c934 int # flips 0<->1 each time a camera move completes
+swrObjHang_cameraMoveActive 0x0050c940 int # a camera move is in flight
 
 swrObjHang_fadeState 0x0050c944 int
 
@@ -1105,13 +1108,12 @@ DAT_00e295d4 0x00e295d4 int
 
 swr_sceneElmos 0x00e29600 swrObjElmo*[151]
 
-rdMatrix44_unk4 0x00e298c0 rdMatrix44
+swrObjHang_sceneCameraEye 0x00e298a0 rdVector3 # eye position swrObjHang_ComputeCameraEye resolves for the scene
+swrObjHang_cameraMatrix 0x00e298c0 rdMatrix44 # front-end camera; .vD is the current eye position
 
 swr_sceneModels 0x00e29900 swrModel_Header*[151]
 
-rdMatrix44_unk8 0x00e29b60 rdMatrix44
-
-rdVector3_unk1 0x00e29b90 rdVector3
+swrObjHang_cameraMatrixTarget 0x00e29b60 rdMatrix44 # .vD is the eye position a camera move ends at
 
 tr_rot1 0x00e29ba0 swrTranslationRotation
 
@@ -1134,15 +1136,13 @@ uiUpgradeInfos2 0x00E2A6C0 swrUIUpgradeInfo[7] // size maybe wrong
 
 DAT_00e2a698 0x00e2a698 int
 
-rdMatrix44_unk3 0x00e2ae80 rdMatrix44
+swrObjHang_cameraMatrixStart 0x00e2ae80 rdMatrix44 # snapshot of swrObjHang_cameraMatrix taken when a move begins
 
 podHandlingData1 0x00e2aec0 PodHandlingData
 
 rdMatrix44_unk7 0x00e2af00 rdMatrix44
-PodHandlingData3 0x00e2af40 PodHandlingData
 
-# rdMatrix44_unk6 0x00e2af60 rdMatrix44 // conflict with above
-DAT_00e2af90 0x00e2af90 rdVector3
+swrObjHang_holoCameraMatrix 0x00e2af60 rdMatrix44 # .vD is the point the front-end camera looks at
 swr_sceneAnimations 0x00e2afa0 swrModel_Animation*[300]
 
 tr_rot3 0x00e2b200 swrTranslationRotation
@@ -1378,9 +1378,9 @@ swrObjHang_someState 0x00ea05a0 swrObjHang_STATE
 
 g_LoadTrackModel 0x00ea05ac INGAME_MODELID
 
-rdMatrix44_unk5 0x00e2b3e0 rdMatrix44
+swrObjHang_holoCameraMatrixStart 0x00e2b3e0 rdMatrix44 # snapshot of swrObjHang_holoCameraMatrix taken when a move begins
 
-rdMatrix44_unk9 0x00e2b440 rdMatrix44
+swrObjHang_holoCameraMatrixTarget 0x00e2b440 rdMatrix44 # .vD is the look-at point a camera move ends at
 
 swrTextEntries1Colors 0x00e2b480 char[128][4]
 

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -118,7 +118,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             hang->mainMenuSelection = 0;
         }
 
-        rdVector_Sub3(&local_6c, (rdVector3 *) &rdMatrix44_unk4.vD, &DAT_00e2af90);
+        rdVector_Sub3(&local_6c, (rdVector3 *) &swrObjHang_cameraMatrix.vD, (rdVector3*) &swrObjHang_holoCameraMatrix.vD);
         fVar9 = rdVector_Len3(&local_6c);
         DAT_0050c11c = (float) fVar9;
         rdVector_Normalize3Acc(&local_6c);
@@ -247,7 +247,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             stdControl_ReadKey(42, 0) != 0 || stdControl_ReadKey(54, 0) != 0) {
             fVar2 = DAT_0050c11c;
             bVar1 = false;
-            DAT_0050c930 = 0;
+            swrObjHang_cameraMoveMode = 0;
             if (DAT_00e98ea0[i] > 0.1f || DAT_00e98ea0[i] < -0.1) {
                 bVar1 = true;
                 gamma_unk = gamma_unk - DAT_00e98ea0[iVar6] * swrRace_fdeltaTimeSecs * 105.0;
@@ -264,14 +264,14 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             }
             if (bVar1) {
                 rdMatrix_SetRotation44(&local_40, gamma_unk, alpha_unk, 0);
-                rdVector_Scale3Add3((rdVector3 *) &DAT_00e2af90, (rdVector3 *) &rdMatrix44_unk4.vD,
+                rdVector_Scale3Add3((rdVector3*) &swrObjHang_holoCameraMatrix.vD, (rdVector3 *) &swrObjHang_cameraMatrix.vD,
                                     -DAT_0050c11c, (rdVector3 *) &local_40.vB);
                 if (DAT_0050c11c != fVar2) {
-                    fVar9 = rdVector_Dist3((rdVector3 *) &rdMatrix44_unk4.vD,
-                                           (rdVector3 *) &DAT_00e2af90);
+                    fVar9 = rdVector_Dist3((rdVector3 *) &swrObjHang_cameraMatrix.vD,
+                                           (rdVector3*) &swrObjHang_holoCameraMatrix.vD);
                     DAT_0050c11c = (float) fVar9;
                 }
-                rdMatrix_Copy44(&rdMatrix44_unk3, &rdMatrix44_unk4);
+                rdMatrix_Copy44(&swrObjHang_cameraMatrixStart, &swrObjHang_cameraMatrix);
             }
         }
         if (swrControl_cancelPressedEdge != 0) {

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -2633,3 +2633,165 @@ void swrCam_CamState_InitMainMat4(uint16_t index, uint16_t val1, rdMatrix44* mat
     unkCameraArray[entry].behaviorType = val1;
     unkCameraArray[entry].matrixSource = mat;
 }
+
+// Cosine ease driving the front-end camera moves: 0 at t == 0, `period` at t == period.
+// 0x0045a420
+float swrObjHang_EaseSine_Maybe(float t, float period) {
+    float sine;
+    // The original passes its own `t` slot as the cosine out-param and reads it back.
+    stdMath_SinCos((t / period) * 180.0f, &sine, &t);
+    return (1.0f - t) * 0.5f * period;
+}
+
+// 0x00440b50
+int swrObjHang_IsCameraMoving(swrObjHang* hang)
+{
+    const swrUICameraPlacement* place = &maybeUICameraPlacements[hang->cameraState];
+
+    if (rdVector_AreSame3((rdVector3*)&place->position2, (rdVector3*)&swrObjHang_holoCameraMatrix.vD) && rdVector_AreSame3((rdVector3*)&place->position2, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD) && rdVector_AreSame3((rdVector3*)&place->position1, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD)) {
+        return 0;
+    }
+    return 1;
+}
+
+// Point the camera-facing billboard rotation at the current look-at, keeping the eye position.
+// 0x0043e210
+void swrObjHang_UpdateHoloBillboardMatrix(void)
+{
+    float yaw;
+    float pitch;
+    rdVector3 dir;
+    rdVector3 eye;
+
+    rdVector_Copy3(&eye, (rdVector3*)&swrObjHang_cameraMatrix.vD);
+    rdVector_Sub3(&dir, (rdVector3*)&swrObjHang_holoCameraMatrix.vD, (rdVector3*)&swrObjHang_cameraMatrix.vD);
+    rdVector_Normalize3Acc(&dir);
+    yaw = stdMath_ArcTan2(-dir.x, dir.y);
+    pitch = stdMath_ArcSin(dir.z);
+    // Wrap yaw into [0, 360] and pitch into [-90, 90]; this family works in degrees.
+    if (yaw < 0.0f)
+        yaw = yaw + 360.0f;
+    if (360.0f < yaw)
+        yaw = yaw - 360.0f;
+    if (pitch < -90.0f)
+        pitch = pitch + 180.0f;
+    if (90.0f < pitch)
+        pitch = pitch - 180.0f;
+    rdMatrix_SetRotation44(&swrObjHang_cameraMatrix, yaw, pitch, 0.0f);
+    rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrix.vD, &eye);
+}
+
+// 0x0045c010
+void swrObjHang_SetHoloCameraTarget(rdVector3* pos, rdVector3* lookAt, short mode, int keepEyeOffset, int reset)
+{
+    rdVector3 eyeToLookAt;
+
+    if (reset == 0) {
+        rdMatrix_Copy44(&swrObjHang_holoCameraMatrixStart, &swrObjHang_holoCameraMatrix);
+        rdMatrix_Copy44(&swrObjHang_cameraMatrixStart, &swrObjHang_cameraMatrix);
+    }
+    rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, pos);
+    rdVector_Copy3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, lookAt);
+    swrObjHang_cameraMoveMode = mode;
+    if (mode == 3 && keepEyeOffset != 0) {
+        // Put the target eye the same offset from the target look-at as it is from the current one.
+        rdVector_Sub3(&eyeToLookAt, (rdVector3*)&swrObjHang_cameraMatrix.vD, (rdVector3*)&swrObjHang_holoCameraMatrix.vD);
+        rdVector_Add3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, &eyeToLookAt);
+    }
+}
+
+// 0x0045c9d0
+void swrObjHang_BeginCameraMove(swrObjHang* hang, int mode)
+{
+    rdVector3 lookAtToEye;
+    rdVector3 delta;
+    float jitterScale;
+
+    if (mode == 0) {
+        rdVector_Copy3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position2);
+        rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position1);
+    } else {
+        if (swrObjHang_state2 != (swrObjHang_STATE)~swrObjHang_STATE_LEGAL) {
+            rdVector_Sub3(&lookAtToEye, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD);
+            rdVector_Scale3Add3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, 10.0f, &lookAtToEye);
+        }
+        rdVector_Scale3Add3_both((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, 0.3333f, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD, 0.6667f, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD);
+        if (hang->cameraState == HangCameraState_CounterBuyParts) {
+            // The buy-parts counter is framed from a jittered eye so the shot differs each visit.
+            // swrUtils_Rand returns a positive 31-bit value; 1/2^31 maps it to [0, 1).
+            rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, &swrObjHang_wattoCounterEyePos);
+            jitterScale = swrUtils_RandFloat();
+            swrObjHang_cameraMatrixTarget.vD.x = ((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 10.0f + 180.0f) * jitterScale + swrObjHang_cameraMatrixTarget.vD.x;
+            swrObjHang_cameraMatrixTarget.vD.y = ((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 125.0f - 375.0f) + swrObjHang_cameraMatrixTarget.vD.y;
+            swrObjHang_cameraMatrixTarget.vD.z = (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 30.0f + 40.0f;
+            rdVector_Copy3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, &swrObjHang_wattoCounterEyePos);
+            rdVector_Sub3(&delta, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD);
+            rdVector_Add3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, &delta);
+        }
+    }
+    swrObjHang_cameraMoveMode = 1;
+    swrObjHang_cameraMoveActive = 1;
+}
+
+// Resolve this frame's scene-camera eye, then override its height for the current room.
+// 0x0045cb80
+void swrObjHang_ComputeCameraEye(swrObjHang* hang, int mode)
+{
+    rdVector3 eye;
+    rdVector3 up;
+    rdVector3 side;
+    rdVector3 forward;
+    rdVector3 from;
+    rdVector3 to;
+    rdVector3* a;
+    rdVector3* b;
+    const rdVector3* eyeSrc;
+
+    up.x = 0.0f;
+    up.y = 0.0f;
+    up.z = 1.0f;
+    rdVector_Copy3(&from, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position1);
+    rdVector_Copy3(&to, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position2);
+
+    if (hang->cameraState == HangCameraState_CantinaHolotableFar) {
+        eyeSrc = (rdVector3*)&maybeUICameraPlacements[HangCameraState_CantinaHolotableFar].position1;
+    } else if (hang->menuScreen == swrObjHang_STATE_LOOK_AT_VEHICLE) {
+        eyeSrc = (rdVector3*)&maybeUICameraPlacements[HangCameraState_InspectCharacter].position2;
+    } else if (swrObjHang_cameraMoveParity == 0 || mode != 0 || hang->menuScreen != swrObjHang_STATE_WATTO || (swrObjHang_cameraMoveMode != 0 && swrObjHang_cameraMoveMode != 5)) {
+        // Offset the eye off the from->to line: 3 parts along it to 1 part sideways, scaled x60.
+        rdVector_Sub3(&forward, &to, &from);
+        if (mode == 0) {
+            b = &forward;
+            a = &up;
+        } else {
+            b = &up;
+            a = &forward;
+        }
+        rdVector_Cross3(&side, a, b);
+        rdVector_Normalize3Acc(&side);
+        rdVector_Normalize3Acc(&forward);
+        rdVector_Scale3(&forward, 3.0f, &forward);
+        rdVector_Add3(&eye, &forward, &side);
+        rdVector_Scale3(&eye, 60.0f, &eye);
+        rdVector_Add3(&eye, &from, &eye);
+        eyeSrc = &eye;
+    } else {
+        eyeSrc = &to;
+    }
+    rdVector_Copy3(&swrObjHang_sceneCameraEye, eyeSrc);
+
+    switch (hang->room) {
+    case Shop:
+    case Cantina:
+        swrObjHang_sceneCameraEye.z = -60.0f;
+        break;
+    case Junkyard:
+        swrObjHang_sceneCameraEye.z = -145.0f;
+        break;
+    case Hangar:
+        swrObjHang_sceneCameraEye.z = -157.0f;
+        break;
+    default:
+        break;
+    }
+}

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -513,7 +513,7 @@ void swrObjHang_ShowPartNodes(swrObjHang* hang);
 // Unload/clear the front-end scene's model nodes and clear scene animations.
 void swrModel_clearSceneModelsAndChildren(void);
 // Set the target position/look-at (and transition mode) for the holo-scene camera move.
-void swrObjHang_SetHoloCameraTarget(rdVector3* pos, rdVector3* lookAt, short mode, int param_4, int reset);
+void swrObjHang_SetHoloCameraTarget(rdVector3* pos, rdVector3* lookAt, short mode, int keepEyeOffset, int reset);
 // Compute a holo-scene camera target for a scene element (jittered one-shot framing, or a direct
 // snap) and feed it to swrObjHang_SetHoloCameraTarget.
 void swrObjHang_AimHoloCamera(swrObjHang* hang, int param_2, int param_3);

--- a/src/types.h
+++ b/src/types.h
@@ -3247,14 +3247,14 @@ extern "C"
         uint8_t unk[16]; // 0x28
     };
 
-    // actual usage of this struct unclear, maybe camera positions on junkyard
-    struct swrUICameraPlacement
+    // One front-end camera framing, indexed by swrObjHang.cameraState out of maybeUICameraPlacements.
+    typedef struct swrUICameraPlacement
     {
-        rdVector3 position1; // 0x0
-        rdVector3 position2; // 0xc
+        rdVector3 position1; // 0x0  eye
+        rdVector3 position2; // 0xc  look-at
         uint32_t unk1; // 0x18
         uint32_t unk2; // 0x1c
-    };
+    } swrUICameraPlacement; // sizeof(0x20)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Reimplements the six functions that drive the hangar / galaxy-map camera, and names the globals they share.

| fn | addr |
|---|---|
| `swrObjHang_EaseSine_Maybe` | `0x0045a420` |
| `swrObjHang_IsCameraMoving` | `0x00440b50` |
| `swrObjHang_UpdateHoloBillboardMatrix` | `0x0043e210` |
| `swrObjHang_SetHoloCameraTarget` | `0x0045c010` |
| `swrObjHang_BeginCameraMove` | `0x0045c9d0` |
| `swrObjHang_ComputeCameraEye` | `0x0045cb80` |

### The globals are two parallel matrix triples

Not a loose cluster -- one triple for the eye, one for the look-at, each with the current value, the snapshot taken when a move begins, and the value the move ends at. `swrObjHang_LerpHoloCamera` interpolates current from start toward target on both rows, which is what pins the roles:

| role | eye | look-at |
|---|---|---|
| current | `cameraMatrix` `0xe298c0` | `holoCameraMatrix` `0xe2af60` |
| move start | `cameraMatrixStart` `0xe2ae80` | `holoCameraMatrixStart` `0xe2b3e0` |
| move target | `cameraMatrixTarget` `0xe29b60` | `holoCameraMatrixTarget` `0xe2b440` |

### Three symbols were mis-symbolized views into those triples

- **`PodHandlingData3` `0xe2af40` is spurious.** `PodHandlingData` is `0x3c` bytes, and its only reader -- `&PodHandlingData3.heatRate`, at `+0x20` -- lands on `0xe2af60`, which is the `rdMatrix44_unk6` that was sitting commented out in `data_symbols.syms` with a `// conflict with above` note. So the conflict is resolved rather than skirted, and a `rdMatrix_Copy44` that was reading 0x40 bytes out of a 0x3c-byte struct now has a real symbol.
- `rdVector3_unk1` `0xe29b90` is `cameraMatrixTarget.vD` (`0xe29b60 + 0x30`).
- `DAT_00e2af90` is `holoCameraMatrix.vD` (`0xe2af60 + 0x30`).

Also named `swrObjHang_cameraMoveMode` / `Parity` / `Active`, `swrObjHang_sceneCameraEye`, `swrObjHang_wattoCounterEyePos`.

### Two things worth a look

**`cameraMoveMode` `0x0050c930` is typed `short`, not `int`.** Every access in the binary is 16-bit -- reads are cast to short, writes store only the low half -- so `int` would make a faithful write impossible and would falsely claim `0x0050c932`.

**`swrUICameraPlacement` had no typedef**, so the generated `globals.h` accessor for `maybeUICameraPlacements` would not compile from C. Typedef'd it and documented `position1`/`position2` as eye/look-at.

`tracks_delta.c` referenced four of the renamed globals and is updated to match.

### Notes

The family works in degrees (`stdMath_SinCos` takes `angle_degrees`), which is what the +-90 / +-180 / +-360 wrap constants in `UpdateHoloBillboardMatrix` are. The `1.0f / 2147483648.0f` literals are the exact bit pattern of the `0x30000000` the binary uses to map `swrUtils_Rand` onto `[0, 1)`.

The camera transition-mode ids (`mode == 3`, `cameraMoveMode != 5`) are left as literals -- I only see 0/1/3/5 used and did not want to invent enum names for values I have not actually pinned down.

Builds and links clean; hook-annotation, header-dup and data-symbol-dup checks all pass. Burndown goes 889 -> 895 fully reimplemented.

Heads-up: your Ghidra DB still has these globals under the `rdMatrix44_unk*` / `DAT_` names, so it will disagree with the branch until `importDataSymbols.py` runs.
