### PR TITLE
reimpl(swrObjHang): the front-end camera move engine

### DIFF
--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -340,6 +340,7 @@ swrTextFmtString2 0x004c3e48 char[8] = "~f%d%s\0\0"
 DAT_004c4000 0x004c4000 int
 
 maybeUICameraPlacements 0x004C4010 swrUICameraPlacement[40]
+swrObjHang_wattoCounterEyePos 0x004C4558 rdVector3 # base eye position for the jittered Watto-counter framing
 
 drawDistance 0x004c4a5c float
 
@@ -708,7 +709,9 @@ swrObjHang_menuTextPulsePhase 0x0050c8f4 float # selected menu-item text-color p
 swrUI_localPlayersInputDownBitset 0x0050C908 int[4]
 swrUI_localPlayersInputPressedBitset 0x0050C918 int[4]
 
-DAT_0050c930 0x0050c930 int
+swrObjHang_cameraMoveMode 0x0050c930 short # front-end camera transition mode; every access is 16-bit, so 0x0050c932 stays free
+swrObjHang_cameraMoveParity 0x0050c934 int # flips 0<->1 each time a camera move completes
+swrObjHang_cameraMoveActive 0x0050c940 int # a camera move is in flight
 
 swrObjHang_fadeState 0x0050c944 int
 
@@ -1105,13 +1108,12 @@ DAT_00e295d4 0x00e295d4 int
 
 swr_sceneElmos 0x00e29600 swrObjElmo*[151]
 
-rdMatrix44_unk4 0x00e298c0 rdMatrix44
+swrObjHang_sceneCameraEye 0x00e298a0 rdVector3 # eye position swrObjHang_ComputeCameraEye resolves for the scene
+swrObjHang_cameraMatrix 0x00e298c0 rdMatrix44 # front-end camera; .vD is the current eye position
 
 swr_sceneModels 0x00e29900 swrModel_Header*[151]
 
-rdMatrix44_unk8 0x00e29b60 rdMatrix44
-
-rdVector3_unk1 0x00e29b90 rdVector3
+swrObjHang_cameraMatrixTarget 0x00e29b60 rdMatrix44 # .vD is the eye position a camera move ends at
 
 tr_rot1 0x00e29ba0 swrTranslationRotation
 
@@ -1134,15 +1136,13 @@ uiUpgradeInfos2 0x00E2A6C0 swrUIUpgradeInfo[7] // size maybe wrong
 
 DAT_00e2a698 0x00e2a698 int
 
-rdMatrix44_unk3 0x00e2ae80 rdMatrix44
+swrObjHang_cameraMatrixStart 0x00e2ae80 rdMatrix44 # snapshot of swrObjHang_cameraMatrix taken when a move begins
 
 podHandlingData1 0x00e2aec0 PodHandlingData
 
 rdMatrix44_unk7 0x00e2af00 rdMatrix44
-PodHandlingData3 0x00e2af40 PodHandlingData
 
-# rdMatrix44_unk6 0x00e2af60 rdMatrix44 // conflict with above
-DAT_00e2af90 0x00e2af90 rdVector3
+swrObjHang_holoCameraMatrix 0x00e2af60 rdMatrix44 # .vD is the point the front-end camera looks at
 swr_sceneAnimations 0x00e2afa0 swrModel_Animation*[300]
 
 tr_rot3 0x00e2b200 swrTranslationRotation
@@ -1378,9 +1378,9 @@ swrObjHang_someState 0x00ea05a0 swrObjHang_STATE
 
 g_LoadTrackModel 0x00ea05ac INGAME_MODELID
 
-rdMatrix44_unk5 0x00e2b3e0 rdMatrix44
+swrObjHang_holoCameraMatrixStart 0x00e2b3e0 rdMatrix44 # snapshot of swrObjHang_holoCameraMatrix taken when a move begins
 
-rdMatrix44_unk9 0x00e2b440 rdMatrix44
+swrObjHang_holoCameraMatrixTarget 0x00e2b440 rdMatrix44 # .vD is the look-at point a camera move ends at
 
 swrTextEntries1Colors 0x00e2b480 char[128][4]
 

--- a/data_symbols.syms
+++ b/data_symbols.syms
@@ -338,6 +338,8 @@ rdMatrix_unk2 0x004c3d78 rdMatrix44 = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0
 swrTextFmtString2 0x004c3e48 char[8] = "~f%d%s\0\0"
 
 DAT_004c4000 0x004c4000 int
+swrObjHang_cameraLerpNeedsInit 0x004c4004 int # swrObjHang_LerpHoloCamera: recompute the move deltas and restart the clock
+swrObjHang_cameraMoveSettled 0x004c400c char # set when a camera move settles; swrObjHang_UpdateIdleCamera consumes it
 
 maybeUICameraPlacements 0x004C4010 swrUICameraPlacement[40]
 swrObjHang_wattoCounterEyePos 0x004C4558 rdVector3 # base eye position for the jittered Watto-counter framing
@@ -621,6 +623,7 @@ DAT_0050c308 0x0050c308 char[12]
 
 g_objHang2 0x0050c454 swrObjHang*
 DAT_0050c458 0x0050c458 int
+swrObjHang_screenTransitionDir 0x0050c468 int # nonzero while a screen slide animates; sign is the slide direction
 
 DAT_0050c430 0x0050c430 char[1]
 
@@ -704,6 +707,17 @@ swrEvent_f0SkipMask 0x0050c87c int
 swrEvent_lastManager 0x0050c880 swrEventManager*
 
 debug_showSurfaceFlags 0x0050c88c int
+
+# swrObjHang_LerpHoloCamera move state. The six deltas are individual interleaved floats, not two
+# rdVector3s: look-at uses 8b4/8c4/8e4 and eye uses 8b8/8b0/8bc.
+swrObjHang_cameraMoveEyeDeltaY 0x0050c8b0 float
+swrObjHang_cameraMoveLookAtDeltaX 0x0050c8b4 float
+swrObjHang_cameraMoveEyeDeltaX 0x0050c8b8 float
+swrObjHang_cameraMoveEyeDeltaZ 0x0050c8bc float
+swrObjHang_cameraMoveDuration 0x0050c8c0 float # seconds the current move takes
+swrObjHang_cameraMoveLookAtDeltaY 0x0050c8c4 float
+swrObjHang_cameraMoveElapsed 0x0050c8e0 float # seconds into the current move
+swrObjHang_cameraMoveLookAtDeltaZ 0x0050c8e4 float
 swrObjHang_menuTextPulsePhase 0x0050c8f4 float # selected menu-item text-color pulse phase (degrees after *360, fed to SinCos)
 
 swrUI_localPlayersInputDownBitset 0x0050C908 int[4]
@@ -714,6 +728,12 @@ swrObjHang_cameraMoveParity 0x0050c934 int # flips 0<->1 each time a camera move
 swrObjHang_cameraMoveActive 0x0050c940 int # a camera move is in flight
 
 swrObjHang_fadeState 0x0050c944 int
+
+swrObjHang_inspectCameraTimer 0x0050c95c float # >= 5.0 slows the look-at-vehicle camera step
+swrObjHang_cameraStepEyeSpeed 0x0050c990 float # swrObjHang_StepCameraToward carry for the eye
+swrObjHang_cameraStepLookAtSpeed 0x0050c994 float # ... and for the look-at
+swrObjHang_cameraLookAtTargetCached 0x0050c998 rdVector3 # last look-at target, to detect a retarget
+swrObjHang_cameraStepScratch 0x0050c9a4 int # swrObjHang_StepCameraToward zeroes this; nothing in the binary reads it
 
 someUI 0x0050c968 swrUI_unk*
 

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -118,7 +118,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             hang->mainMenuSelection = 0;
         }
 
-        rdVector_Sub3(&local_6c, (rdVector3 *) &rdMatrix44_unk4.vD, &DAT_00e2af90);
+        rdVector_Sub3(&local_6c, (rdVector3 *) &swrObjHang_cameraMatrix.vD, (rdVector3*) &swrObjHang_holoCameraMatrix.vD);
         fVar9 = rdVector_Len3(&local_6c);
         DAT_0050c11c = (float) fVar9;
         rdVector_Normalize3Acc(&local_6c);
@@ -247,7 +247,7 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             stdControl_ReadKey(42, 0) != 0 || stdControl_ReadKey(54, 0) != 0) {
             fVar2 = DAT_0050c11c;
             bVar1 = false;
-            DAT_0050c930 = 0;
+            swrObjHang_cameraMoveMode = 0;
             if (DAT_00e98ea0[i] > 0.1f || DAT_00e98ea0[i] < -0.1) {
                 bVar1 = true;
                 gamma_unk = gamma_unk - DAT_00e98ea0[iVar6] * swrRace_fdeltaTimeSecs * 105.0;
@@ -264,14 +264,14 @@ void swrRace_MainMenu_delta(swrObjHang *hang) {
             }
             if (bVar1) {
                 rdMatrix_SetRotation44(&local_40, gamma_unk, alpha_unk, 0);
-                rdVector_Scale3Add3((rdVector3 *) &DAT_00e2af90, (rdVector3 *) &rdMatrix44_unk4.vD,
+                rdVector_Scale3Add3((rdVector3*) &swrObjHang_holoCameraMatrix.vD, (rdVector3 *) &swrObjHang_cameraMatrix.vD,
                                     -DAT_0050c11c, (rdVector3 *) &local_40.vB);
                 if (DAT_0050c11c != fVar2) {
-                    fVar9 = rdVector_Dist3((rdVector3 *) &rdMatrix44_unk4.vD,
-                                           (rdVector3 *) &DAT_00e2af90);
+                    fVar9 = rdVector_Dist3((rdVector3 *) &swrObjHang_cameraMatrix.vD,
+                                           (rdVector3*) &swrObjHang_holoCameraMatrix.vD);
                     DAT_0050c11c = (float) fVar9;
                 }
-                rdMatrix_Copy44(&rdMatrix44_unk3, &rdMatrix44_unk4);
+                rdMatrix_Copy44(&swrObjHang_cameraMatrixStart, &swrObjHang_cameraMatrix);
             }
         }
         if (swrControl_cancelPressedEdge != 0) {

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -2633,3 +2633,165 @@ void swrCam_CamState_InitMainMat4(uint16_t index, uint16_t val1, rdMatrix44* mat
     unkCameraArray[entry].behaviorType = val1;
     unkCameraArray[entry].matrixSource = mat;
 }
+
+// Cosine ease driving the front-end camera moves: 0 at t == 0, `period` at t == period.
+// 0x0045a420
+float swrObjHang_EaseSine_Maybe(float t, float period) {
+    float sine;
+    // The original passes its own `t` slot as the cosine out-param and reads it back.
+    stdMath_SinCos((t / period) * 180.0f, &sine, &t);
+    return (1.0f - t) * 0.5f * period;
+}
+
+// 0x00440b50
+int swrObjHang_IsCameraMoving(swrObjHang* hang)
+{
+    const swrUICameraPlacement* place = &maybeUICameraPlacements[hang->cameraState];
+
+    if (rdVector_AreSame3((rdVector3*)&place->position2, (rdVector3*)&swrObjHang_holoCameraMatrix.vD) && rdVector_AreSame3((rdVector3*)&place->position2, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD) && rdVector_AreSame3((rdVector3*)&place->position1, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD)) {
+        return 0;
+    }
+    return 1;
+}
+
+// Point the camera-facing billboard rotation at the current look-at, keeping the eye position.
+// 0x0043e210
+void swrObjHang_UpdateHoloBillboardMatrix(void)
+{
+    float yaw;
+    float pitch;
+    rdVector3 dir;
+    rdVector3 eye;
+
+    rdVector_Copy3(&eye, (rdVector3*)&swrObjHang_cameraMatrix.vD);
+    rdVector_Sub3(&dir, (rdVector3*)&swrObjHang_holoCameraMatrix.vD, (rdVector3*)&swrObjHang_cameraMatrix.vD);
+    rdVector_Normalize3Acc(&dir);
+    yaw = stdMath_ArcTan2(-dir.x, dir.y);
+    pitch = stdMath_ArcSin(dir.z);
+    // Wrap yaw into [0, 360] and pitch into [-90, 90]; this family works in degrees.
+    if (yaw < 0.0f)
+        yaw = yaw + 360.0f;
+    if (360.0f < yaw)
+        yaw = yaw - 360.0f;
+    if (pitch < -90.0f)
+        pitch = pitch + 180.0f;
+    if (90.0f < pitch)
+        pitch = pitch - 180.0f;
+    rdMatrix_SetRotation44(&swrObjHang_cameraMatrix, yaw, pitch, 0.0f);
+    rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrix.vD, &eye);
+}
+
+// 0x0045c010
+void swrObjHang_SetHoloCameraTarget(rdVector3* pos, rdVector3* lookAt, short mode, int keepEyeOffset, int reset)
+{
+    rdVector3 eyeToLookAt;
+
+    if (reset == 0) {
+        rdMatrix_Copy44(&swrObjHang_holoCameraMatrixStart, &swrObjHang_holoCameraMatrix);
+        rdMatrix_Copy44(&swrObjHang_cameraMatrixStart, &swrObjHang_cameraMatrix);
+    }
+    rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, pos);
+    rdVector_Copy3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, lookAt);
+    swrObjHang_cameraMoveMode = mode;
+    if (mode == 3 && keepEyeOffset != 0) {
+        // Put the target eye the same offset from the target look-at as it is from the current one.
+        rdVector_Sub3(&eyeToLookAt, (rdVector3*)&swrObjHang_cameraMatrix.vD, (rdVector3*)&swrObjHang_holoCameraMatrix.vD);
+        rdVector_Add3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, &eyeToLookAt);
+    }
+}
+
+// 0x0045c9d0
+void swrObjHang_BeginCameraMove(swrObjHang* hang, int mode)
+{
+    rdVector3 lookAtToEye;
+    rdVector3 delta;
+    float jitterScale;
+
+    if (mode == 0) {
+        rdVector_Copy3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position2);
+        rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position1);
+    } else {
+        if (swrObjHang_state2 != (swrObjHang_STATE)~swrObjHang_STATE_LEGAL) {
+            rdVector_Sub3(&lookAtToEye, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD);
+            rdVector_Scale3Add3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, 10.0f, &lookAtToEye);
+        }
+        rdVector_Scale3Add3_both((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, 0.3333f, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD, 0.6667f, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD);
+        if (hang->cameraState == HangCameraState_CounterBuyParts) {
+            // The buy-parts counter is framed from a jittered eye so the shot differs each visit.
+            // swrUtils_Rand returns a positive 31-bit value; 1/2^31 maps it to [0, 1).
+            rdVector_Copy3((rdVector3*)&swrObjHang_cameraMatrixTarget.vD, &swrObjHang_wattoCounterEyePos);
+            jitterScale = swrUtils_RandFloat();
+            swrObjHang_cameraMatrixTarget.vD.x = ((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 10.0f + 180.0f) * jitterScale + swrObjHang_cameraMatrixTarget.vD.x;
+            swrObjHang_cameraMatrixTarget.vD.y = ((float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 125.0f - 375.0f) + swrObjHang_cameraMatrixTarget.vD.y;
+            swrObjHang_cameraMatrixTarget.vD.z = (float)swrUtils_Rand() * (1.0f / 2147483648.0f) * 30.0f + 40.0f;
+            rdVector_Copy3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, &swrObjHang_wattoCounterEyePos);
+            rdVector_Sub3(&delta, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD);
+            rdVector_Add3((rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, &delta);
+        }
+    }
+    swrObjHang_cameraMoveMode = 1;
+    swrObjHang_cameraMoveActive = 1;
+}
+
+// Resolve this frame's scene-camera eye, then override its height for the current room.
+// 0x0045cb80
+void swrObjHang_ComputeCameraEye(swrObjHang* hang, int mode)
+{
+    rdVector3 eye;
+    rdVector3 up;
+    rdVector3 side;
+    rdVector3 forward;
+    rdVector3 from;
+    rdVector3 to;
+    rdVector3* a;
+    rdVector3* b;
+    const rdVector3* eyeSrc;
+
+    up.x = 0.0f;
+    up.y = 0.0f;
+    up.z = 1.0f;
+    rdVector_Copy3(&from, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position1);
+    rdVector_Copy3(&to, (rdVector3*)&maybeUICameraPlacements[hang->cameraState].position2);
+
+    if (hang->cameraState == HangCameraState_CantinaHolotableFar) {
+        eyeSrc = (rdVector3*)&maybeUICameraPlacements[HangCameraState_CantinaHolotableFar].position1;
+    } else if (hang->menuScreen == swrObjHang_STATE_LOOK_AT_VEHICLE) {
+        eyeSrc = (rdVector3*)&maybeUICameraPlacements[HangCameraState_InspectCharacter].position2;
+    } else if (swrObjHang_cameraMoveParity == 0 || mode != 0 || hang->menuScreen != swrObjHang_STATE_WATTO || (swrObjHang_cameraMoveMode != 0 && swrObjHang_cameraMoveMode != 5)) {
+        // Offset the eye off the from->to line: 3 parts along it to 1 part sideways, scaled x60.
+        rdVector_Sub3(&forward, &to, &from);
+        if (mode == 0) {
+            b = &forward;
+            a = &up;
+        } else {
+            b = &up;
+            a = &forward;
+        }
+        rdVector_Cross3(&side, a, b);
+        rdVector_Normalize3Acc(&side);
+        rdVector_Normalize3Acc(&forward);
+        rdVector_Scale3(&forward, 3.0f, &forward);
+        rdVector_Add3(&eye, &forward, &side);
+        rdVector_Scale3(&eye, 60.0f, &eye);
+        rdVector_Add3(&eye, &from, &eye);
+        eyeSrc = &eye;
+    } else {
+        eyeSrc = &to;
+    }
+    rdVector_Copy3(&swrObjHang_sceneCameraEye, eyeSrc);
+
+    switch (hang->room) {
+    case Shop:
+    case Cantina:
+        swrObjHang_sceneCameraEye.z = -60.0f;
+        break;
+    case Junkyard:
+        swrObjHang_sceneCameraEye.z = -145.0f;
+        break;
+    case Hangar:
+        swrObjHang_sceneCameraEye.z = -157.0f;
+        break;
+    default:
+        break;
+    }
+}

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -2795,3 +2795,188 @@ void swrObjHang_ComputeCameraEye(swrObjHang* hang, int mode)
         break;
     }
 }
+
+// Duration-based camera move: eases the eye and look-at from their move-start snapshots to their
+// targets over swrObjHang_cameraMoveDuration seconds.
+// 0x0045c0b0
+void swrObjHang_LerpHoloCamera(swrObjHang* hang)
+{
+    float t;
+    rdVector3 lookAt;
+    rdVector3 eye;
+
+    rdVector_Copy3(&eye, (rdVector3*)&swrObjHang_cameraMatrix.vD);
+    rdVector_Copy3(&lookAt, (rdVector3*)&swrObjHang_holoCameraMatrix.vD);
+    if (swrObjHang_cameraLerpNeedsInit != 0) {
+        swrObjHang_cameraMoveLookAtDeltaX = swrObjHang_holoCameraMatrixTarget.vD.x - swrObjHang_holoCameraMatrixStart.vD.x;
+        swrObjHang_cameraMoveLookAtDeltaY = swrObjHang_holoCameraMatrixTarget.vD.y - swrObjHang_holoCameraMatrixStart.vD.y;
+        swrObjHang_cameraMoveLookAtDeltaZ = swrObjHang_holoCameraMatrixTarget.vD.z - swrObjHang_holoCameraMatrixStart.vD.z;
+        swrObjHang_cameraMoveEyeDeltaX = swrObjHang_cameraMatrixTarget.vD.x - swrObjHang_cameraMatrixStart.vD.x;
+        swrObjHang_cameraMoveEyeDeltaY = swrObjHang_cameraMatrixTarget.vD.y - swrObjHang_cameraMatrixStart.vD.y;
+        swrObjHang_cameraMoveEyeDeltaZ = swrObjHang_cameraMatrixTarget.vD.z - swrObjHang_cameraMatrixStart.vD.z;
+        swrObjHang_cameraMoveElapsed = 0.0f;
+        swrObjHang_cameraMoveDuration = 0.5f;
+        // A short hop across the junkyard counter gets a quicker move.
+        if (swrObjHang_cameraMoveLookAtDeltaX < 500.0f && -500.0f < swrObjHang_cameraMoveLookAtDeltaX && swrObjHang_cameraMoveLookAtDeltaY < 500.0f && -500.0f < swrObjHang_cameraMoveLookAtDeltaY && hang->room == Junkyard) {
+            swrObjHang_cameraMoveDuration = 0.3f;
+        }
+        swrObjHang_cameraLerpNeedsInit = 0;
+    }
+    if (swrObjHang_cameraMoveDuration <= swrObjHang_cameraMoveElapsed) {
+        swrObjHang_cameraMoveMode = 5;
+        if (hang->menuScreen == swrObjHang_STATE_LOOK_AT_VEHICLE) {
+            swrObjHang_cameraMoveMode = 0;
+        }
+        swrObjHang_cameraLerpNeedsInit = 1;
+        if (swrObjHang_cameraMoveActive != 0) {
+            swrObjHang_cameraMoveActive = 0;
+            swrObjHang_cameraMoveParity = swrObjHang_cameraMoveParity == 0;
+            if (hang->room == Junkyard && hang->cameraState != HangCameraState__unk_3 && swrObjHang_cameraMoveParity != 0) {
+                swrObjHang_screenTransitionDir = 1;
+            }
+        }
+        rdMatrix_Copy44(&swrObjHang_holoCameraMatrixStart, &swrObjHang_holoCameraMatrix);
+        rdMatrix_Copy44(&swrObjHang_cameraMatrixStart, &swrObjHang_cameraMatrix);
+        if (swrObjHang_state2 != (swrObjHang_STATE)~swrObjHang_STATE_LEGAL && swrObjHang_screenTransitionDir == 0) {
+            swrObjHang_cameraMoveParity = 0;
+            return;
+        }
+    } else {
+        swrObjHang_cameraMoveElapsed = swrObjHang_cameraMoveElapsed + swrRace_fdeltaTimeSecs;
+        if (swrObjHang_cameraMoveDuration < swrObjHang_cameraMoveElapsed) {
+            swrObjHang_cameraMoveElapsed = swrObjHang_cameraMoveDuration;
+        }
+        t = swrObjHang_cameraMoveElapsed / swrObjHang_cameraMoveDuration;
+        swrObjHang_holoCameraMatrix.vD.x = (swrObjHang_holoCameraMatrixTarget.vD.x - swrObjHang_holoCameraMatrixStart.vD.x) * t + swrObjHang_holoCameraMatrixStart.vD.x;
+        swrObjHang_holoCameraMatrix.vD.y = (swrObjHang_holoCameraMatrixTarget.vD.y - swrObjHang_holoCameraMatrixStart.vD.y) * t + swrObjHang_holoCameraMatrixStart.vD.y;
+        swrObjHang_holoCameraMatrix.vD.z = (swrObjHang_holoCameraMatrixTarget.vD.z - swrObjHang_holoCameraMatrixStart.vD.z) * t + swrObjHang_holoCameraMatrixStart.vD.z;
+        // Mode 3 moves the look-at only and leaves the eye where it is.
+        if (swrObjHang_cameraMoveMode != 3) {
+            swrObjHang_cameraMatrix.vD.x = (swrObjHang_cameraMatrixTarget.vD.x - swrObjHang_cameraMatrixStart.vD.x) * t + swrObjHang_cameraMatrixStart.vD.x;
+            swrObjHang_cameraMatrix.vD.y = (swrObjHang_cameraMatrixTarget.vD.y - swrObjHang_cameraMatrixStart.vD.y) * t + swrObjHang_cameraMatrixStart.vD.y;
+            swrObjHang_cameraMatrix.vD.z = (swrObjHang_cameraMatrixTarget.vD.z - swrObjHang_cameraMatrixStart.vD.z) * t + swrObjHang_cameraMatrixStart.vD.z;
+        }
+    }
+}
+
+// Speed-based camera move: steps the eye and look-at toward their targets, and applies the pending
+// menu state once both arrive.
+// 0x0045c3c0
+void swrObjHang_UpdateHoloCamera(swrObjHang* hang)
+{
+    int lookAtArrived;
+    int eyeArrived;
+    float dist;
+    rdVector3 toTarget;
+
+    if (!rdVector_AreSame3(&swrObjHang_cameraLookAtTargetCached, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD)) {
+        rdVector_Copy3(&swrObjHang_cameraLookAtTargetCached, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD);
+        // On a retarget, pull a far-away look-at in to 500 units so the step does not crawl.
+        rdVector_Sub3(&toTarget, (rdVector3*)&swrObjHang_holoCameraMatrix.vD, (rdVector3*)&swrObjHang_cameraMatrix.vD);
+        dist = rdVector_Len3(&toTarget);
+        if (500.0f < dist) {
+            rdVector_Normalize3Acc(&toTarget);
+            rdVector_Scale3Add3((rdVector3*)&swrObjHang_holoCameraMatrix.vD, (rdVector3*)&swrObjHang_cameraMatrix.vD, 500.0f, &toTarget);
+        }
+    }
+    lookAtArrived = swrObjHang_StepCameraToward(hang, &swrObjHang_cameraStepLookAtSpeed, (rdVector3*)&swrObjHang_holoCameraMatrixTarget.vD, (rdVector3*)&swrObjHang_holoCameraMatrix.vD, (rdVector3*)&swrObjHang_holoCameraMatrixStart.vD, 1.5f);
+    eyeArrived = swrObjHang_StepCameraToward(hang, &swrObjHang_cameraStepEyeSpeed, (rdVector3*)&swrObjHang_cameraMatrixTarget.vD, (rdVector3*)&swrObjHang_cameraMatrix.vD, (rdVector3*)&swrObjHang_cameraMatrixStart.vD, 1.0f);
+    if (eyeArrived != 0 && lookAtArrived != 0) {
+        swrObjHang_cameraMoveMode = 5;
+        swrObjHang_cameraMoveSettled = 1;
+        if (hang->menuScreen == swrObjHang_STATE_LOOK_AT_VEHICLE) {
+            swrObjHang_cameraMoveMode = 0;
+        }
+        if (swrObjHang_cameraMoveActive != 0) {
+            swrObjHang_cameraMoveParity = swrObjHang_cameraMoveParity == 0;
+            swrObjHang_cameraMoveActive = 0;
+            if (hang->room == Junkyard && hang->cameraState != HangCameraState__unk_3 && swrObjHang_cameraMoveParity != 0) {
+                swrObjHang_screenTransitionDir = 1;
+            }
+        }
+        rdMatrix_Copy44(&swrObjHang_holoCameraMatrixStart, &swrObjHang_holoCameraMatrix);
+        rdMatrix_Copy44(&swrObjHang_cameraMatrixStart, &swrObjHang_cameraMatrix);
+        if (swrObjHang_state2 != (swrObjHang_STATE)~swrObjHang_STATE_LEGAL && swrObjHang_screenTransitionDir == 0) {
+            swrObjHang_cameraMoveParity = 0;
+            if (swrObjHang_fadeState == 0) {
+                swrObjHang_SetMenuState(hang, swrObjHang_state2);
+            }
+        }
+    }
+}
+
+// Advance `from` toward `target` this frame, ramping the carried speed down over the last stretch so
+// the camera eases in. Returns nonzero once it has arrived.
+// 0x0045c560
+int swrObjHang_StepCameraToward(swrObjHang* hang, float* progress, rdVector3* target, rdVector3* from, rdVector3* to, float speed)
+{
+    swrObjHang_STATE screen;
+    float dot;
+    float step;
+    float rate;
+    float halfSpan;
+    float arriveRadius;
+    float distToTarget;
+    float carriedSpeed;
+    float decelSpan;
+    rdVector3 targetToFrom;
+    rdVector3 fromToTo;
+    rdVector3 targetToTo;
+    rdVector3 remaining;
+    rdVector3 start;
+
+    screen = hang->menuScreen;
+    carriedSpeed = *progress;
+    decelSpan = 1600.0f;
+    if (screen == swrObjHang_STATE_RESULTS_INTRO || screen == swrObjHang_STATE_VEHICLE_SELECT_INTRO || (screen == swrObjHang_STATE_LOOK_AT_VEHICLE && 5.0f <= swrObjHang_inspectCameraTimer) || (screen == swrObjHang_STATE_MAIN_MENU && swrObjHang_fadeState == 0)) {
+        decelSpan = 320.0f;
+        rate = 0.2f;
+    } else if (screen == swrObjHang_STATE_PLANET_SELECT_INTRO) {
+        decelSpan = 80.0f;
+        rate = 0.05f;
+    } else {
+        rate = 1.0f;
+    }
+    step = swrRace_fdeltaTimeSecs * 60000.0f * rate;
+
+    rdVector_Copy3(&start, from);
+    swrObjHang_cameraStepScratch = 0;
+    step = step * speed;
+    rdVector_Sub3(&targetToTo, target, to);
+    halfSpan = rdVector_Len3(&targetToTo) * 0.5f;
+    rdVector_Sub3(&fromToTo, to, from);
+    rdVector_Len3(&fromToTo);
+    rdVector_Sub3(&remaining, target, from);
+    distToTarget = rdVector_Len3(&remaining);
+    arriveRadius = step * 6.0f;
+    if (halfSpan < arriveRadius) {
+        arriveRadius = halfSpan;
+    }
+    if (distToTarget < arriveRadius || step <= carriedSpeed) {
+        if ((distToTarget < arriveRadius || carriedSpeed < step) && distToTarget < arriveRadius && 1.0f < distToTarget) {
+            if (swrObjHang_state2 != (swrObjHang_STATE)~swrObjHang_STATE_LEGAL && hang->menuScreen != swrObjHang_STATE_VEHICLE_SELECT_INTRO) {
+                return 1;
+            }
+            carriedSpeed = stdMath_Sqrt(distToTarget / (decelSpan * speed)) * decelSpan * speed;
+        }
+    } else {
+        carriedSpeed = carriedSpeed - speed * swrRace_fdeltaTimeSecs * -2000.0f;
+        if (step < carriedSpeed) {
+            carriedSpeed = step;
+        }
+    }
+    if (1.0f < distToTarget) {
+        rdVector_Normalize3Acc(&remaining);
+        rdVector_Scale3Add3(from, from, carriedSpeed * swrRace_fdeltaTimeSecs, &remaining);
+        rdVector_Sub3(&targetToFrom, target, from);
+        dot = rdVector_Dot3(&remaining, &targetToFrom);
+        // Overshot the target this frame if the direction flipped.
+        if (0.0f <= dot) {
+            *progress = carriedSpeed;
+            return 0;
+        }
+    }
+    rdVector_Copy3(from, target);
+    *progress = 0.0f;
+    return 1;
+}

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -513,7 +513,7 @@ void swrObjHang_ShowPartNodes(swrObjHang* hang);
 // Unload/clear the front-end scene's model nodes and clear scene animations.
 void swrModel_clearSceneModelsAndChildren(void);
 // Set the target position/look-at (and transition mode) for the holo-scene camera move.
-void swrObjHang_SetHoloCameraTarget(rdVector3* pos, rdVector3* lookAt, short mode, int param_4, int reset);
+void swrObjHang_SetHoloCameraTarget(rdVector3* pos, rdVector3* lookAt, short mode, int keepEyeOffset, int reset);
 // Compute a holo-scene camera target for a scene element (jittered one-shot framing, or a direct
 // snap) and feed it to swrObjHang_SetHoloCameraTarget.
 void swrObjHang_AimHoloCamera(swrObjHang* hang, int param_2, int param_3);

--- a/src/types.h
+++ b/src/types.h
@@ -3247,14 +3247,14 @@ extern "C"
         uint8_t unk[16]; // 0x28
     };
 
-    // actual usage of this struct unclear, maybe camera positions on junkyard
-    struct swrUICameraPlacement
+    // One front-end camera framing, indexed by swrObjHang.cameraState out of maybeUICameraPlacements.
+    typedef struct swrUICameraPlacement
     {
-        rdVector3 position1; // 0x0
-        rdVector3 position2; // 0xc
+        rdVector3 position1; // 0x0  eye
+        rdVector3 position2; // 0xc  look-at
         uint32_t unk1; // 0x18
         uint32_t unk2; // 0x1c
-    };
+    } swrUICameraPlacement; // sizeof(0x20)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Stacked on #293 - merge that first; the first commit is its. Review only `942947c` (the second commit).

Reimplements the three functions that actually drive the eye / look-at matrix triples #293 names.

| fn | addr |
|---|---|
| `swrObjHang_LerpHoloCamera` | `0x0045c0b0` |
| `swrObjHang_UpdateHoloCamera` | `0x0045c3c0` |
| `swrObjHang_StepCameraToward` | `0x0045c560` |

### Two move implementations, one completion path

The interesting bit is that the front end has **two independent camera moves**:

- **`LerpHoloCamera` is duration-based.** It snapshots the six move deltas, runs a 0.5s clock -- 0.3s for a short hop in the junkyard -- and lerps both rows. Mode 3 moves the look-at only and leaves the eye put.
- **`UpdateHoloCamera` is speed-based.** It delegates each row to `StepCameraToward`, which carries a speed between frames and eases in over a sqrt decel curve, then applies the pending menu state once both rows arrive.

`StepCameraToward` has to be in the same PR -- `UpdateHoloCamera` calls it, so shipping it as a prototype would break the link.

### `swrObjHang_screenTransitionDir` `0x0050c468` is not a boolean

Worth flagging because it reads like a flag and is not one. It is a **signed step**:

- `SetMenuState` clears it in the same block where it commits a state
- `UpdateScreenTransition` sets it to `1` and then *multiplies by it* to drive the slide offset
- `UpdateJunkyard` sets it to `-1` to run the slide in reverse

Nonzero means a screen slide is in flight, which is why a finished camera move refuses to apply its pending menu state while it is set. I held off naming this one until all four users lined up.

### Notes

The six lerp deltas are **individual interleaved floats, not two `rdVector3`s** -- look-at lives at `8b4`/`8c4`/`8e4` and eye at `8b8`/`8b0`/`8bc`, so they cannot be declared as vectors.

`swrObjHang_cameraStepScratch` `0x0050c9a4` is a dead store: `StepCameraToward` zeroes it and nothing in the binary reads it. Kept for faithfulness, named so it is obvious.

The `menuScreen` comparisons map onto the existing `swrObjHang_STATE_{PLANET_SELECT,RESULTS,VEHICLE_SELECT}_INTRO` members, so no new enum. Constants decode to 5.0 / 0.2 / 60000.0 / 0.05 / 6.0 / -2000.0.

Builds and links clean; hook-annotation, header-dup and data-symbol-dup checks pass. Burndown 895 -> 898.
