### PR TITLE
fix(spline): refuse a cursor whose spline the asset buffer reclaimed

### DIFF
--- a/dinput_hook/game_deltas/swrObjJdge_delta.cpp
+++ b/dinput_hook/game_deltas/swrObjJdge_delta.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include "swrObjJdge_delta.h"
 #include "swrRace_delta.h"
+#include "swrSpline_delta.h"// spline_cursor_has_usable_spline (fly-by gate)
 
 extern "C" {
 #include <Swr/swrObj.h>
@@ -1213,7 +1214,7 @@ void swrObjJdge_F0_delta(swrObjJdge *jdge) {
     // at camera 5. Re-enabling both during the pre-race state (nibble 4) plays the sweep: F2 walks
     // the cam-spline, F0 holds state 4 until the spline ends, then advances to the pod orbit. We
     // capture the active camera entering the sweep and restore it on the way out so the race view
-    // returns. Takes precedence over the orbit skip below (opposite intents). Default off.
+    // returns. Takes precedence over the orbit skip below (opposite intents).
     static int prevState = -1;
     static short savedCamera = -1;
     // Suppressed while a fast restart is skipping the intro -- the two have opposite intents (play
@@ -1222,17 +1223,21 @@ void swrObjJdge_F0_delta(swrObjJdge *jdge) {
         // swrObjJdge_F2 (+0x32) evaluates camSweepCursor while camSweepState != NULL, and
         // swrObjJdge_SetupTrackEnvironment leaves that cursor's spline NULL on a track with no
         // camera path. Opening the gate then gives a black sweep that never ends (or, before
-        // swrSpline_EvaluateToMatrix_delta guarded it, a fault).
+        // swrSpline_EvaluateToMatrix_delta guarded it, a fault). A NULL test is not enough: on a
+        // track with no camera path the cursor keeps the PREVIOUS track's spline pointer, which the
+        // asset buffer has since overwritten, so it reads non-NULL but garbage (a custom track
+        // raced straight after a stock one). Require a spline that can actually be walked.
         if (state == 4 && prevState != 4 && jdge->cam_spline != NULL &&
-            jdge->camSweepCursor.spline != NULL) {
+            spline_cursor_has_usable_spline(&jdge->camSweepCursor)) {
             savedCamera = (short) unkCameraArrayIndex;
             jdge->camSweepState = jdge->cam_spline;// non-null gate (F0/F2 only test != 0)
             ((swrViewport_SetActiveCameraFn) swrViewport_SetActiveCamera_ADDR)(5);
         } else if (state == 4 && prevState != 4) {
             fprintf(hook_log,
-                    "[prerace_sweep] no fly-by cursor for track model %d (cam_spline=%p); leaving "
-                    "the sweep dormant\n",
-                    jdge->unk1b0_modelId, (void *) jdge->cam_spline);
+                    "[prerace_sweep] no usable fly-by cursor for track model %d (cam_spline=%p, "
+                    "cursor spline=%p); leaving the sweep dormant\n",
+                    jdge->unk1b0_modelId, (void *) jdge->cam_spline,
+                    (void *) jdge->camSweepCursor.spline);
             fflush(hook_log);
         } else if (state != 4 && prevState == 4 && savedCamera != 5) {
             jdge->camSweepState = NULL;

--- a/dinput_hook/game_deltas/swrSpline_delta.cpp
+++ b/dinput_hook/game_deltas/swrSpline_delta.cpp
@@ -11,29 +11,94 @@ extern "C" {
 
 extern FILE *hook_log;
 
+// No stock spline and no custom pack has more than 180 control points, so a count past this is a
+// garbage read, not a real spline.
+#define SPLINE_PLAUSIBLE_MAX_CONTROL_POINTS 4096
+
+// A cursor holds a raw swrSpline* into the asset buffer, which the next track load rewinds and
+// refills, so a cursor that outlives its track reads non-NULL but garbage (seen:
+// num_control_points 0xffcea415). Interpolating through it faults in swrSpline_Interpolate
+// (0x0044e774) and so does re-seeding it, since swrSpline_CursorSeek walks control_points too
+// (0x0044ef14) -- it cannot be repaired from here, only refused.
+static bool cursor_spline_is_usable(const swrSplineCursor *c) {
+    const swrSpline *s = c->spline;
+    return s != NULL && s->control_points != NULL && s->num_control_points > 0 &&
+        s->num_control_points <= SPLINE_PLAUSIBLE_MAX_CONTROL_POINTS;
+}
+
+// Callers that gate cinematics on a cursor need the same test: a NULL check alone passes a cursor
+// left pointing into a reloaded asset buffer, and the evaluation above then (correctly) refuses to
+// run it, which stalls whatever was waiting for the path to end.
+bool spline_cursor_has_usable_spline(const void *cursor) {
+    const swrSplineCursor *c = (const swrSplineCursor *) cursor;
+    return c != NULL && cursor_spline_is_usable(c);
+}
+
+// Report once per distinct caller -- these run per cursor per frame, so an unfiltered log would
+// bury everything else in hook.log.
+static bool report_once_per_caller(const void *caller) {
+    static const void *seen[8] = {};
+    static int seen_count = 0;
+    for (int i = 0; i < seen_count; i++) {
+        if (seen[i] == caller)
+            return false;
+    }
+    if (seen_count < (int) (sizeof(seen) / sizeof(seen[0])))
+        seen[seen_count++] = caller;
+    return true;
+}
+
+// nodeLookahead indexes control_points and swrSpline_Interpolate does not range-check it, while
+// swrSpline_CursorSeekToProgress leaves the window untouched when its scan matches no node -- so a
+// cursor reused across tracks can hold indices from a longer spline. The spline is known good
+// here, so swrSpline_CursorSeek can safely rebuild the whole chain from node 0.
+static void clamp_cursor_indices(swrSplineCursor *c, const void *caller) {
+    const swrSpline *s = c->spline;
+    bool out_of_range = false;
+    for (int i = 0; i < 4; i++)
+        out_of_range = out_of_range || c->nodeLookahead[i] < 0 ||
+            c->nodeLookahead[i] >= (int) s->num_control_points;
+    if (!out_of_range)
+        return;
+
+    if (report_once_per_caller(caller)) {
+        fprintf(hook_log,
+                "[spline] cursor %p nodes %d/%d/%d/%d are outside its %u control points, called "
+                "from %p; re-seeding to node 0\n",
+                (void *) c, c->nodeLookahead[0], c->nodeLookahead[1], c->nodeLookahead[2],
+                c->nodeLookahead[3], s->num_control_points, caller);
+        fflush(hook_log);
+    }
+
+    swrSpline_CursorSeek(c, 0);
+    c->segmentT = 0.0f;
+}
+
+// 0x0047e8b0
+void swrSpline_CursorSeekToProgress_delta(void *cursor, int progress) {
+    hook_call_original(swrSpline_CursorSeekToProgress, cursor, progress);
+
+    swrSplineCursor *c = (swrSplineCursor *) cursor;
+    if (c != NULL && cursor_spline_is_usable(c))
+        clamp_cursor_indices(c, __builtin_return_address(0));
+}
+
 // 0x0044ed80
 void swrSpline_EvaluateToMatrix_delta(void *cursor, void *out) {
     swrSplineCursor *c = (swrSplineCursor *) cursor;
-    if (c == NULL || c->spline == NULL) {
-        // Report once per distinct caller -- this runs per pod per frame, so an unfiltered log
-        // would bury everything else in hook.log.
-        static const void *seen[8] = {};
-        static int seen_count = 0;
-        const void *caller = __builtin_return_address(0);
-        bool known = false;
-        for (int i = 0; i < seen_count; i++)
-            known = known || seen[i] == caller;
-        if (!known) {
-            if (seen_count < (int) (sizeof(seen) / sizeof(seen[0])))
-                seen[seen_count++] = caller;
+    const void *caller = __builtin_return_address(0);
+    if (c == NULL || !cursor_spline_is_usable(c)) {
+        if (report_once_per_caller(caller)) {
             fprintf(hook_log,
-                    "[spline] refusing to evaluate a cursor with no spline: cursor=%p, called from "
-                    "%p\n",
-                    cursor, caller);
+                    "[spline] refusing to evaluate a cursor with no usable spline: cursor=%p, "
+                    "spline=%p, called from %p\n",
+                    cursor, (void *) (c != NULL ? c->spline : NULL), caller);
             fflush(hook_log);
         }
         return;// leave `out` as it was; a stale transform beats a fault
     }
+
+    clamp_cursor_indices(c, caller);
 
     hook_call_original(swrSpline_EvaluateToMatrix, cursor, (rdMatrix44 *) out);
 }

--- a/dinput_hook/game_deltas/swrSpline_delta.h
+++ b/dinput_hook/game_deltas/swrSpline_delta.h
@@ -2,7 +2,16 @@
 
 char *swrSpline_LoadSplineById_delta(char *splineBuffer);
 
-// Choke point for every spline evaluation. swrSpline_Interpolate dereferences
-// cursor->spline (offset 0) unconditionally, so a cursor whose spline went away faults at
-// address 0. Skip the evaluation and name the caller instead of taking the process down.
+// Choke point for every spline evaluation. swrSpline_Interpolate trusts the cursor completely, so
+// a cursor whose spline went away faults at address 0, and one left pointing into a reloaded asset
+// buffer faults on garbage. Skip the evaluation and name the caller instead of taking the process
+// down.
 void swrSpline_EvaluateToMatrix_delta(void *cursor, void *out);
+// Seeding a cursor to a progress band that matches no node leaves its node window untouched, so
+// a cursor reused across tracks keeps indices from the previous (possibly longer) spline.
+void swrSpline_CursorSeekToProgress_delta(void *cursor, int progress);
+
+// True if this cursor can actually be evaluated: a spline with a control-point array and a
+// plausible count. Use instead of a bare `cursor->spline != NULL` before starting anything that
+// waits for the path to finish.
+bool spline_cursor_has_usable_spline(const void *cursor);

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -2654,6 +2654,9 @@ extern "C" void init_renderer_hooks() {
                   (uint8_t *) swrSpline_EvaluateToMatrix_ADDR);
     hook_replace(swrSpline_EvaluateToMatrix, swrSpline_EvaluateToMatrix_delta);
 
+    // Reverse-hooked (registered in hook_generated) -> replace only.
+    hook_replace(swrSpline_CursorSeekToProgress, swrSpline_CursorSeekToProgress_delta);
+
     fprintf(hook_log, "Done\n");
     fflush(hook_log);
 }


### PR DESCRIPTION
Racing a custom track straight after a stock one crashes in `swrSpline_Interpolate` (0x0044e774).

A `swrSplineCursor` holds a raw `swrSpline*` into the asset buffer, and the next track load rewinds and refills it -- so a cursor that outlives its track reads **non-NULL but reclaimed** (seen: `num_control_points` = 0xffcea415). `swrObjJdge_SetupTrackEnvironment` seeds the pre-race fly-by cursor from the track's camera spline, and a track without one leaves the previous track's pointer in place. The existing NULL checks (mine included, from #296) look right past it: the pointer isn't NULL, it's just been recycled.

One predicate, used everywhere it matters:

- `swrSpline_EvaluateToMatrix_delta` refuses any cursor without a *usable* spline (`control_points` set, count in range), not just a NULL one, and logs the calling address so the owner can be found.
- The fly-by gate in `swrObjJdge_delta` tests the same predicate instead of `camSweepCursor.spline != NULL`. This part matters: guarding only the evaluation turns the crash into a **hang** -- the sweep starts, the evaluation is refused, and F0 holds state 4 until a skip press. The gate's own comment predicted exactly that.
- `swrSpline_CursorSeekToProgress_delta` re-seeds a node window left out of range (the original's scan falls through without writing when no node matches the requested band). Only safe once the spline is known good -- re-seeding a reclaimed cursor faults inside `swrSpline_CursorSeek` (0x0044ef14) instead, which is how I found this.

The plausibility cap is 4096 control points; the real maximum across every stock spline and every custom pack I have is 180.

Also drops a stale `Default off` comment -- `restore_prerace_track_sweep` defaults to true, so this path is on for everyone.

Playtested: Boonta Training Course -> Big Blue no longer crashes or hangs, the sweep stays dormant with a log line naming the stale cursor, and stock tracks still play their fly-by. Built + linked clean (WinLibs GCC 13.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)