### PR TITLE
feat(modding): mod module registry (#153 phase 2)

### DIFF
--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -15,7 +15,7 @@
 #include "../nv_dds/nv_dds.h"
 #include "../imgui_utils.h"
 #include "../ui_transform.h"
-#include "../patch.h"
+#include "../mod_registry.h"
 
 #include <regex>
 
@@ -110,12 +110,12 @@ int readFontToBuffer(unsigned char *out_buffer, const char *path) {
 // Added loading font from font files, and using 512, 1024 as a resolution
 // Unrolled all static loops
 
-// --- HD font replacement: journaled live toggle (modding API, issue #153) --------------------
+// HD font replacement: the "hd_font" mod.
 // The vanilla swrText_InitFonts (0x0042d720) and the HD path populate the SAME font-table slots
 // (and write identical font-metadata globals), differing only in which swrMaterial each slot
 // points at. So we keep BOTH font sets resident and flip the toggle by journaling the slot
-// pointers: enable = PatchPointer the HD material over the built-in one (capturing it); disable =
-// UndoOwner("hd_font") restores the built-in. The original is always run first so the built-in
+// pointers: enable = PatchPointer the HD material over the built-in one (capturing it); disable_mod
+// restores the built-in through the journal. The original is always run first so the built-in
 // materials exist to revert to. This makes the F5 toggle apply live, no restart.
 struct HdFontSlot {
     swrMaterial **page;// font-table glyph-page slot the converter fills (swrText_fonts[f].pages[p])
@@ -177,20 +177,28 @@ static bool ensure_hd_fonts_built() {
     return true;
 }
 
-// Live toggle: point the font-table slots at the HD materials (journaled so it reverts cleanly) or
-// restore the built-in materials. Safe any time after swrText_InitFonts_delta has run. Returns
-// false if HD was requested but its assets are missing (caller should clear the toggle).
-extern "C" bool set_hd_fonts(bool on) {
-    if (!on) {
-        UndoOwner("hd_font");
-        return true;
-    }
+// Point the font-table slots at the HD materials. Safe any time after swrText_InitFonts_delta has
+// run. Fails (HD stays off) if the assets are missing.
+static bool hd_font_enable(ModId self, void *) {
     if (!ensure_hd_fonts_built())
         return false;
-    for (int i = 0; i < kNumHdFontSlots; i++)
-        PatchPointer("hd_font", kHdFontSlots[i].page, (uint32_t) (uintptr_t) g_hdFontMaterial[i]);
+    for (int i = 0; i < kNumHdFontSlots; i++) {
+        if (!PatchPointer(mod_owner(self), kHdFontSlots[i].page,
+                          (uint32_t) (uintptr_t) g_hdFontMaterial[i]))
+            return false;
+    }
     return true;
 }
+
+const ModModule swrText_HdFontMod = {
+    .name = "hd_font",
+    .version = "1.0",
+    .depends_on = nullptr,
+    .user = nullptr,
+    .enable = hd_font_enable,
+    .on_disable = nullptr,
+};
+ModId mod_hd_font = MOD_ID_INVALID;
 
 // 0x0042d720
 void swrText_InitFonts_delta(void) {
@@ -198,7 +206,7 @@ void swrText_InitFonts_delta(void) {
     // valid pointers; the HD swap (if enabled) then journals over those slots so it toggles live.
     // This runs before read_settings_ini(), so read the persisted toggle directly here.
     hook_call_original((void (*)(void)) swrText_InitFonts_ADDR);
-    if (read_hd_font_setting() && !set_hd_fonts(true))
+    if (read_hd_font_setting() && !enable_mod(mod_hd_font))
         imgui_state.hd_font = false;// assets missing -> reflect that the built-in fonts are in use
 }
 

--- a/dinput_hook/game_deltas/swrModel_delta.h
+++ b/dinput_hook/game_deltas/swrModel_delta.h
@@ -1,6 +1,13 @@
 #pragma once
 
 #include "types.h"
+#include "../mod_registry.h"
+
+// "hd_font" mod: HD PNGs from assets/textures/fonts over the built-in font materials, journaled so
+// it toggles live. Registered in init_renderer_hooks; enabled from the persisted setting at font
+// init.
+extern const ModModule swrText_HdFontMod;
+extern ModId mod_hd_font;
 
 void swrText_InitFonts_delta(void);
 

--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -23,7 +23,7 @@ extern FILE* hook_log;
 }
 
 #include "../hook_helper.h"
-#include "../patch.h"
+#include "../mod_registry.h"
 #include "../crash_logger.h"
 #include "../ui_transform.h"
 #include "../imgui_utils.h"// imgui_state cutscene-skip toggles + fast_restart (debug-menu toggles)
@@ -594,7 +594,7 @@ void service_fast_restart() {
 // +num_laps*4+0x5c at the finish check). The de-indexed form is 3 bytes, padded with a NOP, so
 // instruction boundaries are preserved and no trampoline is needed. We verify the original bytes
 // before patching so a mismatched / already-patched / future binary is skipped, never corrupted.
-void swrObjJdge_PatchLapTimeOverflow() {
+static bool lap_time_overflow_enable(ModId self, void *) {
     struct LapTimeSite {
         uint32_t address;
         uint8_t original[4];
@@ -628,24 +628,40 @@ void swrObjJdge_PatchLapTimeOverflow() {
             if (std::memcmp(code, site.patched, 4) == 0)
                 continue; // already patched
             fprintf(hook_log,
-                    "[swrObjJdge_PatchLapTimeOverflow] unexpected bytes at %p; aborting patch. "
+                    "[lap_time_overflow] unexpected bytes at %p; aborting patch. "
                     ">5 laps will corrupt memory / crash.\n",
                     (void *) code);
             fflush(hook_log);
-            return;
+            return false;
         }
 
-        // Route the write through the owner-tagged journal (revertible, overlap-checked) instead
-        // of a raw VirtualProtect+memcpy. The verify above guarantees WriteMemory snapshots the
-        // stock bytes, so UndoOwner("lap_time_overflow") restores the original binary exactly.
-        if (WriteMemory("lap_time_overflow", code, site.patched, 4))
-            patched++;
+        // Verified stock bytes above, so the journal snapshot (and disable_mod) is exact.
+        if (!WriteMemory(mod_owner(self), code, site.patched, 4))
+            return false;
+        patched++;
     }
 
-    fprintf(hook_log,
-            "[swrObjJdge_PatchLapTimeOverflow] de-indexed %d/%d lap-time sites; >5 laps now safe.\n",
+    fprintf(hook_log, "[lap_time_overflow] de-indexed %d/%d lap-time sites; >5 laps now safe.\n",
             patched, total);
     fflush(hook_log);
+    return true;
+}
+
+// Startup-scoped: the paired swrObjJdge_F2 / time-formatter replacements stay attached for the
+// process, so this is enabled once at startup and not exposed as a runtime toggle.
+static const ModModule lap_time_overflow_mod = {
+    .name = "lap_time_overflow",
+    .version = "1.0",
+    .depends_on = nullptr,
+    .user = nullptr,
+    .enable = lap_time_overflow_enable,
+    .on_disable = nullptr,
+};
+ModId mod_lap_time_overflow = MOD_ID_INVALID;
+
+void swrObjJdge_PatchLapTimeOverflow() {
+    mod_lap_time_overflow = register_mod(&lap_time_overflow_mod);
+    enable_mod(mod_lap_time_overflow);
 }
 
 // --- 1hr+ race-time support ------------------------------------------------------------------
@@ -656,7 +672,7 @@ void swrObjJdge_PatchLapTimeOverflow() {
 // and both clamp values to 24h so the time keeps accumulating; the time formatter
 // (swrText_CreateTimeEntryPrecise) already prints minutes unbounded (MM:SS.mmm, e.g. 72:34.567),
 // so every total-time readout (in-race timer, results summary, hangar results) follows.
-void swrObjJdge_PatchRaceTimeCap() {
+static bool race_time_cap_enable(ModId self, void *) {
     const float kCap = 86400.0f; // 24h; effectively no cap for any real race, keeps ms precision
     uint8_t cap_bytes[4];
     std::memcpy(cap_bytes, &kCap, 4);
@@ -681,23 +697,39 @@ void swrObjJdge_PatchRaceTimeCap() {
             if (std::memcmp(p, cap_bytes, 4) == 0)
                 continue; // already patched
             fprintf(hook_log,
-                    "[swrObjJdge_PatchRaceTimeCap] unexpected bytes at %p; skipping (timer stays "
-                    "capped at 50:00).\n",
+                    "[race_time_cap] unexpected bytes at %p; skipping (timer stays capped at "
+                    "50:00).\n",
                     (void *) p);
             fflush(hook_log);
-            return;
+            return false;
         }
 
-        // Journaled write (see PatchLapTimeOverflow): the verify above pins the snapshot to the
-        // stock 3000.0f, so UndoOwner("race_time_cap") restores the original cap.
-        if (WriteMemory("race_time_cap", p, cap_bytes, 4))
-            patched++;
+        // Verified stock 3000.0f above, so the journal snapshot (and disable_mod) is exact.
+        if (!WriteMemory(mod_owner(self), p, cap_bytes, 4))
+            return false;
+        patched++;
     }
 
-    fprintf(hook_log,
-            "[swrObjJdge_PatchRaceTimeCap] raised race-time cap %d/%d sites (50:00 -> 24h).\n",
-            patched, total);
+    fprintf(hook_log, "[race_time_cap] raised race-time cap %d/%d sites (50:00 -> 24h).\n", patched,
+            total);
     fflush(hook_log);
+    return true;
+}
+
+// Startup-scoped like lap_time_overflow: the hour-aware time formatters stay attached.
+static const ModModule race_time_cap_mod = {
+    .name = "race_time_cap",
+    .version = "1.0",
+    .depends_on = nullptr,
+    .user = nullptr,
+    .enable = race_time_cap_enable,
+    .on_disable = nullptr,
+};
+ModId mod_race_time_cap = MOD_ID_INVALID;
+
+void swrObjJdge_PatchRaceTimeCap() {
+    mod_race_time_cap = register_mod(&race_time_cap_mod);
+    enable_mod(mod_race_time_cap);
 }
 
 // --- hours in time displays ------------------------------------------------------------------

--- a/dinput_hook/game_deltas/swrObjJdge_delta.h
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include "../mod_registry.h"
 
 unsigned int swrObjJdge_InitTrack_delta(swrObjJdge *judge, swrScore * scores);
 
@@ -41,12 +42,15 @@ void swrObjJdge_F0_delta(swrObjJdge *jdge);
 
 // 100-lap support: de-index swrObjJdge_F2's fixed 5-element per-lap split-time array
 // (swrScore::results_P1_Lap1..Lap5) so lap counts above 5 stop corrupting the score struct.
-// Applied as a verified in-place byte patch at startup. See swrObjJdge_delta.cpp.
+// Registered as the "lap_time_overflow" mod and enabled at startup (verified in-place byte patch).
 void swrObjJdge_PatchLapTimeOverflow();
+extern ModId mod_lap_time_overflow;
 
 // 1hr+ race-time support: raises swrObjJdge_F2's 50:00 (3000.0s) race-time / lap-time clamp to 24h
-// so the in-game timer and every total-time readout can show past one hour. Verified byte patch.
+// so the in-game timer and every total-time readout can show past one hour. Registered as the
+// "race_time_cap" mod and enabled at startup (verified byte patch).
 void swrObjJdge_PatchRaceTimeCap();
+extern ModId mod_race_time_cap;
 
 // 1hr+ race-time support: time formatters reimplemented to show an hours field (H:MM:SS.frac) once
 // the time reaches an hour; identical to stock under one hour. Cover all total-time readouts.

--- a/dinput_hook/imgui_utils.cpp
+++ b/dinput_hook/imgui_utils.cpp
@@ -31,6 +31,8 @@
 #include "game_deltas/tracks_delta.h"
 #include "game_deltas/swrGamepadNav_delta.h"// XInput pad snapshot for input diagnostics
 #include "game_deltas/swrObjJdge_delta.h"
+#include "game_deltas/swrModel_delta.h"// mod_hd_font
+#include "mod_registry.h"
 
 extern "C" {
 #include <globals.h>
@@ -50,8 +52,8 @@ extern float cameraPitch;
 extern float cameraYaw;
 extern float cameraSpeed;
 
-// Defined in main.cpp: writes/reverts the AI full-LOD .text patches (gated by ai_full_lod).
-extern "C" void set_ai_full_lod(bool on);
+// Registered in main.cpp: the AI full-LOD .text patches (Graphics panel checkbox ai_full_lod).
+extern ModId mod_ai_full_lod;
 
 #if !ENABLE_GLFW_INPUT_HANDLING
 // Defined in game_deltas/stdControl_delta.c: device-picker helpers for the input-
@@ -61,10 +63,6 @@ extern "C" void stdControl_RescanJoysticks(void);
 extern "C" const char *stdControl_GetJoystickName(int index);
 extern "C" void stdControl_SelectJoystickByIndex(int index);
 #endif
-
-// Defined in swrModel_delta.cpp: journals the HD<->built-in font swap (gated by hd_font).
-// Returns false if HD was requested but its assets are missing.
-extern "C" bool set_hd_fonts(bool on);
 
 // Registers the built-in overlay panels with the debug-ui shell. Defined at the
 // bottom of this file alongside the panel bodies it splits opengl_render_imgui into.
@@ -279,8 +277,8 @@ void read_settings_ini() {
 
     imgui_state.vsync = config::get_int("settings", "vsync", 1);
 
-    imgui_state.ai_full_lod = config::get_int("settings", "ai_full_lod", 1);
-    set_ai_full_lod(imgui_state.ai_full_lod);
+    imgui_state.ai_full_lod =
+        set_mod_enabled(mod_ai_full_lod, config::get_int("settings", "ai_full_lod", 1));
 
     imgui_state.HD_replacement = config::get_int("settings", "hd_replacement", 1);
     if (!hd_model_assets_available()) {
@@ -1183,9 +1181,8 @@ static void panel_graphics_settings() {
         save_settings_ini();
     }
 
-    if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod)) {
-        set_ai_full_lod(imgui_state.ai_full_lod);
-    }
+    if (ImGui::Checkbox("AI full LOD (no model pop-in)", &imgui_state.ai_full_lod))
+        imgui_state.ai_full_lod = set_mod_enabled(mod_ai_full_lod, imgui_state.ai_full_lod);
 
     // Camera FOV multiplier (1.0 = game default; aspect handled automatically via Hor+).
     if (ImGui::SliderFloat("FOV scale", &imgui_state.fov_scale, 0.5f, 2.0f, "%.2f")) {
@@ -1307,8 +1304,7 @@ static void panel_hd_models() {
     const bool hd_fonts_available = hd_font_assets_available();
     ImGui::BeginDisabled(!hd_fonts_available);
     if (ImGui::Checkbox("Enable HD fonts", &imgui_state.hd_font)) {
-        if (!set_hd_fonts(imgui_state.hd_font))
-            imgui_state.hd_font = false;// HD assets missing -> keep the built-in fonts
+        imgui_state.hd_font = set_mod_enabled(mod_hd_font, imgui_state.hd_font);
         save_settings_ini();
     }
     ImGui::EndDisabled();
@@ -2482,6 +2478,42 @@ static void panel_hud_mode() {
         "Changes the in-race minimap / speedometer layout. Single-player cycles 0-4, splitscreen 4-7.");
 }
 
+// Registered mods and their state (mod_registry.h). Read-only: the startup-scoped mods have paired
+// function hooks that stay attached, so toggling belongs to each feature's own panel control.
+static void panel_mods() {
+    if (mod_count() == 0) {
+        ImGui::TextDisabled("No mods registered");
+        return;
+    }
+    if (ImGui::BeginTable("mods", 3, ImGuiTableFlags_SizingStretchProp)) {
+        ImGui::TableSetupColumn("Mod");
+        ImGui::TableSetupColumn("Version");
+        ImGui::TableSetupColumn("State");
+        ImGui::TableHeadersRow();
+        for (ModId id = 0; id < mod_count(); id++) {
+            const ModModule *mod = mod_info(id);
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::TextUnformatted(mod->name);
+            if (mod->depends_on && ImGui::IsItemHovered()) {
+                ImGui::BeginTooltip();
+                ImGui::Text("Requires:");
+                for (const char *const *req = mod->depends_on; *req; req++)
+                    ImGui::BulletText("%s", *req);
+                ImGui::EndTooltip();
+            }
+            ImGui::TableNextColumn();
+            ImGui::TextUnformatted(mod->version ? mod->version : "-");
+            ImGui::TableNextColumn();
+            if (mod_enabled(id))
+                ImGui::TextUnformatted("enabled");
+            else
+                ImGui::TextDisabled("disabled");
+        }
+        ImGui::EndTable();
+    }
+}
+
 static DebugPanel g_panel_fps = {
     .category = "Render", .name = "FPS", .draw = panel_fps, .dev_only = false};
 static DebugPanel g_panel_hud_mode = {
@@ -2517,6 +2549,8 @@ static DebugPanel g_panel_pod_transforms = {
     .dev_only = true};
 static DebugPanel g_panel_pod_readout = {
     .category = "Inspect", .name = "Pod Readout", .draw = panel_pod_readout, .dev_only = true};
+static DebugPanel g_panel_mods = {
+    .category = "Debug", .name = "Mods", .draw = panel_mods, .dev_only = true};
 
 static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_fps);
@@ -2535,4 +2569,5 @@ static void register_builtin_debug_panels() {
     debug_ui_register(&g_panel_textures);
     debug_ui_register(&g_panel_pod_transforms);
     debug_ui_register(&g_panel_pod_readout);
+    debug_ui_register(&g_panel_mods);
 }

--- a/dinput_hook/main.cpp
+++ b/dinput_hook/main.cpp
@@ -11,6 +11,7 @@
 #include "hook_helper.h"
 #include "custom_tracks.h"
 #include "patch.h"
+#include "mod_registry.h"
 #include "crash_logger.h"
 
 FILE *hook_log = nullptr;
@@ -76,9 +77,9 @@ DWORD_PTR hookIAT(const char *libName, const char *API_Name, LPVOID newFun) {
 typedef HICON(WINAPI *NewLoadIconA)(HINSTANCE hInstance, LPCSTR lpIconName);
 NewLoadIconA ReCall;
 
-// Toggle the "AI full LOD" feature (debug-menu option ai_full_lod). Three .text patches are
-// applied together when enabled and reverted to the stock bytes when disabled. They take
-// effect on the next race load.
+// The "AI full LOD" mod (debug-menu option ai_full_lod). Three .text patches are applied together
+// on enable; disable_mod reverts them to the stock bytes through the journal. They take effect on
+// the next race load.
 //
 // 1) swrObjJdge_SpawnRacers @0x0046654d: JNZ 0x46655a -> NOP. Makes every racer (not just the
 //    local "Locl" human) load the full pod model + pilot instead of the low-detail "bot" model,
@@ -93,33 +94,44 @@ NewLoadIconA ReCall;
 // no >6-pod crash. Costs some (largely renderer-bound) FPS. NOTE: distant AI still follow the
 // track spline (vanilla AI LOD) and can show a slight "tiptoe"; a clean fix for that is tracked
 // separately and intentionally out of scope here.
-extern "C" void set_ai_full_lod(bool on) {
+static bool ai_full_lod_enable(ModId self, void *) {
     struct Patch {
         uint32_t addr;
         uint8_t len;
     };
-    // Stock bytes are no longer hard-coded: the journal captures the live originals before the
-    // first NOP, and UndoOwner restores them. (Stock, for reference: 75 0b / 0f 8f 30 03 00 00 /
+    // Stock bytes are not hard-coded: the journal captures the live originals before the first
+    // NOP, and disable_mod restores them. (Stock, for reference: 75 0b / 0f 8f 30 03 00 00 /
     // 0f 8f c3 01 00 00.)
     static const Patch patches[] = {
         {0x0046654d, 2},// JNZ 0x0046655a
         {0x004723ce, 6},// JG 0x00472704
         {0x00472577, 6},// JG 0x00472740
     };
-    if (on) {
-        static const uint8_t nops[6] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
-        for (const Patch &p: patches)
-            WriteMemory("ai_full_lod", (void *) p.addr, nops, p.len);
-    } else {
-        UndoOwner("ai_full_lod");
+    static const uint8_t nops[6] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+    for (const Patch &p: patches) {
+        if (!WriteMemory(mod_owner(self), (void *) p.addr, nops, p.len))
+            return false;
     }
+    return true;
 }
+
+static const ModModule ai_full_lod_mod = {
+    .name = "ai_full_lod",
+    .version = "1.0",
+    .depends_on = nullptr,
+    .user = nullptr,
+    .enable = ai_full_lod_enable,
+    .on_disable = nullptr,
+};
+ModId mod_ai_full_lod = MOD_ID_INVALID;
 
 HICON __stdcall LoadIconHook(HINSTANCE hInstance, LPCSTR lpIconName) {
     // Main is ready. Patch the hooks and the function we are in to return properly.
     // Arm the startup hang watchdog + stamp the environment before any init below can wedge, and
     // breadcrumb each init step so a "won't start" report shows exactly how far it got.
     crash_logger_start();
+
+    mod_ai_full_lod = register_mod(&ai_full_lod_mod);
 
     crash_logger_stage("init: renderer hooks");
     init_renderer_hooks();

--- a/dinput_hook/mod_registry.cpp
+++ b/dinput_hook/mod_registry.cpp
@@ -1,0 +1,123 @@
+//
+// Mod module registry (modding API, issue #153). See mod_registry.h.
+//
+#include "mod_registry.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+extern "C" FILE *hook_log;
+
+namespace {
+    struct ModEntry {
+        const ModModule *mod;
+        bool enabled;
+    };
+
+    std::vector<ModEntry> g_mods;
+
+    void log(const char *fmt, ...) {
+        if (!hook_log)
+            return;
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(hook_log, fmt, args);
+        va_end(args);
+        fflush(hook_log);
+    }
+
+    bool valid(ModId id) {
+        return id >= 0 && (size_t) id < g_mods.size();
+    }
+}// namespace
+
+ModId register_mod(const ModModule *mod) {
+    if (!mod || !mod->name || !mod->name[0] || !mod->enable) {
+        log("[mods] refused to register a malformed module\n");
+        return MOD_ID_INVALID;
+    }
+    if (find_mod(mod->name) != MOD_ID_INVALID) {
+        log("[mods] refused duplicate registration of '%s'\n", mod->name);
+        return MOD_ID_INVALID;
+    }
+    g_mods.push_back(ModEntry{mod, false});
+    return (ModId) (g_mods.size() - 1);
+}
+
+ModId find_mod(const char *name) {
+    if (!name)
+        return MOD_ID_INVALID;
+    for (size_t i = 0; i < g_mods.size(); i++) {
+        if (std::strcmp(g_mods[i].mod->name, name) == 0)
+            return (ModId) i;
+    }
+    return MOD_ID_INVALID;
+}
+
+const ModModule *mod_info(ModId id) {
+    return valid(id) ? g_mods[id].mod : nullptr;
+}
+
+int mod_count(void) {
+    return (int) g_mods.size();
+}
+
+PatchOwner mod_owner(ModId id) {
+    return valid(id) ? g_mods[id].mod->name : nullptr;
+}
+
+bool enable_mod(ModId id) {
+    if (!valid(id))
+        return false;
+    ModEntry &e = g_mods[id];
+    if (e.enabled)
+        return true;
+
+    if (e.mod->depends_on) {
+        for (const char *const *req = e.mod->depends_on; *req; req++) {
+            const ModId dep = find_mod(*req);
+            if (dep == MOD_ID_INVALID || !g_mods[dep].enabled) {
+                log("[mods] '%s' not enabled: requires '%s', which is not enabled\n", e.mod->name,
+                    *req);
+                return false;
+            }
+        }
+    }
+
+    if (!e.mod->enable(id, e.mod->user)) {
+        // Whatever the mod journaled before bailing is reverted, so a failed enable leaves stock.
+        UndoOwner(e.mod->name);
+        log("[mods] '%s' failed to enable (reverted)\n", e.mod->name);
+        return false;
+    }
+    e.enabled = true;
+    log("[mods] enabled '%s' %s\n", e.mod->name, e.mod->version ? e.mod->version : "");
+    return true;
+}
+
+void disable_mod(ModId id) {
+    if (!valid(id))
+        return;
+    ModEntry &e = g_mods[id];
+    if (!e.enabled)
+        return;
+
+    UndoOwner(e.mod->name);
+    if (e.mod->on_disable)
+        e.mod->on_disable(e.mod->user);
+    e.enabled = false;
+    log("[mods] disabled '%s'\n", e.mod->name);
+}
+
+bool set_mod_enabled(ModId id, bool on) {
+    if (on)
+        return enable_mod(id);
+    disable_mod(id);
+    return false;
+}
+
+bool mod_enabled(ModId id) {
+    return valid(id) && g_mods[id].enabled;
+}

--- a/dinput_hook/mod_registry.h
+++ b/dinput_hook/mod_registry.h
@@ -1,0 +1,44 @@
+//
+// Mod module registry (modding API, issue #153): a feature as a unit that can be enabled and
+// disabled at runtime. A mod's `name` is its journal owner (patch.h), so disable_mod() reverts
+// every write the mod tagged with mod_owner(self) via UndoOwner - the author writes only enable().
+// Mods without journal entries (runtime-gated hooks) flip their gate in enable()/on_disable().
+//
+// enable_mod: depends_on all enabled -> enable() -> on false, UndoOwner + report.
+// disable_mod: UndoOwner(name) -> on_disable(). Both idempotent, logged to hook.log.
+//
+#pragma once
+
+#include "patch.h"
+
+typedef int ModId;
+#define MOD_ID_INVALID (-1)
+
+typedef struct ModModule {
+    // Unique stable id; also the journal owner of the mod's memory writes.
+    const char *name;
+    const char *version;
+    // NULL-terminated names of mods that must be enabled first; may be NULL.
+    const char *const *depends_on;
+    // Mod-instance state, handed back to the callbacks.
+    void *user;
+    // Apply the mod. Return false to abort: the journal writes made so far are reverted.
+    bool (*enable)(ModId self, void *user);
+    // Optional: tear down what the journal cannot revert (GL objects, handles).
+    void (*on_disable)(void *user);
+} ModModule;
+
+// Register a mod. The registry keeps the pointer, so pass a static ModModule. Returns
+// MOD_ID_INVALID (and logs) for a malformed module or a duplicate name.
+ModId register_mod(const ModModule *mod);
+
+ModId find_mod(const char *name);
+const ModModule *mod_info(ModId id);// NULL for an invalid id
+int mod_count(void);
+PatchOwner mod_owner(ModId id);// the owner tag for this mod's WriteMemory/PatchPointer calls
+
+bool enable_mod(ModId id);
+void disable_mod(ModId id);
+// enable_mod / disable_mod by flag; returns the resulting state.
+bool set_mod_enabled(ModId id, bool on);
+bool mod_enabled(ModId id);

--- a/dinput_hook/patch.h
+++ b/dinput_hook/patch.h
@@ -10,9 +10,9 @@
 // breakage. (Refcounted layering of intentional overlaps is a later phase; for now: one owner per
 // byte.)
 //
-// `owner` is a short stable string ("ai_full_lod", "boot_window_reroute", ...). It is deliberately
-// lightweight - the full mod registry (ModId/ModModule) is a later step, and this is only the key
-// UndoOwner() reverts by.
+// `owner` is a short stable string ("ai_full_lod", "boot_window_reroute", ...): the key UndoOwner()
+// reverts by. A registered mod's name is its owner (mod_registry.h: mod_owner(self)), which is how
+// disable_mod() reverts a mod's writes without the mod spelling out an undo.
 //
 #pragma once
 

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -2414,6 +2414,7 @@ extern "C" void init_renderer_hooks() {
     // swrText
     hook_function("swrText_InitFonts", (uint32_t) swrText_InitFonts_ADDR,
                   (uint8_t *) swrText_InitFonts_delta);
+    mod_hd_font = register_mod(&swrText_HdFontMod);
 
     // swrModel
     hook_function("swrModel_LoadFromId", (uint32_t) swrModel_LoadFromId, (uint8_t *) 0x00448780);


### PR DESCRIPTION
Phase 2 of #153, on top of the journal (#209) and config parser (#217).

`dinput_hook/mod_registry.{h,cpp}`: a feature becomes a `ModModule {name, version, depends_on, user, enable, on_disable}`, registered once and then toggled by id. The trick that makes it worth having: the mod's name **is** its journal owner, so `disable_mod` = `UndoOwner(name)` + optional `on_disable()`. The author writes only `enable()`; the undo is derived from what the journal captured. If `enable()` returns false, whatever it journaled so far is reverted, so a failed enable leaves stock bytes. `depends_on` is checked at enable time against other enabled mods.

Migrated the four existing journal owners:
- `ai_full_lod` (main.cpp) and `hd_font` (swrModel_delta.cpp) as live toggles. Their `set_*()` entry points are gone; the overlay checkboxes now assign from the registry's returned state, so a refused enable (missing HD font PNGs, journal conflict) un-ticks the box instead of lying.
- `lap_time_overflow` / `race_time_cap` (swrObjJdge_delta.cpp) as startup-scoped mods. Their paired `hook_replace`'d F2 / time formatters stay attached, so they're enabled once at boot and not exposed as toggles - bringing those hooks under the same mod id is the phase 3 (observer/replacement registry) step.
- Skipped `asset_buffer_size`: it's a sized parameter, not an on/off feature.

Plus a read-only dev "Mods" panel listing name / version / state.

Two notes: the field is `depends_on` rather than `requires` because `requires` is a C++20 keyword. And there's no separate "provider" concept yet - nothing in-tree declares a dependency, the renderer-fused visual features that would are waiting on the un-fusing.

On your churn point about `imgui_utils` / `renderer_hook` (per-feature `hook_X()` / `ui_X()` trees): agreed, and this registry is the landing pad for it. I've slotted it in as the next step ("2b") before the conflict-policy phase - a pure move where each feature file owns its `ModModule`, its `hook_<feature>()` and its panel, done incrementally as PRs rebase so it doesn't fight the open queue. Phase 3's duplicate-replacement checks then land on those per-feature registration sites. Will write it up on #153.

Boot-verified via hook.log (each mod's `[patch]` lines followed by `[mods] enabled '<name>'`); the live F5 toggle path issues the same journal calls as before but I haven't re-playtested it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
