### PR TITLE
fix(screenshot): F12 crashes the game (#289)

### DIFF
--- a/dinput_hook/game_deltas/sithRender_delta.cpp
+++ b/dinput_hook/game_deltas/sithRender_delta.cpp
@@ -13,22 +13,40 @@ extern "C" {
 #include "globals.h"
 }
 
-extern "C" FILE* hook_log;
+extern "C" FILE *hook_log;
 
 // Armed by the F12 handler, consumed at end of frame. Empty means nothing pending.
 static std::string g_pending_screenshot;
 
+// Time of the last accepted request, in glfwGetTime() seconds; negative means "none yet".
+//
+// swrMain_ProcessDebugKeys has no rising-edge check on F12, so one press can ask for a screenshot
+// more than once and write several files. Two approaches do not work here. A frame count does not:
+// measured on a 2560x1377 capture the repeat came two frames later, but two other presses in the
+// same run never repeated at all, so how long the key happens to be held decides it. Reading the
+// physical key state does not either: the handler fires a frame or more after the key-down edge, so
+// by the time the request arrives the key already reads as held and every press gets swallowed.
+//
+// What does separate them is the spacing. Across the runs, repeats landed 47-70 ms behind their
+// press, while deliberate presses were never closer than 1.8 s. A debounce anywhere in that gap
+// collapses a press to one file, and a quarter second is far below what a person can intend as two
+// screenshots.
+static double g_last_request_time = -1.0;
+
+// Requests closer together than this are the same press. See the note above for the measurements.
+static constexpr double SCREENSHOT_DEBOUNCE_SECONDS = 0.25;
+
 // 24-bit bottom-up BMP. glReadPixels already hands back rows bottom-up in GL_BGR order, which is
 // exactly the on-disk layout, so the rows go straight out with only the 4-byte stride padding
 // applied.
-static bool write_bmp_24(const char* filename, int width, int height,
-                         const std::vector<uint8_t>& bgr) {
+static bool write_bmp_24(const char *filename, int width, int height,
+                         const std::vector<uint8_t> &bgr) {
     const int row_bytes = width * 3;
     const int padded_row = (row_bytes + 3) & ~3;
     const uint32_t pixel_bytes = (uint32_t) padded_row * (uint32_t) height;
     const uint32_t pixel_offset = 14 + 40;
 
-    FILE* f = fopen(filename, "wb");
+    FILE *f = fopen(filename, "wb");
     if (!f)
         return false;
 
@@ -66,11 +84,20 @@ static bool write_bmp_24(const char* filename, int width, int height,
     return ok;
 }
 
-void sithRender_MakeScreenShot_delta(char* prefix) {
+void sithRender_MakeScreenShot_delta(char *prefix) {
+    // Swallow the repeat before picking a name, so it does not burn a file index and leave a gap in
+    // the numbering.
+    const double now = glfwGetTime();
+    if (g_last_request_time >= 0.0 && (now - g_last_request_time) < SCREENSHOT_DEBOUNCE_SECONDS) {
+        g_last_request_time = now;
+        return;
+    }
+    g_last_request_time = now;
+
     // Same numbering the original uses: walk the index until a name is free, and leave
     // stdDisplay_ScreenshotIndex past it so the next shot starts from there.
     char filename[80];
-    FILE* probe = NULL;
+    FILE *probe = NULL;
     do {
         const int index = stdDisplay_ScreenshotIndex;
         stdDisplay_ScreenshotIndex = index + 1;
@@ -81,8 +108,8 @@ void sithRender_MakeScreenShot_delta(char* prefix) {
         fclose(probe);
     } while (true);
 
-    // Arm only; the frame is not finished at input time. A second F12 in the same frame keeps the
-    // first name rather than dropping a numbered file that never gets written.
+    // Arm only; the frame is not finished at input time. A second request in the same frame keeps
+    // the first name rather than dropping a numbered file that never gets written.
     if (g_pending_screenshot.empty())
         g_pending_screenshot = filename;
 }
@@ -96,7 +123,7 @@ void sithRender_CapturePendingScreenshot(void) {
 
     int width = 0;
     int height = 0;
-    GLFWwindow* window = glfwGetCurrentContext();
+    GLFWwindow *window = glfwGetCurrentContext();
     if (window)
         glfwGetFramebufferSize(window, &width, &height);
     if (width <= 0 || height <= 0)

--- a/dinput_hook/game_deltas/sithRender_delta.cpp
+++ b/dinput_hook/game_deltas/sithRender_delta.cpp
@@ -1,0 +1,127 @@
+#include "sithRender_delta.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+extern "C" {
+#include "globals.h"
+}
+
+extern "C" FILE* hook_log;
+
+// Armed by the F12 handler, consumed at end of frame. Empty means nothing pending.
+static std::string g_pending_screenshot;
+
+// 24-bit bottom-up BMP. glReadPixels already hands back rows bottom-up in GL_BGR order, which is
+// exactly the on-disk layout, so the rows go straight out with only the 4-byte stride padding
+// applied.
+static bool write_bmp_24(const char* filename, int width, int height,
+                         const std::vector<uint8_t>& bgr) {
+    const int row_bytes = width * 3;
+    const int padded_row = (row_bytes + 3) & ~3;
+    const uint32_t pixel_bytes = (uint32_t) padded_row * (uint32_t) height;
+    const uint32_t pixel_offset = 14 + 40;
+
+    FILE* f = fopen(filename, "wb");
+    if (!f)
+        return false;
+
+    uint8_t header[14 + 40] = {0};
+    // BITMAPFILEHEADER
+    header[0] = 'B';
+    header[1] = 'M';
+    const uint32_t file_size = pixel_offset + pixel_bytes;
+    std::memcpy(&header[2], &file_size, 4);
+    std::memcpy(&header[10], &pixel_offset, 4);
+    // BITMAPINFOHEADER
+    const uint32_t info_size = 40;
+    const int32_t w32 = width;
+    const int32_t h32 = height;
+    const uint16_t planes = 1;
+    const uint16_t bpp = 24;
+    std::memcpy(&header[14], &info_size, 4);
+    std::memcpy(&header[18], &w32, 4);
+    std::memcpy(&header[22], &h32, 4);
+    std::memcpy(&header[26], &planes, 2);
+    std::memcpy(&header[28], &bpp, 2);
+    std::memcpy(&header[34], &pixel_bytes, 4);
+
+    bool ok = fwrite(header, 1, sizeof(header), f) == sizeof(header);
+
+    static const uint8_t padding[3] = {0, 0, 0};
+    const int pad = padded_row - row_bytes;
+    for (int y = 0; ok && y < height; y++) {
+        ok = fwrite(&bgr[(size_t) y * row_bytes], 1, row_bytes, f) == (size_t) row_bytes;
+        if (ok && pad)
+            ok = fwrite(padding, 1, pad, f) == (size_t) pad;
+    }
+
+    fclose(f);
+    return ok;
+}
+
+void sithRender_MakeScreenShot_delta(char* prefix) {
+    // Same numbering the original uses: walk the index until a name is free, and leave
+    // stdDisplay_ScreenshotIndex past it so the next shot starts from there.
+    char filename[80];
+    FILE* probe = NULL;
+    do {
+        const int index = stdDisplay_ScreenshotIndex;
+        stdDisplay_ScreenshotIndex = index + 1;
+        snprintf(filename, sizeof(filename), "%s%03d.bmp", prefix ? prefix : "snap_", index);
+        probe = fopen(filename, "rb");
+        if (probe == NULL)
+            break;
+        fclose(probe);
+    } while (true);
+
+    // Arm only; the frame is not finished at input time. A second F12 in the same frame keeps the
+    // first name rather than dropping a numbered file that never gets written.
+    if (g_pending_screenshot.empty())
+        g_pending_screenshot = filename;
+}
+
+void sithRender_CapturePendingScreenshot(void) {
+    if (g_pending_screenshot.empty())
+        return;
+
+    const std::string filename = g_pending_screenshot;
+    g_pending_screenshot.clear();
+
+    int width = 0;
+    int height = 0;
+    GLFWwindow* window = glfwGetCurrentContext();
+    if (window)
+        glfwGetFramebufferSize(window, &width, &height);
+    if (width <= 0 || height <= 0)
+        return;
+
+    std::vector<uint8_t> pixels((size_t) width * height * 3);
+
+    // The scene has already been blitted into framebuffer 0 by swrViewport_Render_Hook. Read from
+    // the front-most complete image, and force a tight row stride so the buffer matches the width.
+    GLint prev_read_fb = 0;
+    GLint prev_pack_align = 4;
+    glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &prev_read_fb);
+    glGetIntegerv(GL_PACK_ALIGNMENT, &prev_pack_align);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    glReadBuffer(GL_BACK);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, width, height, GL_BGR, GL_UNSIGNED_BYTE, pixels.data());
+    glPixelStorei(GL_PACK_ALIGNMENT, prev_pack_align);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, prev_read_fb);
+
+    if (!write_bmp_24(filename.c_str(), width, height, pixels)) {
+        fprintf(hook_log, "[screenshot] failed to write %s\n", filename.c_str());
+        fflush(hook_log);
+        return;
+    }
+    fprintf(hook_log, "[screenshot] wrote %s (%dx%d)\n", filename.c_str(), width, height);
+    fflush(hook_log);
+}

--- a/dinput_hook/game_deltas/sithRender_delta.cpp
+++ b/dinput_hook/game_deltas/sithRender_delta.cpp
@@ -19,60 +19,67 @@ extern "C" FILE *hook_log;
 static std::string g_pending_screenshot;
 
 // Time of the last accepted request, in glfwGetTime() seconds; negative means "none yet".
-//
-// swrMain_ProcessDebugKeys has no rising-edge check on F12, so one press can ask for a screenshot
-// more than once and write several files. Two approaches do not work here. A frame count does not:
-// measured on a 2560x1377 capture the repeat came two frames later, but two other presses in the
-// same run never repeated at all, so how long the key happens to be held decides it. Reading the
-// physical key state does not either: the handler fires a frame or more after the key-down edge, so
-// by the time the request arrives the key already reads as held and every press gets swallowed.
-//
-// What does separate them is the spacing. Across the runs, repeats landed 47-70 ms behind their
-// press, while deliberate presses were never closer than 1.8 s. A debounce anywhere in that gap
-// collapses a press to one file, and a quarter second is far below what a person can intend as two
-// screenshots.
+// swrMain_ProcessDebugKeys has no rising-edge check on F12, so one press can ask for a capture
+// more than once. Neither a frame count nor the physical key state separates a repeat from a
+// second press: the repeat lands a variable number of frames out, and the handler runs after the
+// key-down edge so the key always reads as held. Spacing does -- measured repeats sit 47-70 ms
+// behind their press, deliberate presses no closer than 1.8 s.
 static double g_last_request_time = -1.0;
 
-// Requests closer together than this are the same press. See the note above for the measurements.
 static constexpr double SCREENSHOT_DEBOUNCE_SECONDS = 0.25;
 
-// 24-bit bottom-up BMP. glReadPixels already hands back rows bottom-up in GL_BGR order, which is
-// exactly the on-disk layout, so the rows go straight out with only the 4-byte stride padding
-// applied.
+// BMP layout (BITMAPFILEHEADER + BITMAPINFOHEADER, both fixed by the format).
+static constexpr int BMP_FILE_HEADER_SIZE = 14;
+static constexpr int BMP_INFO_HEADER_SIZE = 40;
+static constexpr int BMP_PIXEL_OFFSET = BMP_FILE_HEADER_SIZE + BMP_INFO_HEADER_SIZE;
+static constexpr int BMP_BITS_PER_PIXEL = 24;
+static constexpr int BMP_BYTES_PER_PIXEL = 3;
+static constexpr int BMP_ROW_ALIGN = 4;// each row is padded up to a 4-byte boundary
+
+// Field offsets within the two headers, in the order the format lays them out.
+static constexpr int BMP_OFF_FILE_SIZE = 2;
+static constexpr int BMP_OFF_PIXEL_OFFSET = 10;
+static constexpr int BMP_OFF_INFO_SIZE = BMP_FILE_HEADER_SIZE + 0;
+static constexpr int BMP_OFF_WIDTH = BMP_FILE_HEADER_SIZE + 4;
+static constexpr int BMP_OFF_HEIGHT = BMP_FILE_HEADER_SIZE + 8;
+static constexpr int BMP_OFF_PLANES = BMP_FILE_HEADER_SIZE + 12;
+static constexpr int BMP_OFF_BIT_COUNT = BMP_FILE_HEADER_SIZE + 14;
+static constexpr int BMP_OFF_IMAGE_SIZE = BMP_FILE_HEADER_SIZE + 20;
+
+// glReadPixels hands back rows bottom-up in GL_BGR, which is the on-disk layout, so rows go
+// straight out with only stride padding applied.
 static bool write_bmp_24(const char *filename, int width, int height,
                          const std::vector<uint8_t> &bgr) {
-    const int row_bytes = width * 3;
-    const int padded_row = (row_bytes + 3) & ~3;
+    const int row_bytes = width * BMP_BYTES_PER_PIXEL;
+    const int padded_row = (row_bytes + BMP_ROW_ALIGN - 1) & ~(BMP_ROW_ALIGN - 1);
     const uint32_t pixel_bytes = (uint32_t) padded_row * (uint32_t) height;
-    const uint32_t pixel_offset = 14 + 40;
 
     FILE *f = fopen(filename, "wb");
     if (!f)
         return false;
 
-    uint8_t header[14 + 40] = {0};
-    // BITMAPFILEHEADER
+    uint8_t header[BMP_PIXEL_OFFSET] = {0};
     header[0] = 'B';
     header[1] = 'M';
-    const uint32_t file_size = pixel_offset + pixel_bytes;
-    std::memcpy(&header[2], &file_size, 4);
-    std::memcpy(&header[10], &pixel_offset, 4);
-    // BITMAPINFOHEADER
-    const uint32_t info_size = 40;
+    const uint32_t file_size = (uint32_t) BMP_PIXEL_OFFSET + pixel_bytes;
+    const uint32_t pixel_offset = BMP_PIXEL_OFFSET;
+    const uint32_t info_size = BMP_INFO_HEADER_SIZE;
     const int32_t w32 = width;
     const int32_t h32 = height;
     const uint16_t planes = 1;
-    const uint16_t bpp = 24;
-    std::memcpy(&header[14], &info_size, 4);
-    std::memcpy(&header[18], &w32, 4);
-    std::memcpy(&header[22], &h32, 4);
-    std::memcpy(&header[26], &planes, 2);
-    std::memcpy(&header[28], &bpp, 2);
-    std::memcpy(&header[34], &pixel_bytes, 4);
+    const uint16_t bpp = BMP_BITS_PER_PIXEL;
+    std::memcpy(&header[BMP_OFF_FILE_SIZE], &file_size, sizeof(file_size));
+    std::memcpy(&header[BMP_OFF_PIXEL_OFFSET], &pixel_offset, sizeof(pixel_offset));
+    std::memcpy(&header[BMP_OFF_INFO_SIZE], &info_size, sizeof(info_size));
+    std::memcpy(&header[BMP_OFF_WIDTH], &w32, sizeof(w32));
+    std::memcpy(&header[BMP_OFF_HEIGHT], &h32, sizeof(h32));
+    std::memcpy(&header[BMP_OFF_PLANES], &planes, sizeof(planes));
+    std::memcpy(&header[BMP_OFF_BIT_COUNT], &bpp, sizeof(bpp));
+    std::memcpy(&header[BMP_OFF_IMAGE_SIZE], &pixel_bytes, sizeof(pixel_bytes));
 
     bool ok = fwrite(header, 1, sizeof(header), f) == sizeof(header);
 
-    static const uint8_t padding[3] = {0, 0, 0};
+    static const uint8_t padding[BMP_ROW_ALIGN - 1] = {0};
     const int pad = padded_row - row_bytes;
     for (int y = 0; ok && y < height; y++) {
         ok = fwrite(&bgr[(size_t) y * row_bytes], 1, row_bytes, f) == (size_t) row_bytes;
@@ -129,10 +136,10 @@ void sithRender_CapturePendingScreenshot(void) {
     if (width <= 0 || height <= 0)
         return;
 
-    std::vector<uint8_t> pixels((size_t) width * height * 3);
+    std::vector<uint8_t> pixels((size_t) width * height * BMP_BYTES_PER_PIXEL);
 
-    // The scene has already been blitted into framebuffer 0 by swrViewport_Render_Hook. Read from
-    // the front-most complete image, and force a tight row stride so the buffer matches the width.
+    // swrViewport_Render_Hook has already blitted the scene into framebuffer 0. Tight row stride so
+    // the buffer matches the width.
     GLint prev_read_fb = 0;
     GLint prev_pack_align = 4;
     glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &prev_read_fb);

--- a/dinput_hook/game_deltas/sithRender_delta.h
+++ b/dinput_hook/game_deltas/sithRender_delta.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// Screenshot capture (issue #289).
+//
+// The original F12 path is sithRender_MakeScreenShot -> stdDisplay_SaveScreen ->
+// stdBmp_VBufferToBmp(&stdDisplay_g_backBuffer). That back buffer is the DirectDraw surface, which
+// the OpenGL takeover never fills, so the converter walks an unmapped row pointer and the game dies
+// with an access violation inside stdColor_ColorConvertOneRow. The delta keeps the original's
+// filename numbering but reads the finished frame back out of GL instead.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Replaces sithRender_MakeScreenShot. Picks the next free "<prefix>NNN.bmp" and arms the capture;
+// the pixels are read at the end of the frame, where the scene is actually complete.
+void sithRender_MakeScreenShot_delta(char* prefix);
+
+// Called once per frame from stdDisplay_Update_Hook, after the scene has been resolved into the
+// default framebuffer and before the debug overlay is drawn. No-op unless a capture is armed.
+void sithRender_CapturePendingScreenshot(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/dinput_hook/game_deltas/sithRender_delta.h
+++ b/dinput_hook/game_deltas/sithRender_delta.h
@@ -14,7 +14,7 @@ extern "C" {
 
 // Replaces sithRender_MakeScreenShot. Picks the next free "<prefix>NNN.bmp" and arms the capture;
 // the pixels are read at the end of the frame, where the scene is actually complete.
-void sithRender_MakeScreenShot_delta(char* prefix);
+void sithRender_MakeScreenShot_delta(char *prefix);
 
 // Called once per frame from stdDisplay_Update_Hook, after the scene has been resolved into the
 // default framebuffer and before the debug overlay is drawn. No-op unless a capture is armed.

--- a/dinput_hook/game_deltas/sithRender_delta.h
+++ b/dinput_hook/game_deltas/sithRender_delta.h
@@ -1,23 +1,18 @@
 #pragma once
 
-// Screenshot capture (issue #289).
-//
-// The original F12 path is sithRender_MakeScreenShot -> stdDisplay_SaveScreen ->
-// stdBmp_VBufferToBmp(&stdDisplay_g_backBuffer). That back buffer is the DirectDraw surface, which
-// the OpenGL takeover never fills, so the converter walks an unmapped row pointer and the game dies
-// with an access violation inside stdColor_ColorConvertOneRow. The delta keeps the original's
-// filename numbering but reads the finished frame back out of GL instead.
+// Screenshot capture (issue #289). The original path (sithRender_MakeScreenShot ->
+// stdDisplay_SaveScreen -> stdBmp_VBufferToBmp) converts stdDisplay_g_backBuffer, the DirectDraw
+// surface the OpenGL takeover never fills, and faults in stdColor_ColorConvertOneRow. These read
+// the finished frame back out of GL instead.
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Replaces sithRender_MakeScreenShot. Picks the next free "<prefix>NNN.bmp" and arms the capture;
-// the pixels are read at the end of the frame, where the scene is actually complete.
+// Replaces sithRender_MakeScreenShot: picks the next free "<prefix>NNN.bmp" and arms the capture.
 void sithRender_MakeScreenShot_delta(char *prefix);
 
-// Called once per frame from stdDisplay_Update_Hook, after the scene has been resolved into the
-// default framebuffer and before the debug overlay is drawn. No-op unless a capture is armed.
+// Per frame from stdDisplay_Update_Hook, after the scene resolves and before the overlay draws.
 void sithRender_CapturePendingScreenshot(void);
 
 #ifdef __cplusplus

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -1808,8 +1808,7 @@ extern "C" int stdDisplay_Update_Hook() {
         applied_vsync = imgui_state.vsync;
     }
 
-    // Screenshot read-back (issue #289), before imgui_Update so the debug overlay stays out of the
-    // shot. The scene is already resolved into framebuffer 0 by swrViewport_Render_Hook.
+    // Before imgui_Update, so the debug overlay stays out of the shot.
     sithRender_CapturePendingScreenshot();
 
     begin_texture_replacement();
@@ -2048,9 +2047,7 @@ extern "C" void init_renderer_hooks() {
     // the Smush skip hook.)
     hook_replace(swrSound_Startup, swrSound_Startup_delta);
 
-    // F12 screenshot (issue #289): the original writes the DirectDraw back buffer, which the GL
-    // takeover never fills, so it faults inside stdColor_ColorConvertOneRow. sithRender_MakeScreenShot
-    // is reverse-hooked (registered in hook_generated) -> replace it.
+    // F12 screenshot (issue #289). Reverse-hooked (registered in hook_generated) -> replace it.
     hook_replace(sithRender_MakeScreenShot, sithRender_MakeScreenShot_delta);
 
     // Free-camera spike (Phase 1): render-only takeover of the scene camera at the

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -40,6 +40,7 @@ extern "C" {
 #include "./game_deltas/swrPlayerHUD_delta.h"
 #include "./game_deltas/swrWeather_delta.h"
 #include "./game_deltas/swrObjHang_delta.h"
+#include "./game_deltas/sithRender_delta.h"
 #include "./game_deltas/swrRace_delta.h"
 
 #include <glad/glad.h>
@@ -72,6 +73,7 @@ extern "C" {
 #include <main.h>
 #include <Main/swrControl.h>
 #include <Swr/swrAssetBuffer.h>
+#include <Engine/sithRender.h>
 #include <Platform/std3D.h>
 #include <Platform/stdControl.h>
 #include <Primitives/rdMatrix.h>
@@ -1806,6 +1808,10 @@ extern "C" int stdDisplay_Update_Hook() {
         applied_vsync = imgui_state.vsync;
     }
 
+    // Screenshot read-back (issue #289), before imgui_Update so the debug overlay stays out of the
+    // shot. The scene is already resolved into framebuffer 0 by swrViewport_Render_Hook.
+    sithRender_CapturePendingScreenshot();
+
     begin_texture_replacement();
     imgui_Update();// Added
     end_texture_replacement();
@@ -2041,6 +2047,11 @@ extern "C" void init_renderer_hooks() {
     // (Window_PlayCinematic, which also carries the cutscene audio scaling, is registered below with
     // the Smush skip hook.)
     hook_replace(swrSound_Startup, swrSound_Startup_delta);
+
+    // F12 screenshot (issue #289): the original writes the DirectDraw back buffer, which the GL
+    // takeover never fills, so it faults inside stdColor_ColorConvertOneRow. sithRender_MakeScreenShot
+    // is reverse-hooked (registered in hook_generated) -> replace it.
+    hook_replace(sithRender_MakeScreenShot, sithRender_MakeScreenShot_delta);
 
     // Free-camera spike (Phase 1): render-only takeover of the scene camera at the
     // rdCamera_Update seam. Toggle in-race with F9; WASD + Space/Ctrl to move, arrows or RMB-drag to


### PR DESCRIPTION
Fixes #289.

F12 kills the game. The path is `sithRender_MakeScreenShot` -> `stdDisplay_SaveScreen` -> `stdBmp_VBufferToBmp(&stdDisplay_g_backBuffer)`, and that back buffer is the DirectDraw surface, which the GL takeover never fills. The row converter then walks an unmapped pointer:

```
0x4104d9  sithRender_MakeScreenShot   + 0x59
0x489d2f  stdDisplay_SaveScreen       + 0xf
0x48d6dd  stdBmp_VBufferToBmp         + 0x23d
0x48d2d3  stdColor_ColorConvertOneRow + 0x113   <- c0000005, read at 0x003fe800
```

The truncated `.bmp` in the report is the same failure, not a separate one — it writes part of the file and then faults.

`sithRender_MakeScreenShot` is already reverse-hooked, so this replaces it with `hook_replace` rather than putting a second hook on the address. The delta keeps the original's filename numbering and only arms the capture, since F12 is handled during input processing before the frame exists; the pixels are read in `stdDisplay_Update_Hook` from framebuffer 0, which `swrViewport_Render_Hook` has already resolved the scene into. `glReadPixels` returns rows bottom-up in BGR, which is BMP's on-disk layout, so the rows copy straight out with only stride padding.

The read-back runs before `imgui_Update`, so the debug overlay stays out of the shot and the game's own HUD stays in. Happy to flip that if you'd rather screenshots were WYSIWYG.

**Second commit, worth a look.** Once it stopped crashing, one press wrote several files — `swrMain_ProcessDebugKeys` has no rising-edge check on F12, which was invisible before because nothing survived the first request. Two fixes that seem obvious are both wrong, and I tried both: a frame count fails because the repeat arrived two frames out while other presses in the same run never repeated at all, and reading the physical key state fails worse — the handler runs after the key-down edge, so the key always reads as held and *every* press gets swallowed. What separates them is spacing: repeats landed 47-70 ms behind their press, deliberate presses never closer than 1.8 s. So it debounces, and the comment records the measurements so nobody retries the other two.

Note for anyone testing: F12 is also Steam's screenshot hotkey, so Steam captures its own copies at the same time. Those are unrelated to the game's `snap_*.bmp`.

Verified in-game at 2560x1377, menu and in-race: header self-consistent (declared size == actual, declared pixel bytes == padded stride * height), images decode right way up with correct colours, and four presses give exactly four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
