### PR TITLE
Loose per-model replacement (RAWM chunk loader)

### DIFF
--- a/dinput_hook/game_deltas/swrModel_delta.cpp
+++ b/dinput_hook/game_deltas/swrModel_delta.cpp
@@ -12,6 +12,7 @@
 #include "../node_utils.h"
 #include "../stb_image.h"
 #include "../custom_tracks.h"
+#include "../model_replacement.h"
 #include "../nv_dds/nv_dds.h"
 #include "../imgui_utils.h"
 #include "../ui_transform.h"
@@ -214,6 +215,7 @@ void swrText_InitFonts_delta(void) {
 swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
     const MODELID requested_id = id;
     const bool is_custom_track = prepare_loading_custom_track_model(&id);
+    const bool is_loose_model = !is_custom_track && try_prepare_loose_model(&id);
 
     char *model_asset_pointer_begin = swrAssetBuffer_GetBuffer();
     swrModel_Header *header = hook_call_original(swrModel_LoadFromId, id);
@@ -224,6 +226,12 @@ swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
         finalize_loading_custom_track_model(header);
     } else {
         fixup_custom_model(header);
+    }
+    if (is_loose_model) {
+        finalize_loose_model();
+        fprintf(hook_log, "[model_replacement] loaded loose model %d, header=%p\n",
+                (int) requested_id, (void *) header);
+        fflush(hook_log);
     }
 
     // remove all models whose asset pointer is invalid: the buffer rewound past them, stale
@@ -241,10 +249,12 @@ swrModel_Header *swrModel_LoadFromId_delta(MODELID id) {
                 id, requested_id, swrAssetBuffer_RemainingSize());
         fflush(hook_log);
     } else {
+        // A loose model loaded through a single-entry block came back as id 0; register
+        // the originally-requested id so the renderer associates it with the real model.
         asset_pointer_to_model.emplace_back() = {
             model_asset_pointer_begin,
             model_asset_pointer_end,
-            id,
+            is_loose_model ? requested_id : id,
         };
     }
 

--- a/dinput_hook/model_replacement.cpp
+++ b/dinput_hook/model_replacement.cpp
@@ -1,5 +1,7 @@
 #include "model_replacement.h"
 
+#include "custom_tracks.h"// SWR_MODELBLOCK_PATH_PTR
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -17,8 +19,7 @@ bool enable_model_replacement = true;
 
 namespace fs = std::filesystem;
 
-// stock modelblock path pointer in the game's .data section (see custom_tracks.cpp).
-static const char **const MODELBLOCK_PATH_PTR = (const char **) 0x4B9598;
+
 
 static std::map<int, fs::path> replacement_models;
 static bool loaded_replacement_models_at_least_once = false;
@@ -137,8 +138,8 @@ bool try_prepare_loose_model(MODELID *model_id) {
     fclose(out);
 
     // point the modelblock path at our temp block and remap to its single entry.
-    saved_modelblock_path = *MODELBLOCK_PATH_PTR;
-    *MODELBLOCK_PATH_PTR = temp_block_path_storage.c_str();
+    saved_modelblock_path = *SWR_MODELBLOCK_PATH_PTR;
+    *SWR_MODELBLOCK_PATH_PTR = temp_block_path_storage.c_str();
     fprintf(hook_log, "[model_replacement] replacing model %d from %s\n", (int) *model_id,
             src.c_str());
     fflush(hook_log);
@@ -148,7 +149,7 @@ bool try_prepare_loose_model(MODELID *model_id) {
 
 void finalize_loose_model() {
     if (saved_modelblock_path) {
-        *MODELBLOCK_PATH_PTR = saved_modelblock_path;
+        *SWR_MODELBLOCK_PATH_PTR = saved_modelblock_path;
         saved_modelblock_path = nullptr;
     }
 }

--- a/dinput_hook/model_replacement.cpp
+++ b/dinput_hook/model_replacement.cpp
@@ -1,0 +1,154 @@
+#include "model_replacement.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <regex>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include "game_deltas/tracks_delta.h"// CUSTOM_TRACK_MODELID_BEGIN
+}
+
+extern "C" FILE *hook_log;
+
+bool enable_model_replacement = true;
+
+namespace fs = std::filesystem;
+
+// stock modelblock path pointer in the game's .data section (see custom_tracks.cpp).
+static const char **const MODELBLOCK_PATH_PTR = (const char **) 0x4B9598;
+
+static std::map<int, fs::path> replacement_models;
+static bool loaded_replacement_models_at_least_once = false;
+
+static const char *saved_modelblock_path = nullptr;
+static std::string temp_block_path_storage;// keeps the swapped-in path alive
+
+void refresh_replacement_models() {
+    loaded_replacement_models_at_least_once = true;
+    replacement_models.clear();
+
+    const static std::regex file_regex("([0-9]+)\\.bin");
+    const char *dir = "./assets/replacement_models/";
+    if (!fs::is_directory(dir)) {
+        fprintf(hook_log, "[model_replacement] folder %s does not exist, no model replacements.\n",
+                dir);
+        fflush(hook_log);
+        return;
+    }
+
+    for (const auto &entry: fs::recursive_directory_iterator(dir)) {
+        if (!entry.is_regular_file())
+            continue;
+
+        const std::string filename = entry.path().filename().generic_string();
+        std::smatch match;
+        if (std::regex_match(filename, match, file_regex)) {
+            const int id = std::stoi(match.str(1));
+            replacement_models[id] = entry.path();
+            fprintf(hook_log, "[model_replacement] found replacement for model %d: %s\n", id,
+                    entry.path().generic_string().c_str());
+        }
+    }
+    fflush(hook_log);
+}
+
+bool try_prepare_loose_model(MODELID *model_id) {
+    if (!enable_model_replacement)
+        return false;
+
+    if (!loaded_replacement_models_at_least_once)
+        refresh_replacement_models();
+
+    // only stock model ids; the custom-track id range is handled separately.
+    if ((int) *model_id < 0 || (int) *model_id >= CUSTOM_TRACK_MODELID_BEGIN)
+        return false;
+
+    const auto it = replacement_models.find((int) *model_id);
+    if (it == replacement_models.end())
+        return false;
+
+    const std::string src = it->second.generic_string();
+
+    // read the raw chunk file
+    FILE *f = fopen(src.c_str(), "rb");
+    if (!f) {
+        fprintf(hook_log, "[model_replacement] could not open %s\n", src.c_str());
+        fflush(hook_log);
+        return false;
+    }
+    fseek(f, 0, SEEK_END);
+    const long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char magic[4] = {};
+    uint32_t mask_size = 0;
+    uint32_t model_size = 0;
+    if (file_size < 12 || fread(magic, 1, 4, f) != 4 || fread(&mask_size, 4, 1, f) != 1 ||
+        fread(&model_size, 4, 1, f) != 1 || memcmp(magic, "RAWM", 4) != 0 ||
+        (long) (12 + mask_size + model_size) != file_size) {
+        fprintf(hook_log, "[model_replacement] %s is not a valid raw chunk, ignoring.\n",
+                src.c_str());
+        fflush(hook_log);
+        fclose(f);
+        return false;
+    }
+
+    // assemble a single-entry modelblock:
+    //   [count=1][W0=mask_off][W1=model_off][W2=end]  then mask payload then model payload.
+    // all four header words are big-endian; the payloads are copied verbatim (already big-endian).
+    const uint32_t header_size = 16;// count + 3 offset words
+    const uint32_t mask_off = header_size;
+    const uint32_t model_off = header_size + mask_size;
+    const uint32_t end_off = header_size + mask_size + model_size;
+
+    std::vector<uint8_t> block(end_off);
+    const auto store_be = [&](uint32_t off, uint32_t v) {
+        *(uint32_t *) &block[off] = __builtin_bswap32(v);
+    };
+    store_be(0, 1);
+    store_be(4, mask_off);
+    store_be(8, model_off);
+    store_be(12, end_off);
+
+    if (fread(&block[mask_off], 1, mask_size, f) != mask_size ||
+        fread(&block[model_off], 1, model_size, f) != model_size) {
+        fprintf(hook_log, "[model_replacement] short read on %s, ignoring.\n", src.c_str());
+        fflush(hook_log);
+        fclose(f);
+        return false;
+    }
+    fclose(f);
+
+    // write the assembled block next to the replacements, using a relative path under the
+    // game dir (matches how custom tracks point the loader at a file, and avoids any
+    // absolute-path quirks in the game's old CRT fopen).
+    temp_block_path_storage = "./assets/replacement_models/.loose_model_cache.bin";
+    FILE *out = fopen(temp_block_path_storage.c_str(), "wb");
+    if (!out) {
+        fprintf(hook_log, "[model_replacement] could not write temp block %s\n",
+                temp_block_path_storage.c_str());
+        fflush(hook_log);
+        return false;
+    }
+    fwrite(block.data(), 1, block.size(), out);
+    fclose(out);
+
+    // point the modelblock path at our temp block and remap to its single entry.
+    saved_modelblock_path = *MODELBLOCK_PATH_PTR;
+    *MODELBLOCK_PATH_PTR = temp_block_path_storage.c_str();
+    fprintf(hook_log, "[model_replacement] replacing model %d from %s\n", (int) *model_id,
+            src.c_str());
+    fflush(hook_log);
+    *model_id = (MODELID) 0;
+    return true;
+}
+
+void finalize_loose_model() {
+    if (saved_modelblock_path) {
+        *MODELBLOCK_PATH_PTR = saved_modelblock_path;
+        saved_modelblock_path = nullptr;
+    }
+}

--- a/dinput_hook/model_replacement.h
+++ b/dinput_hook/model_replacement.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <filesystem>
+#include <map>
+
+#include "types.h"
+
+// Raw-chunk per-model replacement.
+//
+// Drop a file at ./assets/replacement_models/<model_id>.bin with this layout:
+//   [0]  char     magic[4]   = "RAWM"
+//   [4]  uint32_t mask_size   (little-endian)
+//   [8]  uint32_t model_size  (little-endian)
+//   [12] mask payload   (mask_size  bytes, big-endian, verbatim from out_modelblock.bin)
+//   [..] model payload  (model_size bytes, big-endian, verbatim from out_modelblock.bin)
+//
+// The mask/model payloads are the exact byte ranges [mask_offset, model_offset) and
+// [model_offset, next_model_offset) for that model in the stock modelblock. They are
+// stored unchanged (big-endian); the game's loader byte-swaps them on load.
+// See scripts/extract_raw_model.py for a producer.
+
+extern bool enable_model_replacement;
+
+// (Re)scan ./assets/replacement_models/ into the replacement map.
+void refresh_replacement_models();
+
+// If a replacement exists for *model_id (a stock id < CUSTOM_TRACK_MODELID_BEGIN),
+// assemble a single-entry modelblock in a temp file, point the modelblock path at it,
+// and remap *model_id to 0. Returns true if a replacement was prepared.
+bool try_prepare_loose_model(MODELID *model_id);
+
+// Revert the modelblock path swap performed by try_prepare_loose_model.
+void finalize_loose_model();

--- a/dinput_hook/renderer_hook.cpp
+++ b/dinput_hook/renderer_hook.cpp
@@ -488,8 +488,16 @@ void parse_display_list_commands(const rdMatrix44 &model_matrix, const swrModel_
     while (command->type != 0xdf) {
         switch (command->type) {
             case 0x1: {
-                const uint8_t n = (SWAP16(command->gSPVertex.n_packed) >> 4) & 0xFF;
-                const uint8_t v0 = command->gSPVertex.v0_plus_n - n;
+                uint8_t n = (SWAP16(command->gSPVertex.n_packed) >> 4) & 0xFF;
+                uint8_t v0 = command->gSPVertex.v0_plus_n - n;
+                // blender-swe1r encodes a vertex load as (n=0, v0_plus_n=count) instead of the
+                // game's (n=count, v0=base). Normalize here, where the renderer actually reads
+                // the display list, so loose blender models render without relying on a separate
+                // display-list fixup pass hitting the right DL. No-op for game-native data (n!=0).
+                if (n == 0 && v0 != mesh->vertex_base_offset) {
+                    n = v0;
+                    v0 = mesh->vertex_base_offset;
+                }
                 if (v0 != mesh->vertex_base_offset)
                     std::abort();
 

--- a/scripts/extract_raw_model.py
+++ b/scripts/extract_raw_model.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Extract one model from out_modelblock.bin into a raw-chunk replacement file.
+
+Usage:
+    python scripts/extract_raw_model.py <out_modelblock.bin> <model_id> <output.bin>
+
+Output format (consumed by dinput_hook/model_replacement.cpp):
+    [0]  b"RAWM"
+    [4]  uint32 mask_size   (little-endian)
+    [8]  uint32 model_size  (little-endian)
+    [12] mask payload   (big-endian, verbatim from the block)
+    [..] model payload  (big-endian, verbatim from the block)
+
+Round-trip sanity check: extract model N, drop it at
+./assets/replacement_models/N.bin, and the game should render identically.
+"""
+import os
+import struct
+import sys
+
+
+def be32(data, off):
+    return struct.unpack_from(">I", data, off)[0]
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__)
+        sys.exit(1)
+
+    block_path = sys.argv[1]
+    model_id = int(sys.argv[2])
+    out_path = sys.argv[3]
+
+    with open(block_path, "rb") as f:
+        data = f.read()
+
+    num_models = be32(data, 0)
+    if not (0 <= model_id < num_models):
+        sys.exit(f"model id {model_id} out of range (block has {num_models} models)")
+
+    # TOC entry stride is 8 bytes; each model uses three consecutive offset words.
+    mask_offset = be32(data, 8 * model_id + 4)
+    model_offset = be32(data, 8 * model_id + 8)
+    next_offset = be32(data, 8 * model_id + 12)
+
+    mask = data[mask_offset:model_offset]
+    model = data[model_offset:next_offset]
+
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    with open(out_path, "wb") as f:
+        f.write(b"RAWM")
+        f.write(struct.pack("<II", len(mask), len(model)))
+        f.write(mask)
+        f.write(model)
+
+    kind = "compressed" if model[:4] == b"Comp" else "uncompressed"
+    print(f"wrote {out_path}: mask={len(mask)} bytes, model={len(model)} bytes ({kind})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_raw_model.py
+++ b/scripts/validate_raw_model.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate a raw-chunk model replacement file and report likely crash causes.
+
+Usage:
+    python scripts/validate_raw_model.py <chunk.bin> [<out_modelblock.bin> <model_id>]
+
+Checks the RAWM container, the mask/model sizing, the model tag, and walks the
+mask-flagged words to verify pointers land inside the model and texture indices
+look sane. If the stock block + id are given, compares against stock.
+"""
+import struct
+import sys
+
+KNOWN_TAGS = {b"Modl", b"Trak", b"Podd", b"Part", b"Scen", b"MAlt", b"Pupp"}
+
+
+def be32(data, off):
+    return struct.unpack_from(">I", data, off)[0]
+
+
+def analyze(chunk):
+    problems = []
+    notes = []
+
+    if len(chunk) < 12:
+        return ["file is smaller than the 12-byte header"], []
+
+    magic = chunk[0:4]
+    mask_size = struct.unpack_from("<I", chunk, 4)[0]
+    model_size = struct.unpack_from("<I", chunk, 8)[0]
+    notes.append(f"magic={magic!r}  mask_size={mask_size}  model_size={model_size}  "
+                 f"file_size={len(chunk)}")
+
+    if magic != b"RAWM":
+        problems.append(f"bad magic {magic!r} (expected b'RAWM')")
+    if 12 + mask_size + model_size != len(chunk):
+        problems.append(f"size mismatch: 12 + {mask_size} + {model_size} = "
+                        f"{12 + mask_size + model_size}, but file is {len(chunk)} bytes")
+        return problems, notes
+    if mask_size % 4 != 0:
+        problems.append(f"mask_size {mask_size} is not a multiple of 4 "
+                        f"(loader byte-swaps the mask as dwords; the tail won't swap)")
+    if model_size % 4 != 0:
+        problems.append(f"model_size {model_size} is not a multiple of 4")
+    if mask_size > 153600:
+        problems.append(f"mask_size {mask_size} exceeds the loader cap 153600 "
+                        f"(swrLoader_MaskBuffer) -> loader bails, returns NULL")
+
+    n_words = model_size // 4
+    needed_mask = ((n_words + 31) // 32) * 4
+    if mask_size != needed_mask:
+        problems.append(f"mask covers {mask_size * 8} bits but the model has {n_words} words; "
+                        f"expected mask_size = {needed_mask}")
+
+    mask = chunk[12:12 + mask_size]
+    model = chunk[12 + mask_size:]
+
+    tag = model[0:4]
+    if tag == b"Comp":
+        notes.append("model is LZ77-compressed ('Comp'); decompressed by the original loader")
+        return problems, notes
+    if tag not in KNOWN_TAGS:
+        problems.append(f"model does not start with a known tag (got {tag!r}); "
+                        f"expected one of {sorted(t.decode() for t in KNOWN_TAGS)} or 'Comp'")
+
+    # walk the mask-flagged words (bit k, MSB-first over bytes, governs word k)
+    def bit(k):
+        return (mask[k // 8] >> (7 - k % 8)) & 1 if k // 8 < len(mask) else 0
+
+    n_ptr = n_tex = n_null = n_bad_ptr = 0
+    bad_ptr_examples = []
+    tex_ids = []
+    if bit(0):
+        problems.append("word 0 is mask-flagged, but the tag word should be literal (mask bit 0)")
+
+    for i in range(n_words):
+        if not bit(i):
+            continue
+        v = be32(model, 4 * i)
+        if (v & 0xFF000000) == 0x0A000000:
+            n_tex += 1
+            tex_ids.append(v & 0xFFFFFF)
+        elif v == 0:
+            n_null += 1
+        else:
+            n_ptr += 1
+            if v >= model_size:
+                n_bad_ptr += 1
+                if len(bad_ptr_examples) < 6:
+                    bad_ptr_examples.append((i, v))
+
+    notes.append(f"mask-flagged words: {n_ptr} pointers, {n_tex} texture refs, {n_null} null")
+    if tex_ids:
+        notes.append(f"texture indices referenced: min={min(tex_ids)} max={max(tex_ids)} "
+                     f"count={len(tex_ids)}")
+    if n_bad_ptr:
+        ex = ", ".join(f"word#{i}=0x{v:X}" for i, v in bad_ptr_examples)
+        problems.append(f"{n_bad_ptr} pointer(s) point past the end of the model "
+                        f"(>= model_size {model_size}) -> rebased outside the buffer -> crash. "
+                        f"e.g. {ex}")
+    return problems, notes
+
+
+def main():
+    if len(sys.argv) not in (2, 4):
+        print(__doc__)
+        sys.exit(1)
+
+    with open(sys.argv[1], "rb") as f:
+        chunk = f.read()
+
+    print(f"=== {sys.argv[1]} ===")
+    problems, notes = analyze(chunk)
+    for n in notes:
+        print(f"  - {n}")
+
+    if len(sys.argv) == 4:
+        with open(sys.argv[2], "rb") as f:
+            block = f.read()
+        mid = int(sys.argv[3])
+        m_off = be32(block, 8 * mid + 4)
+        d_off = be32(block, 8 * mid + 8)
+        nx_off = be32(block, 8 * mid + 12)
+        print(f"  - stock model {mid}: mask_size={d_off - m_off} model_size={nx_off - d_off} "
+              f"tag={block[d_off:d_off + 4]!r}")
+
+    if problems:
+        print("PROBLEMS:")
+        for p in problems:
+            print(f"  !! {p}")
+        sys.exit(2)
+    print("OK: no structural problems found "
+          "(a crash may still come from out-of-range texture indices or n64 display-list quirks)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lets a single model be replaced from a loose file, instead of shipping a whole rebuilt `out_modelblock.bin`.

Drop a chunk at `./assets/replacement_models/<model_id>.bin` and that model loads from it: the loader assembles a single-entry modelblock in memory, points the block path at it, remaps the id, and restores the path afterwards. Format is `"RAWM"` + mask/model sizes + the two payloads verbatim (big-endian, exactly the byte ranges that entry occupies in the stock block), so no conversion is involved in either direction.

Two scripts come with it: `extract_raw_model.py` carves a chunk out of a block (so the round trip is checkable -- extract model N, drop it back as N, nothing should change), and `validate_raw_model.py` checks the container, walks the mask-flagged words, and reports pointer/texture-index problems before the game ever sees the file.

The renderer change normalizes the blender-swe1r vertex-load encoding (`n=0, v0_plus_n=count`) to the game's (`n=count, v0=base`) where the display list is actually read. Without it a blender-authored chunk hits the `v0 != vertex_base_offset` abort; it is a no-op for game-native data, which never uses that encoding.

This is groundwork for shipping custom tracks as discrete assets rather than repacked archives -- a pack that redistributes the whole block is both large and forces the loader to guess which entry is the custom one by hashing.

Rebased onto current master (it had gone stale) and playtested two ways on the planet-select hologram (`MODELID_pln_tatooine_part`): a blender-authored chunk, which exercises the vertex-encoding path -- 42 of its vertex loads use `n=0` where a stock carve has none -- and a byte-exact stock carve, which renders indistinguishably from vanilla. A control run with the replacement removed logs nothing and loads from the block as before. Built + linked clean (WinLibs GCC 13.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)