### PR TITLE
Retype swrObjJdge 0x134 as the camera-sweep cursor

### DIFF
--- a/dinput_hook/crash_logger.cpp
+++ b/dinput_hook/crash_logger.cpp
@@ -349,6 +349,26 @@ void crash_logger_stage(const char *name) {
     }
 }
 
+void crash_logger_stagef(const char *fmt, ...) {
+    // Formatted milestone, for stages that carry a value (which track is loading, ...). The text
+    // has to outlive the call, so it goes into one of two static slots used alternately: the
+    // reader (crash filter / watchdog) may be looking at the previous stage string while this one
+    // is written, and alternating means it is never the slot being overwritten. Fixed buffers, so
+    // this allocates nothing.
+    static char slot[2][192];
+    static int next_slot = 0;
+
+    char *buf = slot[next_slot];
+    next_slot ^= 1;
+
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(slot[0]), fmt, ap);
+    va_end(ap);
+
+    crash_logger_stage(buf);
+}
+
 void crash_logger_heartbeat(void) {
     // Re-assert our filter each frame: if the game's CRT startup installed its own top-level
     // filter over ours, this puts ours back on top so in-game crashes still reach us. Cheap

--- a/dinput_hook/crash_logger.cpp
+++ b/dinput_hook/crash_logger.cpp
@@ -25,6 +25,9 @@ static const int STARTUP_TIMEOUT_MS = 45000;
 // static literals, so no lock is needed.
 static const char *volatile g_last_stage = "pre-init";
 
+// Longest crash_logger_stagef() string; longer is truncated, not dropped.
+static const int STAGE_TEXT_MAX = 192;
+
 // ---------------------------------------------------------------------------------------------
 // Shared report writers. Everything writes through write_fmt to a caller-supplied Win32 file
 // HANDLE (never a CRT FILE): the crash filter runs on the faulting thread and the hang watchdog
@@ -350,12 +353,9 @@ void crash_logger_stage(const char *name) {
 }
 
 void crash_logger_stagef(const char *fmt, ...) {
-    // Formatted milestone, for stages that carry a value (which track is loading, ...). The text
-    // has to outlive the call, so it goes into one of two static slots used alternately: the
-    // reader (crash filter / watchdog) may be looking at the previous stage string while this one
-    // is written, and alternating means it is never the slot being overwritten. Fixed buffers, so
-    // this allocates nothing.
-    static char slot[2][192];
+    // The text has to outlive the call, and the crash filter may be reading the previous stage
+    // while this one is written -- so two static slots, used alternately, never the one being read.
+    static char slot[2][STAGE_TEXT_MAX];
     static int next_slot = 0;
 
     char *buf = slot[next_slot];

--- a/dinput_hook/crash_logger.h
+++ b/dinput_hook/crash_logger.h
@@ -17,6 +17,8 @@
 //                               watchdog and stamps the environment.
 //   crash_logger_stage(name) -- at boot/init milestones; `name` must be a static string. The
 //                               most recent one is echoed into every report.
+//   crash_logger_stagef(fmt, ...) -- same, for a milestone that carries a value (track id, ...).
+//                               The text is copied, so callers need no storage of their own.
 //   crash_logger_heartbeat() -- once per rendered frame; drives per-frame hang detection.
 
 #ifdef __cplusplus
@@ -26,6 +28,7 @@ extern "C" {
 void crash_logger_install(void);
 void crash_logger_start(void);
 void crash_logger_stage(const char *name);
+void crash_logger_stagef(const char *fmt, ...);
 void crash_logger_heartbeat(void);
 
 #ifdef __cplusplus

--- a/dinput_hook/custom_tracks.cpp
+++ b/dinput_hook/custom_tracks.cpp
@@ -31,15 +31,33 @@ static std::vector<CustomTrack> custom_tracks;
 int currentCustomID = -1;
 std::optional<CustomTrack> currentCustomTrack = std::nullopt;
 
-std::vector<TrackSplineInfo> compute_spline_hashes(const std::filesystem::path &file) {
+// Slurp a whole block file. Returns an empty buffer if it cannot be read at all -- a missing or
+// unreadable data/lev01 block used to fault here (fseek on a null FILE*) before hook_log even
+// existed, which is the worst possible place for a mod to die silently.
+static std::vector<char> read_block_file(const std::filesystem::path &file) {
     FILE *f = fopen(file.generic_string().c_str(), "rb");
+    if (!f) {
+        fprintf(hook_log, "[custom_tracks] cannot open block file %s\n",
+                file.generic_string().c_str());
+        fflush(hook_log);
+        return {};
+    }
+
     fseek(f, 0, SEEK_END);
     const long size = ftell(f);
     fseek(f, 0, SEEK_SET);
 
-    std::vector<char> data(size);
-    fread(data.data(), 1, data.size(), f);
+    std::vector<char> data(size > 0 ? size : 0);
+    if (!data.empty())
+        fread(data.data(), 1, data.size(), f);
     fclose(f);
+    return data;
+}
+
+std::vector<TrackSplineInfo> compute_spline_hashes(const std::filesystem::path &file) {
+    const std::vector<char> data = read_block_file(file);
+    if (data.size() < sizeof(uint32_t))
+        return {};
 
     const uint32_t num_entries = __builtin_bswap32(*(const uint32_t *) &data[0]);
     std::vector<TrackSplineInfo> hashes(num_entries);
@@ -49,21 +67,35 @@ std::vector<TrackSplineInfo> compute_spline_hashes(const std::filesystem::path &
         hashes[i] = {
             .spline_id = i,
             .hash = ImHashData(&data[entry_begin], entry_end - entry_begin),
+            .num_control_points = 0,
+            .bUsable = false,
         };
+
+        // A spline entry is a swrSpline header (big-endian on disk) immediately followed by its
+        // control points, so its size is fully determined by the control point count -- an
+        // invariant that holds exactly for all 91 stock entries. Record whether it holds, so a
+        // track is never paired with an entry that would hand swrSpline_Interpolate a garbage
+        // control_points array.
+        if (entry_end <= entry_begin || entry_end > data.size() ||
+            entry_end - entry_begin < sizeof(swrSpline))
+            continue;
+
+        const uint32_t num_control_points = __builtin_bswap32(
+            *(const uint32_t *) &data[entry_begin + offsetof(swrSpline, num_control_points)]);
+        hashes[i].num_control_points = num_control_points;
+        hashes[i].bUsable =
+            num_control_points > 0 &&
+            entry_end - entry_begin ==
+                sizeof(swrSpline) + num_control_points * sizeof(swrSplineControlPoint);
     }
 
     return hashes;
 }
 
 std::vector<TrackModelInfo> compute_track_model_infos(const std::filesystem::path &file) {
-    FILE *f = fopen(file.generic_string().c_str(), "rb");
-    fseek(f, 0, SEEK_END);
-    const long size = ftell(f);
-    fseek(f, 0, SEEK_SET);
-
-    std::vector<char> data(size);
-    fread(data.data(), 1, data.size(), f);
-    fclose(f);
+    const std::vector<char> data = read_block_file(file);
+    if (data.size() < sizeof(uint32_t))
+        return {};
 
     const uint32_t num_entries = __builtin_bswap32(*(const uint32_t *) &data[0]);
 
@@ -82,10 +114,23 @@ std::vector<TrackModelInfo> compute_track_model_infos(const std::filesystem::pat
     return track_infos;
 }
 
-const static std::vector<TrackModelInfo> default_track_model_infos =
-    compute_track_model_infos("./data/lev01/out_modelblock.bin");
-const static std::vector<TrackSplineInfo> default_spline_hashes =
-    compute_spline_hashes("./data/lev01/out_splineblock.bin");
+// The on-disk spline entry layout the size check in compute_spline_hashes relies on.
+static_assert(sizeof(swrSpline) == 0x10);
+static_assert(sizeof(swrSplineControlPoint) == 0x54);
+
+// Reference hashes of the stock blocks: whatever in a custom folder does NOT match these is taken
+// to be the custom track. Built on first use rather than at static-init time so a failure to read
+// them lands in hook.log instead of before it is open.
+static const std::vector<TrackModelInfo> &default_track_model_infos() {
+    static const std::vector<TrackModelInfo> infos =
+        compute_track_model_infos("./data/lev01/out_modelblock.bin");
+    return infos;
+}
+static const std::vector<TrackSplineInfo> &default_spline_hashes() {
+    static const std::vector<TrackSplineInfo> hashes =
+        compute_spline_hashes("./data/lev01/out_splineblock.bin");
+    return hashes;
+}
 
 // this function tries to find the changed modelid/splineid in the block files by computing their
 // hashes.
@@ -96,9 +141,32 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
 
     int trackCounterInThisFolder = 0;
 
+    // A track model is only usable with a spline the game can actually evaluate: swrSpline_Interpolate
+    // walks swrSpline::control_points unconditionally, so a malformed entry faults on the first frame
+    // of the race instead of failing the load. Reject the pairing here and say why.
+    auto spline_is_usable = [&](const TrackSplineInfo &spline_info, int model_id) {
+        if (spline_info.bUsable)
+            return true;
+
+        fprintf(hook_log,
+                "[try_load_custom_track_folder] skipping track model %d in %s: spline %d is "
+                "malformed (%u control points, entry size does not match) -- racing it would "
+                "crash.\n",
+                model_id, folder.filename().generic_string().c_str(), spline_info.spline_id,
+                spline_info.num_control_points);
+        fflush(hook_log);
+        return false;
+    };
+
     auto add_track = [&](CustomTrack info) {
-        if (trackCount >= MAX_NB_TRACKS)
+        if (trackCount >= MAX_NB_TRACKS) {
+            fprintf(hook_log,
+                    "[try_load_custom_track_folder] dropping track from %s: the %d track slots are "
+                    "full.\n",
+                    folder.filename().generic_string().c_str(), MAX_NB_TRACKS);
+            fflush(hook_log);
             return;
+        }
 
         const int trackIndex = trackCount++;
         const int customID = custom_tracks.size();
@@ -138,16 +206,12 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
         model_infos = compute_track_model_infos(folder / "out_modelblock.bin");
         std::erase_if(model_infos, [](const TrackModelInfo &info) {
             const bool is_default_track =
-                std::find_if(default_track_model_infos.begin(), default_track_model_infos.end(),
+                std::find_if(default_track_model_infos().begin(), default_track_model_infos().end(),
                              [&](const TrackModelInfo &default_info) {
                                  return info.hash == default_info.hash;
-                             }) != default_track_model_infos.end();
+                             }) != default_track_model_infos().end();
             return is_default_track;
         });
-        /*for (int i = 0; i < infos.size(); i++) {
-            fprintf(hook_log, "model %d\n", infos[i].model_id);
-            fflush(hook_log);
-        }*/
     }
     if (model_infos.empty()) {
         fprintf(hook_log,
@@ -163,17 +227,12 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
         spline_hashes = compute_spline_hashes(folder / "out_splineblock.bin");
         std::erase_if(spline_hashes, [](const TrackSplineInfo &info) {
             const bool is_default_track =
-                std::find_if(default_spline_hashes.begin(), default_spline_hashes.end(),
+                std::find_if(default_spline_hashes().begin(), default_spline_hashes().end(),
                              [&](const TrackSplineInfo &default_info) {
                                  return info.hash == default_info.hash;
-                             }) != default_spline_hashes.end();
+                             }) != default_spline_hashes().end();
             return is_default_track;
         });
-
-        /*for (int i = 0; i < spline_hashes.size(); i++) {
-            fprintf(hook_log, "spline %d\n", spline_hashes[i].spline_id);
-            fflush(hook_log);
-        }*/
     }
     if (spline_hashes.empty()) {
         fprintf(hook_log,
@@ -186,9 +245,12 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
 
     // default case: there is one custom track model and spline in the file.
     if (model_infos.size() == 1 && spline_hashes.size() == 1) {
-        // fprintf(hook_log, "[try_load_custom_track_folder] found track %d with spline %d.\n",
-        //         model_infos.front().model_id, spline_hashes.front().spline_id);
-        // fflush(hook_log);
+        fprintf(hook_log, "[try_load_custom_track_folder] found track %d with spline %d.\n",
+                model_infos.front().model_id, spline_hashes.front().spline_id);
+        fflush(hook_log);
+
+        if (!spline_is_usable(spline_hashes.front(), model_infos.front().model_id))
+            return false;
 
         add_track(CustomTrack{
             .folder = folder,
@@ -196,10 +258,12 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
             .spline_id = spline_hashes.front().spline_id,
         });
     } else {
-        // fprintf(hook_log,
-        //         "[try_load_custom_track_folder] more than one custom model/spline in %s:\n    "
-        //         "searching for fitting spline for each model.\n",
-        //         folder.filename().generic_string().c_str());
+        fprintf(hook_log,
+                "[try_load_custom_track_folder] %d custom models / %d custom splines in %s:\n    "
+                "searching for a fitting spline for each model.\n",
+                (int) model_infos.size(), (int) spline_hashes.size(),
+                folder.filename().generic_string().c_str());
+        fflush(hook_log);
 
         // search for a spline for each custom model.
         for (const TrackModelInfo &model_info: model_infos) {
@@ -212,15 +276,17 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
                                                return info.spline_id == track_info.splineID;
                                            });
                     if (it == spline_hashes.end()) {
-                        // fprintf(hook_log,
-                        //         "[try_load_custom_track_folder] did not find a fitting spline for "
-                        //         "track model %d (expected spline %d).\n",
-                        //         model_info.model_id, track_info.splineID);
-                    } else {
-                        // fprintf(hook_log,
-                        //         "[try_load_custom_track_folder] found fitting spline %d for model "
-                        //         "%d.\n",
-                        //         it->spline_id, model_info.model_id);
+                        fprintf(hook_log,
+                                "[try_load_custom_track_folder] did not find a fitting spline for "
+                                "track model %d (expected spline %d).\n",
+                                model_info.model_id, track_info.splineID);
+                        fflush(hook_log);
+                    } else if (spline_is_usable(*it, model_info.model_id)) {
+                        fprintf(hook_log,
+                                "[try_load_custom_track_folder] found fitting spline %d for model "
+                                "%d.\n",
+                                it->spline_id, model_info.model_id);
+                        fflush(hook_log);
                         add_track({
                             .folder = folder,
                             .model_id = model_info.model_id,
@@ -287,6 +353,14 @@ void init_customTracks() {
     for (uint8_t i = 0; i < 25; i++)
         g_aNewTrackInfos[i] = g_aTrackInfos[i];
 
+    // Detection is a hash diff against the stock blocks, so a modified data/lev01 silently
+    // mis-pairs every custom track. Stamp the reference counts -- a stock install reads
+    // 25 track models / 91 splines.
+    fprintf(hook_log,
+            "[init_customTracks] reference blocks (data/lev01): %d track models, %d splines\n",
+            (int) default_track_model_infos().size(), (int) default_spline_hashes().size());
+    fflush(hook_log);
+
     const char *custom_tracks_path = "./assets/custom_tracks";
     if (std::filesystem::exists(custom_tracks_path) &&
         std::filesystem::is_directory(custom_tracks_path)) {
@@ -299,7 +373,13 @@ void init_customTracks() {
         fflush(hook_log);
     }
 
-    fprintf(hook_log, "[init_customTracks] Done\n");
+    for (int i = 0; i < (int) custom_tracks.size(); i++) {
+        fprintf(hook_log, "[init_customTracks] track %d \"%s\": model %d, spline %d from %s\n",
+                DEFAULT_NB_TRACKS + i, g_aCustomTrackNames[i], custom_tracks[i].model_id,
+                custom_tracks[i].spline_id, custom_tracks[i].folder.generic_string().c_str());
+    }
+
+    fprintf(hook_log, "[init_customTracks] Done: %d custom tracks\n", (int) custom_tracks.size());
     fflush(hook_log);
 }
 

--- a/dinput_hook/custom_tracks.cpp
+++ b/dinput_hook/custom_tracks.cpp
@@ -504,6 +504,13 @@ void fixup_custom_model_node(swrModel_Node *node) {
 }
 
 void fixup_custom_model(swrModel_Header *header) {
+    // swrModel_LoadFromId returns NULL for a model it cannot load; walking the entry list from
+    // there reads address 0x4 (entries[0] sits at offset 0, and the walk pre-increments). The
+    // caller still has to revert the block file paths afterwards, so bail out here rather than at
+    // the call site.
+    if (!header)
+        return;
+
     swrModel_HeaderEntry *curr = header->entries;
     curr++;
 

--- a/dinput_hook/custom_tracks.cpp
+++ b/dinput_hook/custom_tracks.cpp
@@ -528,6 +528,12 @@ bool prepare_loading_custom_track_model(MODELID *model_id) {
             currentCustomID = -1;
             currentCustomTrack = std::nullopt;
             crash_logger_stagef("loading stock track model %d", *model_id);
+
+            // Symmetric with the custom branch below: coming back to a stock track has to drop the
+            // texture cache a custom track left behind, or its entries get handed out as this
+            // track's textures. The block paths are already reverted here, so this re-reads
+            // data/lev01 and clears the table.
+            swrModel_InitializeTextureBuffer_delta();
         }
 
         return false;

--- a/dinput_hook/custom_tracks.cpp
+++ b/dinput_hook/custom_tracks.cpp
@@ -31,9 +31,8 @@ static std::vector<CustomTrack> custom_tracks;
 int currentCustomID = -1;
 std::optional<CustomTrack> currentCustomTrack = std::nullopt;
 
-// Slurp a whole block file. Returns an empty buffer if it cannot be read at all -- a missing or
-// unreadable data/lev01 block used to fault here (fseek on a null FILE*) before hook_log even
-// existed, which is the worst possible place for a mod to die silently.
+// Empty buffer if the file cannot be read: a missing data/lev01 block used to fault on
+// fseek(NULL) here, inside a static initializer, before hook_log was even open.
 static std::vector<char> read_block_file(const std::filesystem::path &file) {
     FILE *f = fopen(file.generic_string().c_str(), "rb");
     if (!f) {
@@ -71,11 +70,9 @@ std::vector<TrackSplineInfo> compute_spline_hashes(const std::filesystem::path &
             .bUsable = false,
         };
 
-        // A spline entry is a swrSpline header (big-endian on disk) immediately followed by its
-        // control points, so its size is fully determined by the control point count -- an
-        // invariant that holds exactly for all 91 stock entries. Record whether it holds, so a
-        // track is never paired with an entry that would hand swrSpline_Interpolate a garbage
-        // control_points array.
+        // An entry is a big-endian swrSpline header followed by its control points, so its size
+        // is determined by the control point count -- exact for all 91 stock entries. Pairing a
+        // track with an entry that fails this hands swrSpline_Interpolate a garbage array.
         if (entry_end <= entry_begin || entry_end > data.size() ||
             entry_end - entry_begin < sizeof(swrSpline))
             continue;
@@ -118,9 +115,8 @@ std::vector<TrackModelInfo> compute_track_model_infos(const std::filesystem::pat
 static_assert(sizeof(swrSpline) == 0x10);
 static_assert(sizeof(swrSplineControlPoint) == 0x54);
 
-// Reference hashes of the stock blocks: whatever in a custom folder does NOT match these is taken
-// to be the custom track. Built on first use rather than at static-init time so a failure to read
-// them lands in hook.log instead of before it is open.
+// Stock block hashes: whatever in a custom folder does NOT match is taken to be the custom
+// track. Built on first use, not at static-init, so a read failure can reach hook.log.
 static const std::vector<TrackModelInfo> &default_track_model_infos() {
     static const std::vector<TrackModelInfo> infos =
         compute_track_model_infos("./data/lev01/out_modelblock.bin");
@@ -141,9 +137,8 @@ bool try_load_custom_track_folder(const std::filesystem::path &folder) {
 
     int trackCounterInThisFolder = 0;
 
-    // A track model is only usable with a spline the game can actually evaluate: swrSpline_Interpolate
-    // walks swrSpline::control_points unconditionally, so a malformed entry faults on the first frame
-    // of the race instead of failing the load. Reject the pairing here and say why.
+    // swrSpline_Interpolate walks control_points unconditionally, so a malformed entry faults on
+    // the first frame of the race rather than failing the load. Reject the pairing instead.
     auto spline_is_usable = [&](const TrackSplineInfo &spline_info, int model_id) {
         if (spline_info.bUsable)
             return true;
@@ -353,9 +348,8 @@ void init_customTracks() {
     for (uint8_t i = 0; i < 25; i++)
         g_aNewTrackInfos[i] = g_aTrackInfos[i];
 
-    // Detection is a hash diff against the stock blocks, so a modified data/lev01 silently
-    // mis-pairs every custom track. Stamp the reference counts -- a stock install reads
-    // 25 track models / 91 splines.
+    // Detection diffs against these, so a modified data/lev01 silently mis-pairs every custom
+    // track. A stock install reads 25 track models / 91 splines.
     fprintf(hook_log,
             "[init_customTracks] reference blocks (data/lev01): %d track models, %d splines\n",
             (int) default_track_model_infos().size(), (int) default_spline_hashes().size());
@@ -389,24 +383,24 @@ void replace_block_filepaths(const std::filesystem::path &folder) {
 
     if (exists(folder / "out_modelblock.bin")) {
         modelblock_path = (folder / "out_modelblock.bin").generic_string();
-        *(const char **) 0x4B9598 = modelblock_path.c_str();
+        *SWR_MODELBLOCK_PATH_PTR = modelblock_path.c_str();
     }
 
     if (exists(folder / "out_splineblock.bin")) {
         splineblock_path = (folder / "out_splineblock.bin").generic_string();
-        *(const char **) 0x4B9590 = splineblock_path.c_str();
+        *SWR_SPLINEBLOCK_PATH_PTR = splineblock_path.c_str();
     }
 
     if (exists(folder / "out_textureblock.bin")) {
         textureblock_path = (folder / "out_textureblock.bin").generic_string();
-        *(const char **) 0x4B9594 = textureblock_path.c_str();
+        *SWR_TEXTUREBLOCK_PATH_PTR = textureblock_path.c_str();
     }
 }
 
 void revert_block_filepaths() {
-    *(const char **) 0x4B9598 = "data/lev01/out_modelblock.bin";
-    *(const char **) 0x4B9590 = "data/lev01/out_splineblock.bin";
-    *(const char **) 0x4B9594 = "data/lev01/out_textureblock.bin";
+    *SWR_MODELBLOCK_PATH_PTR = "data/lev01/out_modelblock.bin";
+    *SWR_SPLINEBLOCK_PATH_PTR = "data/lev01/out_splineblock.bin";
+    *SWR_TEXTUREBLOCK_PATH_PTR = "data/lev01/out_textureblock.bin";
 }
 
 // fixup functions: the n64 material flags and display list in custom tracks built with blender-swe1r
@@ -504,10 +498,9 @@ void fixup_custom_model_node(swrModel_Node *node) {
 }
 
 void fixup_custom_model(swrModel_Header *header) {
-    // swrModel_LoadFromId returns NULL for a model it cannot load; walking the entry list from
-    // there reads address 0x4 (entries[0] sits at offset 0, and the walk pre-increments). The
-    // caller still has to revert the block file paths afterwards, so bail out here rather than at
-    // the call site.
+    // swrModel_LoadFromId returns NULL for a model it cannot load, and walking from there reads
+    // address 0x4 (entries[0] is at offset 0, the walk pre-increments). Guarded here, not at the
+    // call site, because the caller still has to reach revert_block_filepaths().
     if (!header)
         return;
 
@@ -529,10 +522,8 @@ bool prepare_loading_custom_track_model(MODELID *model_id) {
             currentCustomTrack = std::nullopt;
             crash_logger_stagef("loading stock track model %d", *model_id);
 
-            // Symmetric with the custom branch below: coming back to a stock track has to drop the
-            // texture cache a custom track left behind, or its entries get handed out as this
-            // track's textures. The block paths are already reverted here, so this re-reads
-            // data/lev01 and clears the table.
+            // Symmetric with the custom branch below: a stock track has to drop the texture cache
+            // a custom track left behind. Block paths are already reverted, so this re-reads stock.
             swrModel_InitializeTextureBuffer_delta();
         }
 

--- a/dinput_hook/custom_tracks.cpp
+++ b/dinput_hook/custom_tracks.cpp
@@ -9,6 +9,7 @@
 #include "types.h"
 #include "n64_shader.h"
 #include "macros.h"
+#include "crash_logger.h"
 #include "imgui_internal.h"
 
 extern "C" {
@@ -439,6 +440,7 @@ bool prepare_loading_custom_track_model(MODELID *model_id) {
         if (isTrackModel(*model_id)) {
             currentCustomID = -1;
             currentCustomTrack = std::nullopt;
+            crash_logger_stagef("loading stock track model %d", *model_id);
         }
 
         return false;
@@ -446,6 +448,9 @@ bool prepare_loading_custom_track_model(MODELID *model_id) {
 
     currentCustomID = *model_id - CUSTOM_TRACK_MODELID_BEGIN;
     currentCustomTrack = custom_tracks.at(currentCustomID);
+    crash_logger_stagef("loading custom track \"%s\" (model %d) from %s",
+                        g_aCustomTrackNames[currentCustomID], currentCustomTrack.value().model_id,
+                        currentCustomTrack.value().folder.generic_string().c_str());
     replace_block_filepaths(currentCustomTrack.value().folder);
     *model_id = (MODELID) currentCustomTrack.value().model_id;
 
@@ -466,6 +471,9 @@ bool prepare_loading_custom_track_spline(SPLINEID *spline_id) {
 
     const int customID = *spline_id - CUSTOM_TRACK_MODELID_BEGIN;
     const CustomTrack &track = custom_tracks.at(customID);
+    crash_logger_stagef("loading custom track \"%s\" spline %d from %s",
+                        g_aCustomTrackNames[customID], track.spline_id,
+                        track.folder.generic_string().c_str());
     replace_block_filepaths(track.folder);
     *spline_id = (SPLINEID) track.spline_id;
 

--- a/dinput_hook/custom_tracks.h
+++ b/dinput_hook/custom_tracks.h
@@ -20,6 +20,11 @@ struct TrackModelInfo {
 struct TrackSplineInfo {
     int spline_id;
     uint32_t hash;
+    uint32_t num_control_points;
+    // false when the on-disk entry is not a well-formed spline (no control points, or a size that
+    // doesn't match the control point count). Pairing a track with one of these is what produces a
+    // garbage swrSpline::control_points and a crash on the first frame of the race.
+    bool bUsable;
 };
 
 extern int currentCustomID;

--- a/dinput_hook/custom_tracks.h
+++ b/dinput_hook/custom_tracks.h
@@ -22,10 +22,15 @@ struct TrackSplineInfo {
     uint32_t hash;
     uint32_t num_control_points;
     // false when the on-disk entry is not a well-formed spline (no control points, or a size that
-    // doesn't match the control point count). Pairing a track with one of these is what produces a
-    // garbage swrSpline::control_points and a crash on the first frame of the race.
+    // disagrees with the count). Pairing a track with one crashes on the first frame of the race.
     bool bUsable;
 };
+
+// The loader's three block file paths, as pointers into the game's own string globals.
+// Redirecting them is how a custom track's blocks load in place of data/lev01.
+#define SWR_SPLINEBLOCK_PATH_PTR ((const char **) 0x004B9590)
+#define SWR_TEXTUREBLOCK_PATH_PTR ((const char **) 0x004B9594)
+#define SWR_MODELBLOCK_PATH_PTR ((const char **) 0x004B9598)
 
 extern int currentCustomID;
 extern std::optional<CustomTrack> currentCustomTrack;

--- a/dinput_hook/game_deltas/swrAssetBuffer_delta.cpp
+++ b/dinput_hook/game_deltas/swrAssetBuffer_delta.cpp
@@ -20,17 +20,15 @@ extern "C" FILE *hook_log;
 //   00449046: e8 ..              CALL malloc
 //   0044904b: 8d 88 00 00 80 00  LEA ECX,[EAX + 0x800000] ; -> assetBufferEnd
 //
-// Everything else reads the buffer through assetBuffer / assetBufferEnd, so no other site encodes
-// the size. They must agree because swrAssetBuffer_CheckOverflow spins in an infinite loop if the
-// buffer top ever passes assetBufferEnd -- a half-applied pair would hang the game.
+// No other site encodes the size. The two must agree: swrAssetBuffer_CheckOverflow spins forever
+// if the buffer top passes assetBufferEnd, so a half-applied pair would hang the game.
 static const uint32_t kSizeSites[] = {
     0x00449042,// PUSH imm32: the malloc request
     0x0044904D,// LEA disp32: assetBufferEnd = assetBuffer + size
 };
 
-// How big the asset buffer should be, in bytes. Read straight from settings.ini rather than via
-// read_settings_ini(), which has not run this early -- the same thing read_hd_font_setting() does
-// for its own patch-time toggle.
+// Read straight from settings.ini: read_settings_ini() has not run this early, the same reason
+// read_hd_font_setting() does it for its own patch-time toggle.
 static uint32_t read_asset_buffer_size() {
     int mb = (int) GetPrivateProfileIntW(L"settings", L"asset_buffer_mb",
                                          SWR_ASSET_BUFFER_MB_DEFAULT, settings_ini_path());

--- a/dinput_hook/game_deltas/swrAssetBuffer_delta.cpp
+++ b/dinput_hook/game_deltas/swrAssetBuffer_delta.cpp
@@ -1,0 +1,91 @@
+#include "swrAssetBuffer_delta.h"
+
+#include <windows.h>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+#include <engine_config.h>
+}
+
+#include "../imgui_utils.h"// settings_ini_path
+#include "../patch.h"
+
+extern "C" FILE *hook_log;
+
+// swrScene_InitWorld sizes the asset buffer with two immediates that must agree -- the malloc
+// request and the end pointer derived from the same constant:
+//
+//   00449041: 68 00 00 80 00     PUSH 0x800000            ; malloc size
+//   00449046: e8 ..              CALL malloc
+//   0044904b: 8d 88 00 00 80 00  LEA ECX,[EAX + 0x800000] ; -> assetBufferEnd
+//
+// Everything else reads the buffer through assetBuffer / assetBufferEnd, so no other site encodes
+// the size. They must agree because swrAssetBuffer_CheckOverflow spins in an infinite loop if the
+// buffer top ever passes assetBufferEnd -- a half-applied pair would hang the game.
+static const uint32_t kSizeSites[] = {
+    0x00449042,// PUSH imm32: the malloc request
+    0x0044904D,// LEA disp32: assetBufferEnd = assetBuffer + size
+};
+
+// How big the asset buffer should be, in bytes. Read straight from settings.ini rather than via
+// read_settings_ini(), which has not run this early -- the same thing read_hd_font_setting() does
+// for its own patch-time toggle.
+static uint32_t read_asset_buffer_size() {
+    int mb = (int) GetPrivateProfileIntW(L"settings", L"asset_buffer_mb",
+                                         SWR_ASSET_BUFFER_MB_DEFAULT, settings_ini_path());
+
+    const int retail_mb = (int) (SWR_ASSET_BUFFER_SIZE_RETAIL / (1024u * 1024u));
+    if (mb < retail_mb) {
+        fprintf(hook_log,
+                "[swrAssetBuffer_PatchSize] asset_buffer_mb=%d is below retail; using %d MiB.\n",
+                mb, retail_mb);
+        fflush(hook_log);
+        mb = retail_mb;
+    } else if (mb > SWR_ASSET_BUFFER_MB_MAX) {
+        fprintf(hook_log,
+                "[swrAssetBuffer_PatchSize] asset_buffer_mb=%d exceeds the %d MiB ceiling; using "
+                "the ceiling.\n",
+                mb, SWR_ASSET_BUFFER_MB_MAX);
+        fflush(hook_log);
+        mb = SWR_ASSET_BUFFER_MB_MAX;
+    }
+
+    return (uint32_t) mb * 1024u * 1024u;
+}
+
+void swrAssetBuffer_PatchSize() {
+    static const PatchOwner kOwner = "asset_buffer_size";
+
+    const uint32_t retail = SWR_ASSET_BUFFER_SIZE_RETAIL;
+    const uint32_t wanted = read_asset_buffer_size();
+    if (wanted == retail)
+        return;
+
+    for (uint32_t address: kSizeSites) {
+        uint32_t found = 0;
+        std::memcpy(&found, (const void *) address, sizeof(found));
+        if (found == wanted)
+            continue;// already patched
+        if (found != retail) {
+            fprintf(hook_log,
+                    "[swrAssetBuffer_PatchSize] unexpected size 0x%x at 0x%x; leaving the asset "
+                    "buffer at retail (0x%x bytes).\n",
+                    found, address, retail);
+            fflush(hook_log);
+            UndoOwner(kOwner);// a half-applied pair would disagree with assetBufferEnd
+            return;
+        }
+
+        if (!PatchPointer(kOwner, (void *) address, wanted)) {
+            fprintf(hook_log, "[swrAssetBuffer_PatchSize] patch refused at 0x%x.\n", address);
+            fflush(hook_log);
+            UndoOwner(kOwner);
+            return;
+        }
+    }
+
+    fprintf(hook_log, "[swrAssetBuffer_PatchSize] asset buffer raised 0x%x -> 0x%x bytes.\n",
+            retail, wanted);
+    fflush(hook_log);
+}

--- a/dinput_hook/game_deltas/swrAssetBuffer_delta.h
+++ b/dinput_hook/game_deltas/swrAssetBuffer_delta.h
@@ -1,8 +1,6 @@
 #pragma once
 
-// Raises the asset buffer swrScene_InitWorld allocates above the retail 8 MiB, to the size
-// settings.ini asks for ([settings] asset_buffer_mb, default SWR_ASSET_BUFFER_MB_DEFAULT).
-// Applied as a verified in-place byte patch at startup, before swrScene_Startup runs -- the
-// buffer is malloc'd once and kept for the process, so the two immediates have to be right before
-// the allocation happens. See swrAssetBuffer_delta.cpp.
+// Resizes the asset buffer swrScene_InitWorld allocates to what settings.ini asks for
+// ([settings] asset_buffer_mb). Verified byte patch, and it must run before swrScene_Startup:
+// the buffer is allocated once and kept for the process.
 void swrAssetBuffer_PatchSize();

--- a/dinput_hook/game_deltas/swrAssetBuffer_delta.h
+++ b/dinput_hook/game_deltas/swrAssetBuffer_delta.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Raises the asset buffer swrScene_InitWorld allocates above the retail 8 MiB, to the size
+// settings.ini asks for ([settings] asset_buffer_mb, default SWR_ASSET_BUFFER_MB_DEFAULT).
+// Applied as a verified in-place byte patch at startup, before swrScene_Startup runs -- the
+// buffer is malloc'd once and kept for the process, so the two immediates have to be right before
+// the allocation happens. See swrAssetBuffer_delta.cpp.
+void swrAssetBuffer_PatchSize();

--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -204,31 +204,42 @@ void swrText_InitFonts_delta(void) {
 
 // We don't have the original function decompiled properly yet
 swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
-    // if (id > CUSTOM_TRACK_MODELID_BEGIN) {
-    //     fprintf(hook_log, "model id load: %d\n", id);
-    //     fflush(hook_log);
-    // }
+    const MODELID requested_id = id;
     const bool is_custom_track = prepare_loading_custom_track_model(&id);
 
     char *model_asset_pointer_begin = swrAssetBuffer_GetBuffer();
     swrModel_Header *header = hook_call_original(swrModel_LoadFromId, id);
     char *model_asset_pointer_end = swrAssetBuffer_GetBuffer();
+    // finalize_loading_custom_track_model must run even on a failed load -- it restores the block
+    // file paths, and leaving them pointed at the custom track's folder breaks every later load.
     if (is_custom_track) {
         finalize_loading_custom_track_model(header);
     } else {
         fixup_custom_model(header);
     }
 
-    // remove all models whose asset pointer is invalid:
+    // remove all models whose asset pointer is invalid: the asset buffer rewound past them, so
+    // they are stale whether or not this particular load succeeded.
     std::erase_if(asset_pointer_to_model, [&](const AssetPointerToModel &elem) {
         return elem.asset_pointer_begin >= model_asset_pointer_begin;
     });
 
-    asset_pointer_to_model.emplace_back() = {
-        model_asset_pointer_begin,
-        model_asset_pointer_end,
-        id,
-    };
+    if (!header) {
+        // The game asked for a model the loader could not provide -- most often because the asset
+        // buffer is exhausted, which a large custom track makes easy (see swrAssetBuffer). Name
+        // it, and register nothing: a failed load owns no asset range.
+        fprintf(hook_log,
+                "[swrModel_LoadFromId_delta] model %d (requested as %d) failed to load, %d bytes "
+                "of asset buffer left\n",
+                id, requested_id, swrAssetBuffer_RemainingSize());
+        fflush(hook_log);
+    } else {
+        asset_pointer_to_model.emplace_back() = {
+            model_asset_pointer_begin,
+            model_asset_pointer_end,
+            id,
+        };
+    }
 
     // setting this to 0 skips the generation of the renderDroid scene graph in the RenderAll
     // functions. it's not needed since the renderer replacement uses the swrModel_Node scene graph #

--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -254,6 +254,8 @@ swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
 #undef HD_FONT_HEIGHT
 
 void **texture_buffer_replacement = nullptr;
+// Which texture block the cached entries in texture_buffer_replacement were loaded from.
+static std::string texture_block_of_buffer;
 
 // 0x00447420
 void swrModel_InitializeTextureBuffer_delta() {
@@ -262,6 +264,8 @@ void swrModel_InitializeTextureBuffer_delta() {
     // assumes that the out_textureblock.bin file from the custom track only appends to the textures
     // and does not replace existing ones. the behavior is not totally clear if that happens.
     const uint32_t prev_texture_count = texture_count;
+    void **const prev_buffer = texture_buffer_replacement;
+    const void *const caller = __builtin_return_address(0);
 
     swrLoader_OpenBlock(swrLoader_TYPE_TEXTURE_BLOCK);
     swrLoader_ReadAt(swrLoader_TYPE_TEXTURE_BLOCK, 0, &texture_count, 4u);
@@ -269,10 +273,41 @@ void swrModel_InitializeTextureBuffer_delta() {
 
     texture_buffer_replacement =
         (void **) realloc(texture_buffer_replacement, texture_count * sizeof(uint32_t));
-    // clear the new textures:
-    if (prev_texture_count < texture_count)
+
+    // Every cached entry points into texture data read out of whichever block was mapped when it
+    // was loaded, so swapping blocks (stock <-> a custom track's) invalidates all of them at once
+    // -- keeping them means handing swrModel_LoadModelTexture a pointer belonging to the other
+    // block's data. Clear the whole table on a block change and let the textures reload; only a
+    // repeat init of the same block gets to keep its cache and clear just the growth.
+    const char *const block = *(const char **) 0x4B9594;
+    const bool block_changed = texture_block_of_buffer != block;
+    if (block_changed) {
+        memset(texture_buffer_replacement, 0, texture_count * sizeof(void *));
+        texture_block_of_buffer = block;
+    } else if (prev_texture_count < texture_count) {
+        // clear the new textures:
         memset(texture_buffer_replacement + prev_texture_count, 0,
                (texture_count - prev_texture_count) * sizeof(void *));
+    }
+
+    static int call_count = 0;
+    const uintptr_t caller_addr = (uintptr_t) caller;
+    char caller_text[32];
+    if (caller_addr >= 0x00401000 && caller_addr < 0x004AB800)
+        snprintf(caller_text, sizeof(caller_text), "SWEP1RCR.EXE+0x%x", (unsigned) caller_addr);
+    else
+        snprintf(caller_text, sizeof(caller_text), "%p", caller);
+
+    fprintf(hook_log,
+            "[swrModel_InitializeTextureBuffer_delta] call %d: textures %u -> %u, buffer %p -> %p "
+            "(%s), block '%s', %d bytes of asset buffer left, called from %s\n",
+            ++call_count, prev_texture_count, texture_count, (void *) prev_buffer,
+            (void *) texture_buffer_replacement,
+            prev_buffer == texture_buffer_replacement ? "same" : "MOVED", block,
+            swrAssetBuffer_RemainingSize(), caller_text);
+    fprintf(hook_log, "[swrModel_InitializeTextureBuffer_delta] cache %s\n",
+            block_changed ? "CLEARED (block changed)" : "kept (same block)");
+    fflush(hook_log);
 
     char *range_begin = (char *) 0x00447420;
     char *range_end = (char *) 0x004475ED;

--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -218,16 +218,15 @@ swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
         fixup_custom_model(header);
     }
 
-    // remove all models whose asset pointer is invalid: the asset buffer rewound past them, so
-    // they are stale whether or not this particular load succeeded.
+    // remove all models whose asset pointer is invalid: the buffer rewound past them, stale
+    // whether or not this load succeeded.
     std::erase_if(asset_pointer_to_model, [&](const AssetPointerToModel &elem) {
         return elem.asset_pointer_begin >= model_asset_pointer_begin;
     });
 
     if (!header) {
-        // The game asked for a model the loader could not provide -- most often because the asset
-        // buffer is exhausted, which a large custom track makes easy (see swrAssetBuffer). Name
-        // it, and register nothing: a failed load owns no asset range.
+        // Usually the asset buffer is exhausted, which a large custom track makes easy. Register
+        // nothing: a failed load owns no asset range.
         fprintf(hook_log,
                 "[swrModel_LoadFromId_delta] model %d (requested as %d) failed to load, %d bytes "
                 "of asset buffer left\n",
@@ -274,12 +273,11 @@ void swrModel_InitializeTextureBuffer_delta() {
     texture_buffer_replacement =
         (void **) realloc(texture_buffer_replacement, texture_count * sizeof(uint32_t));
 
-    // Every cached entry points into texture data read out of whichever block was mapped when it
-    // was loaded, so swapping blocks (stock <-> a custom track's) invalidates all of them at once
-    // -- keeping them means handing swrModel_LoadModelTexture a pointer belonging to the other
-    // block's data. Clear the whole table on a block change and let the textures reload; only a
-    // repeat init of the same block gets to keep its cache and clear just the growth.
-    const char *const block = *(const char **) 0x4B9594;
+    // Cached entries point into whichever block was mapped when they loaded, so a block swap
+    // (stock <-> custom) invalidates all of them -- keeping them hands swrModel_LoadModelTexture
+    // a pointer into the other block's data. Only a repeat init of the same block may keep its
+    // cache.
+    const char *const block = *SWR_TEXTUREBLOCK_PATH_PTR;
     const bool block_changed = texture_block_of_buffer != block;
     if (block_changed) {
         memset(texture_buffer_replacement, 0, texture_count * sizeof(void *));
@@ -293,7 +291,7 @@ void swrModel_InitializeTextureBuffer_delta() {
     static int call_count = 0;
     const uintptr_t caller_addr = (uintptr_t) caller;
     char caller_text[32];
-    if (caller_addr >= 0x00401000 && caller_addr < 0x004AB800)
+    if (caller_addr >= SWR_TEXT_ADDR_ && caller_addr <= SWR_TEXT_END_ADDR_)
         snprintf(caller_text, sizeof(caller_text), "SWEP1RCR.EXE+0x%x", (unsigned) caller_addr);
     else
         snprintf(caller_text, sizeof(caller_text), "%p", caller);

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -84,15 +84,13 @@ int fixup_invalid_node_ptrs(swrModel_Node *&node) {
 static void reset_lap_tracking(swrScore *scores); // 100-lap support, defined below
 
 unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore *scores) {
-    // Breadcrumb the race being set up, so a crash report says which track the player was on
-    // rather than just "past startup". The judge's model/spline ids are only valid after the
-    // original has run -- before it they still hold the previous track's.
+    // Breadcrumb the race so a crash report names the track. The judge's model/spline ids are
+    // only valid after the original has run; before it they hold the previous track's.
     crash_logger_stage("race: init track");
     // Drop cable nodes from the previous track so freed pointers aren't matched against new meshes.
     swrRace_ClearCableBends();
     const unsigned int x = hook_call_original(swrObjJdge_InitTrack, judge, scores);
-    // Asset buffer left once the whole track is resident: the number to compare between a stock
-    // track and a custom one when the grid gets cut short by the game's low-memory path.
+    // Asset buffer left with the track resident: what to compare when the grid is cut short.
     crash_logger_stagef("race: running track model %d spline %d on planet %d, %d bytes of asset "
                         "buffer left",
                         judge->unk1b0_modelId, judge->unk1b4_splineId, judge->planetId,

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -1161,7 +1161,7 @@ void swrObjJdge_F0_delta(swrObjJdge *jdge) {
 
     // Restore the dormant pre-race track fly-by. swrObjJdge_SetupTrackEnvironment already loads a
     // per-track cinematic camera spline (SPLINEID_*_track*came) into jdge->cam_spline, seeds the
-    // fly-by cursor at jdge->unk134_mat, and registers its output as camera index 5 -- it just ends
+    // fly-by cursor at jdge->camSweepCursor, and registers its output as camera index 5 -- it just ends
     // by zeroing jdge->camSweepState (so F0/F2 never walk the cursor) and never points the viewport
     // at camera 5. Re-enabling both during the pre-race state (nibble 4) plays the sweep: F2 walks
     // the cam-spline, F0 holds state 4 until the spline ends, then advances to the pod orbit. We
@@ -1172,13 +1172,12 @@ void swrObjJdge_F0_delta(swrObjJdge *jdge) {
     // Suppressed while a fast restart is skipping the intro -- the two have opposite intents (play
     // the sweep vs skip straight to the countdown), and the restart wins.
     if (imgui_state.restore_prerace_track_sweep && !fast_restart_skip) {
-        // unk134_mat is really the fly-by SPLINE CURSOR, not a matrix: swrObjJdge_F2+0x32 does
-        //   if ((flag & 0xf) == 4 && camSweepState) EvaluateToMatrix(&unk134_mat, &unk134_mat.vD);
-        // so its first field is the spline pointer. swrObjJdge_SetupTrackEnvironment leaves that
-        // unseeded on a custom track, and opening the gate then makes F2 evaluate a null spline --
-        // a black sweep that never ends, or a fault before the evaluator was guarded.
-        const void *sweepSpline = *(void *const *) &jdge->unk134_mat;
-        if (state == 4 && prevState != 4 && jdge->cam_spline != NULL && sweepSpline != NULL) {
+        // swrObjJdge_F2 (+0x32) evaluates camSweepCursor while camSweepState != NULL, and
+        // swrObjJdge_SetupTrackEnvironment leaves that cursor's spline NULL on a track with no
+        // camera path. Opening the gate then gives a black sweep that never ends (or, before
+        // swrSpline_EvaluateToMatrix_delta guarded it, a fault).
+        if (state == 4 && prevState != 4 && jdge->cam_spline != NULL &&
+            jdge->camSweepCursor.spline != NULL) {
             savedCamera = (short) unkCameraArrayIndex;
             jdge->camSweepState = jdge->cam_spline;// non-null gate (F0/F2 only test != 0)
             ((swrViewport_SetActiveCameraFn) swrViewport_SetActiveCamera_ADDR)(5);

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -1172,10 +1172,22 @@ void swrObjJdge_F0_delta(swrObjJdge *jdge) {
     // Suppressed while a fast restart is skipping the intro -- the two have opposite intents (play
     // the sweep vs skip straight to the countdown), and the restart wins.
     if (imgui_state.restore_prerace_track_sweep && !fast_restart_skip) {
-        if (state == 4 && prevState != 4 && jdge->cam_spline != NULL) {
+        // unk134_mat is really the fly-by SPLINE CURSOR, not a matrix: swrObjJdge_F2+0x32 does
+        //   if ((flag & 0xf) == 4 && camSweepState) EvaluateToMatrix(&unk134_mat, &unk134_mat.vD);
+        // so its first field is the spline pointer. swrObjJdge_SetupTrackEnvironment leaves that
+        // unseeded on a custom track, and opening the gate then makes F2 evaluate a null spline --
+        // a black sweep that never ends, or a fault before the evaluator was guarded.
+        const void *sweepSpline = *(void *const *) &jdge->unk134_mat;
+        if (state == 4 && prevState != 4 && jdge->cam_spline != NULL && sweepSpline != NULL) {
             savedCamera = (short) unkCameraArrayIndex;
             jdge->camSweepState = jdge->cam_spline;// non-null gate (F0/F2 only test != 0)
             ((swrViewport_SetActiveCameraFn) swrViewport_SetActiveCamera_ADDR)(5);
+        } else if (state == 4 && prevState != 4) {
+            fprintf(hook_log,
+                    "[prerace_sweep] no fly-by cursor for track model %d (cam_spline=%p); leaving "
+                    "the sweep dormant\n",
+                    jdge->unk1b0_modelId, (void *) jdge->cam_spline);
+            fflush(hook_log);
         } else if (state != 4 && prevState == 4 && savedCamera != 5) {
             jdge->camSweepState = NULL;
             ((swrViewport_SetActiveCameraFn) swrViewport_SetActiveCamera_ADDR)(savedCamera);

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -10,6 +10,7 @@ extern "C" {
 #include <Swr/swrText.h>
 #include <Swr/swrSprite.h>
 #include <Swr/swrViewport.h> // swrViewport_SetActiveCamera_ADDR (pre-race track fly-by restore)
+#include <Swr/swrAssetBuffer.h>// swrAssetBuffer_RemainingSize (track footprint log)
 #include <Swr/swrEvent.h>
 #include <Swr/swrMultiplayer.h>
 #include <Swr/swrSound.h>
@@ -23,6 +24,7 @@ extern FILE* hook_log;
 
 #include "../hook_helper.h"
 #include "../patch.h"
+#include "../crash_logger.h"
 #include "../ui_transform.h"
 #include "../imgui_utils.h"// imgui_state cutscene-skip toggles + fast_restart (debug-menu toggles)
 
@@ -82,9 +84,19 @@ int fixup_invalid_node_ptrs(swrModel_Node *&node) {
 static void reset_lap_tracking(swrScore *scores); // 100-lap support, defined below
 
 unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore *scores) {
+    // Breadcrumb the race being set up, so a crash report says which track the player was on
+    // rather than just "past startup". The judge's model/spline ids are only valid after the
+    // original has run -- before it they still hold the previous track's.
+    crash_logger_stage("race: init track");
     // Drop cable nodes from the previous track so freed pointers aren't matched against new meshes.
     swrRace_ClearCableBends();
     const unsigned int x = hook_call_original(swrObjJdge_InitTrack, judge, scores);
+    // Asset buffer left once the whole track is resident: the number to compare between a stock
+    // track and a custom one when the grid gets cut short by the game's low-memory path.
+    crash_logger_stagef("race: running track model %d spline %d on planet %d, %d bytes of asset "
+                        "buffer left",
+                        judge->unk1b0_modelId, judge->unk1b4_splineId, judge->planetId,
+                        swrAssetBuffer_RemainingSize());
     reset_lap_tracking(scores);
     capture_scene_animation_state();// record fresh animation state for a later fast restart
     g_countdown_ms = judge->countdownTimer_ms;// fresh countdown duration ('Begn' latched it above)

--- a/dinput_hook/game_deltas/swrSpline_delta.cpp
+++ b/dinput_hook/game_deltas/swrSpline_delta.cpp
@@ -11,6 +11,33 @@ extern "C" {
 
 extern FILE *hook_log;
 
+// 0x0044ed80
+void swrSpline_EvaluateToMatrix_delta(void *cursor, void *out) {
+    swrSplineCursor *c = (swrSplineCursor *) cursor;
+    if (c == NULL || c->spline == NULL) {
+        // Report once per distinct caller -- this runs per pod per frame, so an unfiltered log
+        // would bury everything else in hook.log.
+        static const void *seen[8] = {};
+        static int seen_count = 0;
+        const void *caller = __builtin_return_address(0);
+        bool known = false;
+        for (int i = 0; i < seen_count; i++)
+            known = known || seen[i] == caller;
+        if (!known) {
+            if (seen_count < (int) (sizeof(seen) / sizeof(seen[0])))
+                seen[seen_count++] = caller;
+            fprintf(hook_log,
+                    "[spline] refusing to evaluate a cursor with no spline: cursor=%p, called from "
+                    "%p\n",
+                    cursor, caller);
+            fflush(hook_log);
+        }
+        return;// leave `out` as it was; a stale transform beats a fault
+    }
+
+    hook_call_original(swrSpline_EvaluateToMatrix, cursor, (rdMatrix44 *) out);
+}
+
 // 0x004472e0
 char *swrSpline_LoadSplineById_delta(char *splineBuffer) {
     const bool is_custom_track = prepare_loading_custom_track_spline((SPLINEID *) &splineBuffer);

--- a/dinput_hook/game_deltas/swrSpline_delta.h
+++ b/dinput_hook/game_deltas/swrSpline_delta.h
@@ -1,3 +1,8 @@
 #pragma once
 
 char *swrSpline_LoadSplineById_delta(char *splineBuffer);
+
+// Choke point for every spline evaluation. swrSpline_Interpolate dereferences
+// cursor->spline (offset 0) unconditionally, so a cursor whose spline went away faults at
+// address 0. Skip the evaluation and name the caller instead of taking the process down.
+void swrSpline_EvaluateToMatrix_delta(void *cursor, void *out);

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -378,11 +378,10 @@ void HandleCircuits_delta(swrObjHang *hang) {
             g_CircuitIdxMax = 2;
         }
         // DELTA
-        // Custom tracks occupy the circuit pages past the four vanilla ones, and they live in free
-        // play only: that is the mode swrObjHang_InitTrackSprites_delta allocates their sprites
-        // for, and its circuitId < DEFAULT_NB_CIRCUIT_PER_TRACK assert says tournament must never
-        // reach them. Without raising the navigation limit here the pages exist but page-right
-        // stops at Invitational, so there is no way to select a custom track at all.
+        // Custom tracks occupy the pages past the four vanilla circuits, in free play only --
+        // the mode swrObjHang_InitTrackSprites_delta allocates their sprites for, and whose
+        // circuitId < DEFAULT_NB_CIRCUIT_PER_TRACK assert bars tournament. Without raising the
+        // limit here the pages exist but page-right stops at Invitational.
         if (trackCount > DEFAULT_NB_TRACKS) {
             g_CircuitIdxMax = GetCircuitCount(true) - 1;
         }
@@ -402,9 +401,9 @@ void HandleCircuits_delta(swrObjHang *hang) {
             g_CircuitIdxMax = 2;
         }
         // DELTA
-        // circuitIdx lives on the hangar state, so coming back from a free-play custom page into
-        // tournament can leave it past this mode's last circuit -- which would index
-        // g_aTracksInCircuits (4 entries) out of bounds below. Pull it back into range.
+        // circuitIdx lives on the hangar state, so returning from a free-play custom page into
+        // tournament can leave it past this mode's last circuit and index g_aTracksInCircuits
+        // (4 entries) out of bounds below.
         if (circuitId > g_CircuitIdxMax) {
             circuitId = g_CircuitIdxMax;
             hang->circuitIdx = (char) circuitId;

--- a/dinput_hook/game_deltas/tracks_delta.c
+++ b/dinput_hook/game_deltas/tracks_delta.c
@@ -377,27 +377,43 @@ void HandleCircuits_delta(swrObjHang *hang) {
         if (g_aBeatTracksGlobal[3] == '\0') {
             g_CircuitIdxMax = 2;
         }
-        for (uint8_t i = 0; i < g_aTracksInCircuits[circuitId]; i++) {
-            if ((g_aBeatTracksGlobal[circuitId] & (1 << i)) != 0) {
-                swrRace_MenuMaxSelection += 1;
-            }
-        }
-    } else {
         // DELTA
-        // if (swrRace_UnlockDataBase[4] == '\0') {
-        //     g_CircuitIdxMax = 2;
-        // }
-        g_CircuitIdxMax = GetCircuitCount(true) - 1;
-        // END DELTA
-        // DELTA if (cond) { original_game } else { body }
-        if (circuitId < 4) {
+        // Custom tracks occupy the circuit pages past the four vanilla ones, and they live in free
+        // play only: that is the mode swrObjHang_InitTrackSprites_delta allocates their sprites
+        // for, and its circuitId < DEFAULT_NB_CIRCUIT_PER_TRACK assert says tournament must never
+        // reach them. Without raising the navigation limit here the pages exist but page-right
+        // stops at Invitational, so there is no way to select a custom track at all.
+        if (trackCount > DEFAULT_NB_TRACKS) {
+            g_CircuitIdxMax = GetCircuitCount(true) - 1;
+        }
+        // DELTA if (cond) { body } else { original_game }
+        if (circuitId >= DEFAULT_NB_CIRCUIT_PER_TRACK) {
+            swrRace_MenuMaxSelection = GetTrackCount(circuitId);
+        } else {
+            // END DELTA
             for (uint8_t i = 0; i < g_aTracksInCircuits[circuitId]; i++) {
-                if ((swrRace_UnlockDataBase[circuitId + 1] & (char) (1 << ((char) i))) != 0) {
+                if ((g_aBeatTracksGlobal[circuitId] & (1 << i)) != 0) {
                     swrRace_MenuMaxSelection += 1;
                 }
             }
-        } else {
-            swrRace_MenuMaxSelection = GetTrackCount(circuitId);
+        }
+    } else {
+        if (swrRace_UnlockDataBase[4] == '\0') {
+            g_CircuitIdxMax = 2;
+        }
+        // DELTA
+        // circuitIdx lives on the hangar state, so coming back from a free-play custom page into
+        // tournament can leave it past this mode's last circuit -- which would index
+        // g_aTracksInCircuits (4 entries) out of bounds below. Pull it back into range.
+        if (circuitId > g_CircuitIdxMax) {
+            circuitId = g_CircuitIdxMax;
+            hang->circuitIdx = (char) circuitId;
+        }
+        // END DELTA
+        for (uint8_t i = 0; i < g_aTracksInCircuits[circuitId]; i++) {
+            if ((swrRace_UnlockDataBase[circuitId + 1] & (char) (1 << ((char) i))) != 0) {
+                swrRace_MenuMaxSelection += 1;
+            }
         }
     }
     if (multiplayer_enabled && (circuitId < '\x03')) {

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -2453,9 +2453,8 @@ extern "C" void init_renderer_hooks() {
     // hangar menu cap was also raised to 100 in tracks_delta.c.
     swrObjJdge_PatchLapTimeOverflow();
 
-    // Asset buffer size: has to land before swrScene_Startup, which malloc's the buffer once and
-    // keeps it for the process. A custom track can fill the retail 8 MiB on its own, leaving the
-    // pods to fail their loads and the grid to be cut short.
+    // Must land before swrScene_Startup, which allocates the asset buffer once and keeps it for
+    // the process.
     swrAssetBuffer_PatchSize();
 
     // Weather: the game's 80-particle, fixed-box, sprite-based system (whose motion-blur streak draw

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -2538,6 +2538,10 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) swrSpline_LoadSplineById_ADDR);
     hook_replace(swrSpline_LoadSplineById, swrSpline_LoadSplineById_delta);
 
+    hook_function("swrSpline_EvaluateToMatrix", (uint32_t) swrSpline_EvaluateToMatrix,
+                  (uint8_t *) swrSpline_EvaluateToMatrix_ADDR);
+    hook_replace(swrSpline_EvaluateToMatrix, swrSpline_EvaluateToMatrix_delta);
+
     fprintf(hook_log, "Done\n");
     fflush(hook_log);
 }

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -32,6 +32,7 @@ extern "C" {
 #include "./game_deltas/swrControl_delta.h"
 #include "./game_deltas/swrModel_delta.h"
 #include "./game_deltas/swrSpline_delta.h"
+#include "./game_deltas/swrAssetBuffer_delta.h"
 #include "./game_deltas/swrObjJdge_delta.h"
 #include "./game_deltas/swrGamepadNav_delta.h"
 #include "./game_deltas/swrMultiplayer_delta.h"
@@ -2451,6 +2452,11 @@ extern "C" void init_renderer_hooks() {
     // counts above 5 no longer corrupt the score struct (the real hardcoded 5-lap limit). The
     // hangar menu cap was also raised to 100 in tracks_delta.c.
     swrObjJdge_PatchLapTimeOverflow();
+
+    // Asset buffer size: has to land before swrScene_Startup, which malloc's the buffer once and
+    // keeps it for the process. A custom track can fill the retail 8 MiB on its own, leaving the
+    // pods to fail their loads and the grid to be cut short.
+    swrAssetBuffer_PatchSize();
 
     // Weather: the game's 80-particle, fixed-box, sprite-based system (whose motion-blur streak draw
     // was stubbed out) is replaced with our own particle simulation drawn in the GL layer --

--- a/src/Swr/swrObj.c
+++ b/src/Swr/swrObj.c
@@ -759,7 +759,7 @@ void swrObjJdge_F0(swrObjJdge* jdge)
         if (jdge->camSweepState == NULL) {
             advance = true;
         } else {
-            if (jdge->unk134_mat.vC.x == 0.0f)
+            if (jdge->camSweepCursor.endFlag == 0)
                 jdge->raceTimer_ms -= (float)swrRace_deltaTimeSecs;
             else if ((flags & 0x80) != 0)
                 jdge->raceTimer_ms += (float)swrRace_deltaTimeSecs;
@@ -767,7 +767,7 @@ void swrObjJdge_F0(swrObjJdge* jdge)
                 jdge->raceTimer_ms = 0.0f;
                 jdge->flag = flags | 0x80;
             }
-            if (jdge->unk134_mat.vC.x != 0.0f && 0.5f < jdge->raceTimer_ms)
+            if (jdge->camSweepCursor.endFlag != 0 && 0.5f < jdge->raceTimer_ms)
                 advance = true;
         }
         if (advance) {
@@ -1592,22 +1592,23 @@ int swrObjJdge_F4(swrObjJdge* jdge, int* subEvents, int p3)
         jdge->unk1d8 = 0;
         jdge->unk1dc = 0;
         jdge->camSweepState = NULL;
-        jdge->unk134_mat.vD.x = 1.0f;
-        jdge->unk134_mat.vD.y = 0.0f;
-        jdge->unk134_mat.vD.z = 0.0f;
-        jdge->unk134_mat.vD.w = 0.0f;
-        jdge->unk174[0] = 0.0f;
-        jdge->unk174[1] = 1.0f;
-        jdge->unk174[2] = 0.0f;
-        jdge->unk174[3] = 0.0f;
-        jdge->unk174[4] = 0.0f;
-        jdge->unk174[5] = 0.0f;
-        jdge->unk174[6] = 1.0f;
-        jdge->unk174[7] = 0.0f;
-        jdge->unk174[8] = 0.0f;
-        jdge->unk174[9] = 0.0f;
-        jdge->unk174[10] = 0.0f;
-        jdge->unk1a0 = 1.0f;
+        // camSweepTransform = identity, written field by field as the original does
+        jdge->camSweepTransform.vA.x = 1.0f;
+        jdge->camSweepTransform.vA.y = 0.0f;
+        jdge->camSweepTransform.vA.z = 0.0f;
+        jdge->camSweepTransform.vA.w = 0.0f;
+        jdge->camSweepTransform.vB.x = 0.0f;
+        jdge->camSweepTransform.vB.y = 1.0f;
+        jdge->camSweepTransform.vB.z = 0.0f;
+        jdge->camSweepTransform.vB.w = 0.0f;
+        jdge->camSweepTransform.vC.x = 0.0f;
+        jdge->camSweepTransform.vC.y = 0.0f;
+        jdge->camSweepTransform.vC.z = 1.0f;
+        jdge->camSweepTransform.vC.w = 0.0f;
+        jdge->camSweepTransform.vD.x = 0.0f;
+        jdge->camSweepTransform.vD.y = 0.0f;
+        jdge->camSweepTransform.vD.z = 0.0f;
+        jdge->camSweepTransform.vD.w = 1.0f;
         jdge->cam_spline = NULL;
         jdge->unk1a8 = 0;
         jdge->unk1e0 = 0;

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -51,4 +51,16 @@
 #define SWR_CTL_SCRIPT6_LAP_MIN (0.093f)       // ai_track_script==6 scripted-zone lapComp bounds
 #define SWR_CTL_SCRIPT6_LAP_MAX (0.108f)
 
+// Asset buffer (swrScene_InitWorld @0x00449040): one malloc, held for the process, that every
+// track model, spline and texture is read into. Retail asks for 8 MiB, which a custom track can
+// fill on its own -- leaving no room for the pods, so the game cuts the grid ("Low Memory: %d
+// Racers") and swrModel_LoadFromId starts returning NULL. Overrunning it is worse:
+// swrAssetBuffer_CheckOverflow spins forever rather than failing.
+// The size is read from settings.ini ([settings] asset_buffer_mb) so a player who installs a pack
+// heavier than the default does not need a new build; these bound and default that value. Never
+// below retail: a smaller buffer would overflow where stock does not.
+#define SWR_ASSET_BUFFER_SIZE_RETAIL (0x800000U) // 8 MiB, the size retail mallocs
+#define SWR_ASSET_BUFFER_MB_DEFAULT (16) // used when settings.ini says nothing
+#define SWR_ASSET_BUFFER_MB_MAX (256) // ceiling, so a typo can't request the unbackable
+
 #endif // ENGINE_CONFIG_H

--- a/src/engine_config.h
+++ b/src/engine_config.h
@@ -51,14 +51,11 @@
 #define SWR_CTL_SCRIPT6_LAP_MIN (0.093f)       // ai_track_script==6 scripted-zone lapComp bounds
 #define SWR_CTL_SCRIPT6_LAP_MAX (0.108f)
 
-// Asset buffer (swrScene_InitWorld @0x00449040): one malloc, held for the process, that every
-// track model, spline and texture is read into. Retail asks for 8 MiB, which a custom track can
-// fill on its own -- leaving no room for the pods, so the game cuts the grid ("Low Memory: %d
-// Racers") and swrModel_LoadFromId starts returning NULL. Overrunning it is worse:
-// swrAssetBuffer_CheckOverflow spins forever rather than failing.
-// The size is read from settings.ini ([settings] asset_buffer_mb) so a player who installs a pack
-// heavier than the default does not need a new build; these bound and default that value. Never
-// below retail: a smaller buffer would overflow where stock does not.
+// Asset buffer (swrScene_InitWorld @0x00449040): one allocation, held for the process, that every
+// track model, spline and texture is read into. Retail's 8 MiB can be filled by a custom track
+// alone, leaving no room for the pods; overrunning it spins forever in
+// swrAssetBuffer_CheckOverflow. Sized from settings.ini ([settings] asset_buffer_mb), bounded
+// below by retail because a smaller buffer would overflow where stock does not.
 #define SWR_ASSET_BUFFER_SIZE_RETAIL (0x800000U) // 8 MiB, the size retail mallocs
 #define SWR_ASSET_BUFFER_MB_DEFAULT (16) // used when settings.ini says nothing
 #define SWR_ASSET_BUFFER_MB_MAX (256) // ceiling, so a typo can't request the unbackable

--- a/src/types.h
+++ b/src/types.h
@@ -4,9 +4,18 @@
 // Ghidra: File -> Parse C Source -> Add types.h -> Parse to Program -> Use open archive
 
 #include <windows.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+// Layout assertion usable from both the C reimpls and the C++ delta layer. Ghidra's C parser
+// skips it along with the rest of the preprocessor.
+#ifdef __cplusplus
+#define SWR_ASSERT_LAYOUT(cond, msg) static_assert(cond, msg)
+#else
+#define SWR_ASSERT_LAYOUT(cond, msg) _Static_assert(cond, msg)
+#endif
 
 #include "types_a3d.h"
 #include "types_directx.h"
@@ -778,13 +787,9 @@ extern "C"
         int hud_mode; // 0x124. annodue: _hud_mode
         int event;
         char unk128[4];
-        void* camSweepState; // 0x130 (the field order puts it here, not 0x12c). camera-sweep gate; while non-null F2 walks unk134_mat and F0 gates the finish -> results transition on it
-        // 0x134. NOT a matrix: swrObjJdge_F2+0x32 passes it to swrSpline_EvaluateToMatrix as the
-        // fly-by CURSOR (swrSplineCursor, 0x30) and takes the output matrix at +0x30 (0x164), so
-        // vA.x is cursor.spline and vC.x is cursor.endFlag. Retyping it is a follow-up.
-        rdMatrix44 unk134_mat;
-        float unk174[11];
-        float unk1a0; // 0x1a0. reset to 1.0 at 'Load'; purpose not yet identified (no reader found in the judge functions)
+        void* camSweepState; // 0x130. camera-sweep gate; while non-null F2 walks camSweepCursor and F0 gates the finish -> results transition on it
+        swrSplineCursor camSweepCursor; // 0x134. cinematic camera path walker. swrObjJdge_F2 (+0x32) evaluates it into camSweepTransform while camSweepState != NULL; seeded by swrObjJdge_SetupTrackEnvironment, and left with a NULL spline on a track that has no camera path
+        rdMatrix44 camSweepTransform; // 0x164. swrSpline_EvaluateToMatrix output for the sweep; reset to identity at 'Load'/'RSet'
         void* cam_spline;
         int unk1a8;
         int planetId;
@@ -803,6 +808,12 @@ extern "C"
         int unk1e0;
         float unk1e4;
     } swrObjJdge; // sizeof(0x1e8)
+    // camSweepCursor/camSweepTransform replaced a single rdMatrix44 plus two float runs covering
+    // the same 0x70 bytes; pin the layout so a future edit cannot shift the fields after them.
+    SWR_ASSERT_LAYOUT(sizeof(swrObjJdge) == 0x1e8, "swrObjJdge size changed");
+    SWR_ASSERT_LAYOUT(offsetof(swrObjJdge, camSweepCursor) == 0x134, "camSweepCursor moved");
+    SWR_ASSERT_LAYOUT(offsetof(swrObjJdge, camSweepTransform) == 0x164, "camSweepTransform moved");
+    SWR_ASSERT_LAYOUT(offsetof(swrObjJdge, cam_spline) == 0x1a4, "cam_spline moved");
 
     typedef struct swrObjScen
     {

--- a/src/types.h
+++ b/src/types.h
@@ -778,8 +778,11 @@ extern "C"
         int hud_mode; // 0x124. annodue: _hud_mode
         int event;
         char unk128[4];
-        void* camSweepState; // 0x12c. post-race camera-sweep state; while non-null F2 walks unk134_mat and F0 gates the finish -> results transition on it
-        rdMatrix44 unk134_mat; // 0x134. post-race fly-by transform, driven by swrSpline_EvaluateToMatrix only while camSweepState != NULL
+        void* camSweepState; // 0x130 (the field order puts it here, not 0x12c). camera-sweep gate; while non-null F2 walks unk134_mat and F0 gates the finish -> results transition on it
+        // 0x134. NOT a matrix: swrObjJdge_F2+0x32 passes it to swrSpline_EvaluateToMatrix as the
+        // fly-by CURSOR (swrSplineCursor, 0x30) and takes the output matrix at +0x30 (0x164), so
+        // vA.x is cursor.spline and vC.x is cursor.endFlag. Retyping it is a follow-up.
+        rdMatrix44 unk134_mat;
         float unk174[11];
         float unk1a0; // 0x1a0. reset to 1.0 at 'Load'; purpose not yet identified (no reader found in the judge functions)
         void* cam_spline;


### PR DESCRIPTION
Stacked on #296 - merge that first; the first 8 commits are its.

Follow-up to the pre-race fly-by fix in #296, which documented this but did not act on it.

`swrObjJdge_F2` (+0x32) passes `jdge+0x134` to `swrSpline_EvaluateToMatrix` as a cursor and
takes the output matrix at +0x30 from it:

```c
if (((jdge->flag & 0xf) == 4) && camSweepState)
    swrSpline_EvaluateToMatrix(&jdge->unk134_mat, &jdge->unk134_mat.vD);
```

So the 0x70 bytes modelled as `rdMatrix44 unk134_mat` + `float unk174[11]` + `float unk1a0`
are really `swrSplineCursor camSweepCursor` (0x134) followed by `rdMatrix44
camSweepTransform` (0x164).

The `'Load'`/`'RSet'` handler confirms it independently: its sixteen writes
(`unk134_mat.vD.x..w`, `unk174[0..10]`, `unk1a0`) are exactly the identity matrix once mapped
onto `camSweepTransform`.

| old | offset | new |
|---|---|---|
| `unk134_mat.vD.x..w = 1,0,0,0` | 0x164-0x170 | `camSweepTransform.vA` |
| `unk174[0..3] = 0,1,0,0` | 0x174-0x180 | `camSweepTransform.vB` |
| `unk174[4..7] = 0,0,1,0` | 0x184-0x190 | `camSweepTransform.vC` |
| `unk174[8..10] = 0,0,0`, `unk1a0 = 1` | 0x194-0x1a0 | `camSweepTransform.vD` |

Two readers gain meaning. F2's advance gate tested `unk134_mat.vC.x`, which is
`camSweepCursor.endFlag` -- whether the sweep reached the end of its path. And `unk1a0`,
previously "purpose not yet identified", is `camSweepTransform.vD.w`.

It also removes the cast #296's sweep guard needed to read a spline pointer out of a field
typed as a matrix.

Layout pinned with static assertions (size 0x1e8 unchanged, plus the offsets of
`camSweepCursor` / `camSweepTransform` / `cam_spline`), through a `SWR_ASSERT_LAYOUT` macro
so they compile from both the C reimpls and the C++ delta layer. `GenerateMasterHeader.py`
still parses the header.

No behaviour change: the reimpl readers are reverse-hooked and dormant, and the one live
site reads the same address through a named field instead of a cast.
