### PR TITLE
reimpl(swrObjSmok): the particle entity family + name its struct

### DIFF
--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -1841,29 +1841,274 @@ float swrObjHang_StepTransition(float rate)
     return swrRace_Transition;
 }
 
+// 0x00469e70
+void swrObjSmok_Free(swrObj* obj)
+{
+    swrObjSmok* smok = (swrObjSmok*)obj;
+
+    for (int i = 0; i < smok->particleCount; i++) {
+        if (smok->particleNodes[i] != NULL)
+            swrModel_NodeModifyFlags(smok->particleNodes[i], 2, -4, 0x10, 3);
+    }
+    if (smok->ownerHandle != NULL)
+        *(void**)smok->ownerHandle = NULL;
+    swrObj_Free(obj);
+}
+
 // 0x00469ed0
 void swrObjSmok_F0(swrObjSmok* smok)
 {
-    HANG("TODO");
+    if (smok->lifetime <= 0.0f) {
+        smok->lifetime = 0.0f;
+        if ((smok->flags & swrObjSmok_FLAG_OWNER_MANAGED) == 0) {
+            for (int i = 0; i < 5; i++) {
+                if (smok->particleNodes[i] != NULL)
+                    swrModel_NodeModifyFlags(smok->particleNodes[i], 2, -4, 0x10, 3);
+            }
+            swrObjSmok_Free(&smok->obj);
+        }
+        return;
+    }
+
+    int advanceFront = smok->alphaWindowFront < 1.0f;
+    smok->lifetime = smok->lifetime - (float)swrRace_deltaTimeSecs;
+    if (advanceFront)
+        smok->alphaWindowFront = smok->alphaWindowFront - (swrRace_deltaTimeSecs * -4.0) / smok->totalLifetime;
+    if (smok->lifetime < smok->totalLifetime)
+        smok->alphaWindowTail = smok->alphaWindowTail - (swrRace_deltaTimeSecs * -4.0) / smok->totalLifetime;
 }
 
 // 0x00469fb0
 void swrObjSmok_F3(swrObjSmok* smok)
 {
-    HANG("TODO");
+    for (int i = 0; i < smok->particleCount; i++) {
+        swrModel_Node* node = smok->particleNodes[i];
+        if (node == NULL)
+            continue;
+
+        float phase = (float)i / (float)smok->particleCount + smok->lifetime / smok->totalLifetime;
+        // Wrap into [0,1): subtracting almost-one biases the truncation below toward -inf.
+        if (phase < 0.0f)
+            phase -= 0.99999899f;
+        float t = 1.0f - (phase - (float)(int)phase);
+        if (t < 0.0f)
+            t = 0.0f;
+        if (t > 1.0f)
+            t = 1.0f;
+
+        // Billboard basis: Z runs along the drift velocity, X/Y span the quad.
+        rdVector3 forward = smok->velocity;
+        rdVector_Normalize3Acc(&forward);
+        float absZ = forward.z < 0.0f ? -forward.z : forward.z;
+        rdVector3 up;
+        up.x = 0.0f;
+        if (absZ <= 0.9) { // double compare, as in the original
+            up.y = 0.0f;
+            up.z = 1.0f;
+        } else {
+            up.y = 1.0f;
+            up.z = 0.0f;
+        }
+        rdVector3 right;
+        rdVector_Cross3(&right, &up, &forward);
+        rdVector_Cross3(&up, &forward, &right);
+        rdVector_Normalize3Acc(&up);
+        rdVector_Normalize3Acc(&right);
+
+        rdMatrix44 transform;
+        rdMatrix_SetIdentity44(&transform);
+        float width = (smok->widthStart + (smok->widthEnd - smok->widthStart) * t * t) * 0.01f;
+        rdVector_Scale3((rdVector3*)&transform.vA, width, &right);
+        rdVector_Scale3((rdVector3*)&transform.vB, width, &up);
+        rdVector_Scale3((rdVector3*)&transform.vC, ((smok->lengthEnd - smok->lengthStart) * t * t + smok->lengthStart) * 0.01f, &forward);
+
+        float spin = ((smok->spinRateEnd - smok->spinRateStart) * t + smok->spinRateStart) * (float)swrRace_deltaTimeSecs + smok->particleSpin[i];
+        smok->particleSpin[i] = spin;
+        rdMatrix_AddRotationFromVectorAngle44Before(&transform, spin, 0.0f, 0.0f, 1.0f, &transform);
+        rdVector_Scale3Add3((rdVector3*)&transform.vD, (rdVector3*)&smok->transform.vD, t, &smok->velocity);
+
+        int r = (int)(((smok->colorEnd.x - smok->colorStart.x) * t + smok->colorStart.x) * 255.0f);
+        int g = (int)(((smok->colorEnd.y - smok->colorStart.y) * t + smok->colorStart.y) * 255.0f);
+        int b = (int)(((smok->colorEnd.z - smok->colorStart.z) * t + smok->colorStart.z) * 255.0f);
+        int a = (int)(((smok->colorEnd.w - smok->colorStart.w) * t + smok->colorStart.w) * 255.0f);
+
+        if (t < smok->fadeInEnd && smok->fadeInEnd > 0.0f)
+            a = (int)((float)a * (t / smok->fadeInEnd));
+        if (t > smok->fadeOutStart && smok->fadeOutStart < 1.0f)
+            a = (int)((float)a + (float)-a * ((t - smok->fadeOutStart) / (1.0 - smok->fadeOutStart)));
+        if (t > smok->alphaWindowFront)
+            a = (int)((float)a * (1.0f - (t - smok->alphaWindowFront) * 4.0f));
+        if (t < smok->alphaWindowFront)
+            a = (int)((float)a * (1.0f - (smok->alphaWindowTail - t) * 4.0f));
+
+        if (r < 0)
+            r = 0;
+        if (r > 255)
+            r = 255;
+        if (g < 0)
+            g = 0;
+        if (g > 255)
+            g = 255;
+        if (b < 0)
+            b = 0;
+        if (b > 255)
+            b = 255;
+        if (a < 0)
+            a = 0;
+        if (a > 255)
+            a = 255;
+
+        swrModel_NodeSetTransform((swrModel_NodeTransformed*)node, &transform);
+        swrModel_NodeModifyFlags(node, 2, 3, 0x10, 2);
+        if (a < 2)
+            swrModel_NodeModifyFlags(node, 2, -4, 0x10, 3);
+
+        swrModel_MeshMaterial* material = swrModel_NodeFindFirstMeshMaterial(node);
+        if (material != NULL) {
+            swrModel_MeshMaterialSetColors(material, 0, 0, r, g, b, a);
+            swrModel_MeshMaterialSetTextureUVOffset(material, 0.0f, ((smok->uvScrollEnd - smok->uvScrollStart) * t + smok->uvScrollStart) * (float)swrRace_deltaTimeSecs);
+        }
+    }
 }
 
 // 0x0046a500
 int swrObjSmok_F4(swrObjSmok* smok, int* subEvents)
 {
-    HANG("TODO");
-    return 0;
+    switch (*subEvents) {
+    case 0x416c6f63: // 'Aloc'
+        smok->type = 0;
+        smok->flags = 0;
+        smok->lifetime = 0.0f;
+        smok->ownerHandle = NULL;
+        for (int i = 0; i < 5; i++) {
+            swrModel_Node* node = fireballChildNodesPtr[i + smok->obj.id * 5];
+            smok->particleNodes[i] = node;
+            if (node != NULL)
+                swrModel_NodeModifyFlags(node, 2, -4, 0x10, 3);
+            smok->particleSpin[i] = 0.0f;
+        }
+        return 1;
+    case 0x46726565: // 'Free'
+        for (int i = 0; i < 5; i++)
+            smok->particleNodes[i] = NULL;
+        return 1;
+    case 0x4c6f6164: // 'Load'
+    case 0x52536574: // 'RSet'
+        swrObj_Free(&smok->obj);
+        smok->ownerHandle = NULL;
+        return 1;
+    default:
+        return 0;
+    }
 }
 
 // 0x0046A5E0
 void swrObjSmok_SetFireballChildNodesPtr(swrModel_Node** nodes)
 {
-    HANG("TODO");
+    fireballChildNodesPtr = nodes;
+}
+
+// 0x0046a5f0
+swrObjSmok* swrObjSmok_Spawn(int type, int flags, float lifetime, rdVector3* pos, float scale)
+{
+    swrObjSmok* smok = (swrObjSmok*)swrEvent_AllocObj(0x536d6f6b); // 'Smok'
+    if (smok == NULL)
+        return NULL;
+
+    smok->flags = flags;
+    smok->type = type;
+    smok->lifetime = lifetime;
+    rdMatrix_SetDiagonal44(&smok->transform, scale, scale, scale);
+    rdVector_Copy3((rdVector3*)&smok->transform.vD, pos);
+
+    switch (type) {
+    case swrObjSmok_TYPE_FIRE:
+    case swrObjSmok_TYPE_EXPLOSION:
+        smok->particleCount = 5;
+        rdVector_Set3(&smok->velocity, 0.0f, 0.0f, scale * 10.0f);
+        smok->widthEnd = scale * 5.0f;
+        smok->widthStart = scale;
+        smok->spinRateStart = 360.0f;
+        smok->spinRateEnd = -9.0f;
+        smok->lengthStart = scale * 10.0f;
+        smok->uvScrollStart = 1.4f;
+        smok->uvScrollEnd = 0.0f;
+        smok->lengthEnd = scale * 5.0f;
+        smok->totalLifetime = 3.0f;
+        smok->unkac = 1.0f;
+        smok->unkb0 = 0.5f;
+        rdVector_Set4(&smok->colorStart, 1.0f, 1.0f, 1.0f, 1.0f);
+        break;
+    case swrObjSmok_TYPE_ENGINE_SMOKE:
+        smok->particleCount = 5;
+        rdVector_Set3(&smok->velocity, 0.0f, scale * -10.0f, 0.0f);
+        smok->widthEnd = scale * 3.0f;
+        smok->widthStart = scale;
+        smok->spinRateStart = 360.0f;
+        smok->spinRateEnd = -9.0f;
+        smok->lengthStart = scale * 10.0f;
+        smok->uvScrollStart = 1.4f;
+        smok->uvScrollEnd = 0.0f;
+        smok->totalLifetime = 3.0f;
+        smok->unkac = 1.0f;
+        smok->unkb0 = 0.5f;
+        smok->lengthEnd = scale * 5.0f;
+        rdVector_Set4(&smok->colorStart, 1.0f, 1.0f, 1.0f, 1.0f);
+        break;
+    case swrObjSmok_TYPE_FLAME_ATTACK:
+        smok->particleCount = 5;
+        rdVector_Set3(&smok->velocity, 0.0f, scale * -10.0f, 0.0f);
+        smok->widthEnd = scale * 3.0f;
+        smok->widthStart = scale;
+        smok->spinRateStart = 360.0f;
+        smok->spinRateEnd = -9.0f;
+        smok->lengthStart = scale * 10.0f;
+        smok->uvScrollStart = 2.4f;
+        smok->uvScrollEnd = 0.5f;
+        smok->totalLifetime = 3.0f;
+        smok->unkac = 1.0f;
+        smok->unkb0 = 0.5f;
+        smok->lengthEnd = scale * 5.0f;
+        rdVector_Set4(&smok->colorStart, 1.0f, 1.0f, 1.0f, 1.0f);
+        break;
+    default:
+        return smok;
+    }
+
+    rdVector_Set4(&smok->colorEnd, 0.0f, 0.0f, 0.0f, 1.0f);
+    smok->fadeInEnd = 0.1f;
+    smok->fadeOutStart = 0.5f;
+    smok->alphaWindowTail = 0.0f;
+    smok->alphaWindowFront = 0.0f;
+    return smok;
+}
+
+// 0x0046a920
+void swrObjSmok_SetPosition(swrObjSmok* smok, rdVector3* pos)
+{
+    if (smok != NULL)
+        rdVector_Copy3((rdVector3*)&smok->transform.vD, pos);
+}
+
+// 0x0046a940
+void swrObjSmok_SetVelocity(swrObjSmok* smok, rdVector3* vel)
+{
+    if (smok != NULL)
+        rdVector_Copy3(&smok->velocity, vel);
+}
+
+// 0x0046a960
+void swrObjSmok_SetLifetime(swrObjSmok* smok, float lifetime)
+{
+    if (smok != NULL)
+        smok->lifetime = lifetime;
+}
+
+// 0x0046a970
+void swrObjSmok_SetOwnerHandle(swrObjSmok* smok, void* ownerHandle)
+{
+    if (smok != NULL)
+        smok->ownerHandle = ownerHandle;
 }
 
 // 0x0046d170

--- a/src/Swr/swrObj.h
+++ b/src/Swr/swrObj.h
@@ -720,20 +720,22 @@ void swrObjHang_TickMenuRepeatDelay_Maybe(void);
 // Handles up/down vehicle-select navigation with key-repeat, UI sounds, and transition stepping.
 void swrObjHang_NavigateVehicleSelect(int player, float param_2, int param_3);
 
-// Frees a particle object: hides its model nodes, clears the node-array backref, swrObj_Free.
-void swrObjSmok_Free(swrObj* smok);
+// Frees a particle object: hides its model nodes, clears the owner's backref, swrObj_Free.
+void swrObjSmok_Free(swrObj* obj);
 
+// Ages the particle: counts lifetime down, advances the alpha window, self-frees at end of life.
 void swrObjSmok_F0(swrObjSmok* smok);
 
+// Per-frame billboard update: orients, scales, spins, tints and UV-scrolls each particle node.
 void swrObjSmok_F3(swrObjSmok* smok);
 
 int swrObjSmok_F4(swrObjSmok* smok, int* subEvents);
 
-void swrObjSmok_SetFireballChildNodesPtr(swrModel_Node**);
+void swrObjSmok_SetFireballChildNodesPtr(swrModel_Node** nodes);
 
-// swrObjSmok particle create/setter API (smoke/fire/spark/explosion):
-// Allocates and configures a particle by type (2/3 sparks, 6 fire, 8 explosion); returns the object.
-void* swrObjSmok_Spawn(int type, int param_2, float lifetime, rdVector3* pos, float scale);
+// swrObjSmok particle create/setter API. Spawn applies the preset for the given
+// swrObjSmok_TYPE; the setters are NULL-tolerant, so an expired handle is safe to pass.
+swrObjSmok* swrObjSmok_Spawn(int type, int flags, float lifetime, rdVector3* pos, float scale);
 void swrObjSmok_SetPosition(swrObjSmok* smok, rdVector3* pos);
 void swrObjSmok_SetVelocity(swrObjSmok* smok, rdVector3* vel);
 void swrObjSmok_SetLifetime(swrObjSmok* smok, float lifetime);

--- a/src/types.h
+++ b/src/types.h
@@ -880,43 +880,43 @@ extern "C"
         float unkbc;
     } swrObjElmo; // sizeof(0xc0)
 
+    // Generic particle entity ('Smok'): engine smoke, track fire, explosion bursts,
+    // Sebulba's flame attack. Up to 5 billboards, aged by F0 and drawn by F3. Every
+    // Start/End pair below is interpolated over the per-particle phase,
+    // (lifetime / totalLifetime) + i / particleCount wrapped into [0,1].
     typedef struct swrObjSmok
     {
         swrObj obj;
-        char unk8[32];
-        char unk28[32];
-        char unk48[24];
-        int unk60;
-        int unk64;
-        float unk68_ms;
+        char unk8[24];
+        rdMatrix44 transform; // 0x20. scale on the diagonal; row vD (0x50) holds the spawn position
+        int type; // 0x60. swrObjSmok_TYPE
+        int flags; // 0x64. swrObjSmok_FLAG
+        float lifetime; // 0x68. seconds remaining, counted down by F0
         char unk6c[4];
-        int unk70;
-        float unk74;
-        float unk78;
-        float unk7c;
-        char unk80[4];
-        float unk84;
-        float unk88;
-        float unk8c;
-        float unk90;
-        float unk94;
-        float unk98;
-        float unk9c;
-        float unka0;
-        float unka4;
-        float unka8_ms;
-        char unkac[28];
-        char unkc8[12];
-        float unkd4_ms;
-        float unkd8_ms;
-        char unkdc[12];
-        char unke8[8];
-        float unkf0;
-        struct swrModel_Node* unkf4_model;
-        float unkf8;
-        float unkfc;
-        float unk100;
-        float unk104;
+        int particleCount; // 0x70
+        rdVector3 velocity; // 0x74. particles drift along this, scaled by phase
+        float fadeInEnd; // 0x80. alpha ramps in over phase [0, fadeInEnd]
+        float fadeOutStart; // 0x84. alpha ramps out over phase [fadeOutStart, 1]
+        float widthStart; // 0x88. billboard half-extent across the velocity axis
+        float widthEnd; // 0x8c
+        float lengthStart; // 0x90. billboard extent along the velocity axis
+        float lengthEnd; // 0x94
+        float spinRateStart; // 0x98. degrees/sec about the velocity axis
+        float spinRateEnd; // 0x9c
+        float uvScrollStart; // 0xa0. texture V scroll rate
+        float uvScrollEnd; // 0xa4
+        float totalLifetime; // 0xa8. seconds; the phase denominator
+        float unkac;
+        float unkb0;
+        rdVector4 colorStart; // 0xb4
+        rdVector4 colorEnd; // 0xc4
+        // Phase-space alpha window. Both advance 4 / totalLifetime per second in F0 and
+        // gate alpha outside [tail, front], so the effect reveals itself outward from spawn.
+        float alphaWindowTail; // 0xd4
+        float alphaWindowFront; // 0xd8
+        float particleSpin[5]; // 0xdc. accumulated spin angle per particle
+        void* ownerHandle; // 0xf0. owner's backref slot, NULLed by swrObjSmok_Free
+        struct swrModel_Node* particleNodes[5]; // 0xf4. borrowed from fireballChildNodesPtr[id * 5]
     } swrObjSmok; // sizeof(0x108)
 
     typedef struct swrObjcMan

--- a/src/types_enums.h
+++ b/src/types_enums.h
@@ -259,6 +259,22 @@ typedef enum swrObjTrig_FLAG
     swrObjTrig_FLAG_FX_SPAWNED = 0x4, // earthquake FX has been spawned (SpawnEarthquakeShake phase gate)
 } swrObjTrig_FLAG;
 
+// swrObjSmok.type -- picks the velocity / size / spin / UV-scroll preset applied by
+// swrObjSmok_Spawn. FIRE and EXPLOSION share one preset, ENGINE_SMOKE and FLAME_ATTACK
+// another (they differ only in UV scroll). Any other value spawns an unconfigured object.
+typedef enum swrObjSmok_TYPE
+{
+    swrObjSmok_TYPE_FIRE = 2, // burning track prop (swrRace_InitFireEffects)
+    swrObjSmok_TYPE_EXPLOSION = 3, // death / hard-landing burst (swrRace_Explode, HandleDeathExplosion, PlaceOnTrack)
+    swrObjSmok_TYPE_ENGINE_SMOKE = 6, // per-engine damage plume (swrRace_UpdateEngineDamageFX)
+    swrObjSmok_TYPE_FLAME_ATTACK = 8, // Sebulba's flame jet (swrRace_SpawnFlameAttack)
+} swrObjSmok_TYPE;
+
+typedef enum swrObjSmok_FLAG
+{
+    swrObjSmok_FLAG_OWNER_MANAGED = 0x1, // F0 will not self-free at end of life; the owner frees it
+} swrObjSmok_FLAG;
+
 // array of animations at 0x00e25e60
 typedef enum swrMAPANIM_INDEX
 {


### PR DESCRIPTION
Fills in the ten remaining `swrObjSmok` slots: `Free`, `F0`, `F3`, `F4`, `SetFireballChildNodesPtr`, `Spawn` and the four setters. This is engine-damage smoke, burning track props, death/landing explosion bursts and Sebulba's flame jet — all six callers (`swrRace_Explode`, `UpdateEngineDamageFX`, `SpawnFlameAttack`, `HandleDeathExplosion`, `PlaceOnTrack`, `InitFireEffects`) sit downstream, and every callee was already implemented.

The struct was 30 anonymous fields. The disassembly of F0/F4/Free pins the real shape:

- `rdMatrix44 transform` at 0x20 — the setters' "position" is just its `vD` row at 0x50, which is why `SetDiagonal44(0x20)` and the 0x50 write in `Spawn` don't overlap
- `float particleSpin[5]` at 0xdc running parallel to `swrModel_Node* particleNodes[5]` at 0xf4 — Ghidra had split both into scalars (`unkf4_model`, `unkf8`, `unkfc`, …)
- `void* ownerHandle` at 0xf0, which `Free` NULLs *through* to clear the owner's backref

`sizeof` stays 0x108, checked with a `_Static_assert` on the size plus 12 offsets.

Constants come from reading the pool at 0x004ad6f0 rather than Ghidra's `_UNK_` typing: 0x004ad700 is a double -4.0, not a float, which the `FMUL qword ptr` in the F0 bytes confirms. It sets the rate of the phase-space alpha window that reveals the plume outward from spawn.

Type selector is now `swrObjSmok_TYPE` with each value traced to its call site (2 = track fire, 3 = explosion, 6 = engine smoke, 8 = flame attack), and the one known flag bit is `swrObjSmok_FLAG`.

Two literals are deliberately doubles to match the original arithmetic: `absZ <= 0.9` (commented) and `1.0 - fadeOutStart`. `unkac` / `unkb0` stay unnamed — `Spawn` sets them, nothing I can find reads them.

Full dinput.dll builds and links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
