### PR TITLE
fix(custom tracks): don't commit lap records for tracks with no save slot

### DIFF
--- a/dinput_hook/game_deltas/swrRace_delta.cpp
+++ b/dinput_hook/game_deltas/swrRace_delta.cpp
@@ -318,6 +318,15 @@ void swrRace_ClearCableBends() {
     cable_bend_by_node.clear();
 }
 
+// The save image has a fixed 50 record slots per record kind, indexed `bMirror + track_index * 2`
+// -- the 25 vanilla tracks times their mirror variant. A custom track (id >= DEFAULT_NB_TRACKS)
+// has no slot, so committing a record for one writes past the array: into the record-holder
+// names, and past the end of swrRace_saveData high in the inflated id range.
+static bool track_has_record_slot(int trackIndex) {
+    const int numSlots = (int) (sizeof(swrRace_saveData.record3LapTimes) / sizeof(float));
+    return trackIndex >= 0 && trackIndex * 2 + 1 < numSlots;
+}
+
 // swrRace_ResultsMenu (the post-race standings, STATE_POST_RACE_INFO). When the "Pod Unlock Scene"
 // skip is on, keep the results flow from ever transitioning to that scene (RESULTS_INTRO, state 17):
 // the scene sets up its pod + backdrop the instant it's entered, so skipping it at the scene handler
@@ -329,6 +338,9 @@ void __cdecl swrRace_ResultsMenu_delta(swrObjHang* hang) {
     const bool skip = imgui_state.skip_results;
     if (skip)
         swrRace_resultsStateFlags |= swrRace_RESULTSFLAG_PILOT_UNLOCK_SHOWN;
+    if (!track_has_record_slot(hang->track_index))
+        swrRace_resultsStateFlags |= swrRace_RESULTSFLAG_NAME_ENTRY_P1 |
+            swrRace_RESULTSFLAG_NAME_ENTRY_P2 | swrRace_RESULTSFLAG_RECORDS_COMMITTED;
     hook_call_original(swrRace_ResultsMenu, hang);
 
     // Circuit Winner Scene (state 16) clean-skip. Advancing from the tournament results with a top-3


### PR DESCRIPTION
Setting a record on a custom track corrupts the save image.

Records live in fixed 50-entry arrays in `swrSaveData` (`record3LapTimes` / `recordLapTimes`), indexed `bMirror + track_index * 2` -- the 25 vanilla tracks times their mirror variant. Custom tracks get ids `>= DEFAULT_NB_TRACKS` out of the inflated track table (up to 97), so `swrRace_ResultsMenu` indexes up to 195: it overwrites `record3LapNames[]` and, high in the id range, runs past the end of `swrRace_saveData` entirely.

Fix pre-latches the name-entry + records-committed bits for a track with no slot, so the original skips both the name-entry prompt and the commit (same technique the pod-unlock skip in this delta already uses). The course-info screen already gates its record display on the track id, so custom tracks just show no record.

Custom-track times want their own storage rather than a slot in the vanilla array -- that's a separate change; this one is just the memory-safety half.

Built + linked clean (WinLibs GCC 13.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)